### PR TITLE
Add continuous_compliance subpackage (rulesets, connectors, jobs, executions, logs); add entrypoint for Claude

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ A Model Context Protocol (MCP) server that provides tools for interacting with t
 - **Engine Management**: List, search, and manage DCT engines
 - **Bookmark Management**: Create, search, and manage bookmarks for point-in-time operations
 - **Snapshot Management**: Create, search, and manage snapshots for data sources and VDBs
+- **Ruleset Management**: Create, update, list, search, and manage governance rulesets for continuous compliance
+- **Connector Management**: Create, update, list, search, and manage data source connectors for compliance
 - **Tag Management**: Add, retrieve, and delete tags for resources
 - **Async Operations**: Built with modern async/await patterns for performance
 - **Error Handling**: Robust retry logic and error handling
@@ -209,6 +211,20 @@ The server provides the following categories of tools:
 - `dct_snapshots_find_by_timestamp` - Find snapshots by timestamp
 - `dct_snapshots_find_by_location` - Find snapshots by location/SCN
 
+#### Ruleset Tools
+- `list_rulesets` - List all governance rulesets
+- `search_rulesets` - Search rulesets with filters
+- `get_ruleset` - Get specific ruleset details
+- `create_ruleset` - Create a new ruleset
+- `update_ruleset` - Update an existing ruleset
+
+#### Connector Tools
+- `list_connectors` - List all data source connectors
+- `search_connectors` - Search connectors with filters
+- `get_connector` - Get specific connector details
+- `create_connector` - Create a new connector
+- `update_connector` - Update an existing connector
+
 ## Project Structure
 
 ```
@@ -225,7 +241,9 @@ src/
 │       ├── environments.py  # Environment API tools
 │       ├── engines.py       # Engine API tools
 │       ├── bookmarks.py     # Bookmark API tools
-│       └── snapshots.py     # Snapshot API tools
+│       ├── snapshots.py     # Snapshot API tools
+│       ├── rulesets.py      # Ruleset and governance API tools
+│       └── connectors.py    # Connector and data source API tools
 ```
 
 ## Contributing

--- a/dct_mcp_entry.py
+++ b/dct_mcp_entry.py
@@ -1,0 +1,50 @@
+import os
+import sys
+
+
+def _ensure_src_on_path():
+    repo_root = os.path.dirname(os.path.abspath(__file__))
+    src_path = os.path.join(repo_root, "src")
+    # Prepend absolute src path so package imports resolve regardless of cwd/env
+    if src_path not in sys.path:
+        sys.path.insert(0, src_path)
+
+
+def _debug_startup():
+    # Emit useful diagnostics to stderr for Claude MCP logs
+    print(f"[dct-mcp-entry] cwd={os.getcwd()}", file=sys.stderr)
+    print(f"[dct-mcp-entry] PYTHONPATH={os.environ.get('PYTHONPATH')}", file=sys.stderr)
+    print(f"[dct-mcp-entry] sys.path[0:3]={sys.path[:3]}", file=sys.stderr)
+    print(f"[dct-mcp-entry] DCT_BASE_URL={os.environ.get('DCT_BASE_URL')}", file=sys.stderr)
+    api_key = os.environ.get('DCT_API_KEY', '')
+    print(f"[dct-mcp-entry] DCT_API_KEY[0:6]={api_key[:6]}...", file=sys.stderr)
+
+
+def main():
+    _ensure_src_on_path()
+    _debug_startup()
+    # Import after sys.path is set
+    from dxi_mcp_server.main import main as server_main  # type: ignore
+
+    # Delegate to the FastMCP server starter
+    server_main()
+
+
+if __name__ == "__main__":
+    main()
+#!/usr/bin/env python3
+"""
+Simple entry point for DCT MCP Server to work with Claude Desktop MCP CLI wrapper.
+This follows the same pattern as other MCP servers in the Claude Desktop config.
+"""
+
+import os
+import sys
+
+# Add the src directory to the Python path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'src'))
+
+from dxi_mcp_server.main import main
+
+if __name__ == "__main__":
+    main()

--- a/src/dxi_mcp_server/main.py
+++ b/src/dxi_mcp_server/main.py
@@ -73,6 +73,12 @@ async def async_main():
             register_engine_tools,
             register_bookmark_tools,
             register_snapshot_tools,
+            register_ruleset_tools,
+            register_connector_tools,
+            register_jobs_tools,
+            register_executions_tools,
+            register_logs_tools,
+            register_log_explanation_tools,
         )
 
         # Register all tools
@@ -82,6 +88,12 @@ async def async_main():
         register_engine_tools(app, dct_client)
         register_bookmark_tools(app, dct_client)
         register_snapshot_tools(app, dct_client)
+        register_ruleset_tools(app, dct_client)
+        register_connector_tools(app, dct_client)
+        register_jobs_tools(app, dct_client)
+        register_executions_tools(app, dct_client)
+        register_logs_tools(app, dct_client)
+        register_log_explanation_tools(app)
 
         # Run the server
         try:

--- a/src/dxi_mcp_server/tools/__init__.py
+++ b/src/dxi_mcp_server/tools/__init__.py
@@ -12,6 +12,14 @@ from .environments import register_environment_tools
 from .engines import register_engine_tools
 from .bookmarks import register_bookmark_tools
 from .snapshots import register_snapshot_tools
+from .continuous_compliance import (
+    register_ruleset_tools,
+    register_connector_tools,
+    register_jobs_tools,
+    register_executions_tools,
+    register_logs_tools,
+    register_log_explanation_tools,
+)
 
 logger = logging.getLogger("dct-tools")
 
@@ -44,6 +52,12 @@ __all__ = [
     "register_engine_tools",
     "register_bookmark_tools",
     "register_snapshot_tools",
+    "register_ruleset_tools",
+    "register_connector_tools",
+    "register_jobs_tools",
+    "register_executions_tools",
+    "register_logs_tools",
+    "register_log_explanation_tools",
     "register_cleanup_handler",
     "run_cleanup",
 ]

--- a/src/dxi_mcp_server/tools/continuous_compliance/__init__.py
+++ b/src/dxi_mcp_server/tools/continuous_compliance/__init__.py
@@ -1,0 +1,20 @@
+"""
+Continuous Compliance tools package
+
+Contains tools for rulesets, connectors, jobs, executions, and logs.
+"""
+
+from .rulesets import register_ruleset_tools
+from .connectors import register_connector_tools
+from .jobs import register_jobs_tools
+from .executions import register_executions_tools
+from .logs import register_logs_tools, register_log_explanation_tools
+
+__all__ = [
+    "register_ruleset_tools",
+    "register_connector_tools",
+    "register_jobs_tools",
+    "register_executions_tools",
+    "register_logs_tools",
+    "register_log_explanation_tools",
+]

--- a/src/dxi_mcp_server/tools/continuous_compliance/connectors.py
+++ b/src/dxi_mcp_server/tools/continuous_compliance/connectors.py
@@ -1,0 +1,66 @@
+"""
+Connector tools (Continuous Compliance)
+"""
+
+import logging
+from typing import Any, Dict, Optional
+
+from mcp.server.fastmcp import FastMCP
+
+from ...client import DCTAPIClient
+
+logger = logging.getLogger(__name__)
+
+
+def register_connector_tools(mcp: FastMCP, client: DCTAPIClient):
+    @mcp.tool()
+    async def list_connectors(limit: Optional[int] = None, cursor: Optional[str] = None, sort: Optional[str] = None) -> Dict[str, Any]:
+        params = {}
+        if limit is not None:
+            params["limit"] = limit
+        if cursor is not None:
+            params["cursor"] = cursor
+        if sort is not None:
+            params["sort"] = sort
+        return await client.make_request("GET", "connectors", params=params)
+
+    @mcp.tool()
+    async def search_connectors(
+        search_criteria: Dict[str, Any],
+        limit: Optional[int] = None,
+        cursor: Optional[str] = None,
+        sort: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        params = {}
+        if limit is not None:
+            params["limit"] = limit
+        if cursor is not None:
+            params["cursor"] = cursor
+        if sort is not None:
+            params["sort"] = sort
+        return await client.make_request("POST", "connectors/search", data={"filter_expression": search_criteria}, params=params)
+
+    @mcp.tool()
+    async def get_connector(connector_id: str) -> Dict[str, Any]:
+        return await client.make_request("GET", f"connectors/{connector_id}")
+
+    @mcp.tool()
+    async def create_connector(*args, **kwargs) -> Dict[str, Any]:
+        return {
+            "error": "incomplete_implementation",
+            "message": "Connector creation requires additional required fields that need to be identified.",
+            "details": "Missing required fields: 'type', 'job_orchestrator_id'. Full field requirements need documentation.",
+            "status": "implementation_pending",
+        }
+
+    @mcp.tool()
+    async def update_connector(connector_id: str, *args, **kwargs) -> Dict[str, Any]:
+        return {
+            "error": "read_only",
+            "message": "Connector updates are not currently supported - connectors are read-only.",
+            "details": "The connector object is read only and cannot be modified.",
+            "connector_id": connector_id,
+            "status": "feature_unavailable",
+        }
+
+    logger.info("Connector tools registered successfully (continuous_compliance)")

--- a/src/dxi_mcp_server/tools/continuous_compliance/executions.py
+++ b/src/dxi_mcp_server/tools/continuous_compliance/executions.py
@@ -1,0 +1,139 @@
+"""
+Executions tools (Continuous Compliance)
+
+Provides read-only access to job executions.
+"""
+
+import logging
+from typing import Any, Dict, Optional
+
+from mcp.server.fastmcp import FastMCP
+
+from ...client import DCTAPIClient
+
+logger = logging.getLogger(__name__)
+
+
+def register_executions_tools(mcp: FastMCP, client: DCTAPIClient):
+    @mcp.tool()
+    async def list_executions(
+        limit: Optional[int] = None,
+        cursor: Optional[str] = None,
+        sort: Optional[str] = None,
+        job_id: Optional[str] = None,
+        path_override: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """List executions.
+
+        By default hits 'executions'. Provide job_id to filter if supported.
+        Use path_override to specify an exact API path if your DCT differs.
+        """
+        params = {}
+        if limit is not None:
+            params["limit"] = limit
+        if cursor is not None:
+            params["cursor"] = cursor
+        if sort is not None:
+            params["sort"] = sort
+        if job_id is not None:
+            params["job_id"] = job_id
+        path = path_override or "executions"
+        return await client.make_request("GET", path, params=params)
+
+    @mcp.tool()
+    async def get_execution(execution_id: str, path_override: Optional[str] = None) -> Dict[str, Any]:
+        """Get an execution by ID.
+
+        Default path is 'executions/{id}'. Use path_override to customize.
+        """
+        path = path_override or f"executions/{execution_id}"
+        return await client.make_request("GET", path)
+
+    @mcp.tool()
+    async def list_execution_components(execution_id: str, path_override: Optional[str] = None) -> Dict[str, Any]:
+        """List components processed in an execution.
+
+        Tries common endpoint patterns:
+        - executions/{id}/components (default)
+        - job-executions/{id}/components
+        - executions/{id}/details
+        You may provide path_override to use the exact path for your DCT.
+        """
+        candidates = [
+            path_override or f"executions/{execution_id}/components",
+            f"job-executions/{execution_id}/components",
+            f"executions/{execution_id}/details",
+        ]
+        last_error: Optional[Dict[str, Any]] = None
+        for p in candidates:
+            try:
+                return await client.make_request("GET", p)
+            except Exception as e:
+                last_error = {"error": str(e), "path": p}
+                continue
+        return {
+            "error": "not_found",
+            "message": "No execution components endpoint found for this execution on current DCT release.",
+            "execution_id": execution_id,
+            "tried_paths": candidates,
+            "last_error": last_error,
+            "suggestions": [
+                "Use path_override to specify the exact components endpoint.",
+                "Review execution details payload; components may be embedded.",
+            ],
+        }
+
+    @mcp.tool()
+    async def get_execution_component(
+        execution_id: str,
+        component_id: str,
+        path_override: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Get a specific component from an execution.
+
+        Tries common endpoint patterns:
+        - executions/{execution_id}/components/{component_id}
+        - job-executions/{execution_id}/components/{component_id}
+        - executions/{execution_id}/details (filter client-side if components embedded)
+        Provide path_override to specify the exact API path.
+        """
+        candidates = [
+            path_override or f"executions/{execution_id}/components/{component_id}",
+            f"job-executions/{execution_id}/components/{component_id}",
+        ]
+        last_error: Optional[Dict[str, Any]] = None
+        for p in candidates:
+            try:
+                return await client.make_request("GET", p)
+            except Exception as e:
+                last_error = {"error": str(e), "path": p}
+                continue
+
+        # Fallback: fetch details and try to locate component client-side
+        try:
+            details = await client.make_request("GET", f"executions/{execution_id}/details")
+            comps = details.get("components") or details.get("items") or []
+            for c in comps:
+                if isinstance(c, dict) and str(c.get("id")) == str(component_id):
+                    return c
+            return {
+                "error": "component_not_found",
+                "message": "Component not found in execution details payload.",
+                "execution_id": execution_id,
+                "component_id": component_id,
+                "checked_keys": ["components", "items"],
+            }
+        except Exception as e:
+            return {
+                "error": "not_found",
+                "message": "No execution component endpoint found for this execution on current DCT release.",
+                "execution_id": execution_id,
+                "component_id": component_id,
+                "last_error": last_error or {"error": str(e)},
+                "suggestions": [
+                    "Use path_override to specify the exact component endpoint.",
+                    "Inspect execution details in DCT UI to confirm component IDs.",
+                ],
+            }
+
+    logger.info("Executions tools registered successfully (continuous_compliance)")

--- a/src/dxi_mcp_server/tools/continuous_compliance/jobs.py
+++ b/src/dxi_mcp_server/tools/continuous_compliance/jobs.py
@@ -1,0 +1,102 @@
+"""
+Jobs tools (Continuous Compliance)
+
+Provides read-only access to compliance jobs.
+"""
+
+import logging
+from typing import Any, Dict, Optional
+
+from mcp.server.fastmcp import FastMCP
+
+from ...client import DCTAPIClient
+
+logger = logging.getLogger(__name__)
+
+
+def register_jobs_tools(mcp: FastMCP, client: DCTAPIClient):
+    @mcp.tool()
+    async def list_jobs(limit: Optional[int] = None, cursor: Optional[str] = None, sort: Optional[str] = None) -> Dict[str, Any]:
+        """List compliance jobs"""
+        params = {}
+        if limit is not None:
+            params["limit"] = limit
+        if cursor is not None:
+            params["cursor"] = cursor
+        if sort is not None:
+            params["sort"] = sort
+        # Known working endpoint from prior tests
+        return await client.make_request("GET", "compliance-jobs", params=params)
+
+    @mcp.tool()
+    async def get_job(job_id: str) -> Dict[str, Any]:
+        """Get a job by ID"""
+        return await client.make_request("GET", f"compliance-jobs/{job_id}")
+
+    @mcp.tool()
+    async def create_profile_job(
+        name: str,
+        connector_id: str,
+        ruleset_id: Optional[str] = None,
+        rule_set_id: Optional[str] = None,
+        profile_set_id: Optional[str] = None,
+        policy_id: Optional[str] = None,
+        schedule: Optional[Dict[str, Any]] = None,
+        options: Optional[Dict[str, Any]] = None,
+        description: Optional[str] = None,
+        job_type: Optional[str] = "profile",
+    ) -> Dict[str, Any]:
+        """Create a new profile job (compliance job).
+
+        Notes:
+        - This posts to 'compliance-jobs' with provided payload.
+        - Provide either ruleset_id or profile_set_id/policy_id depending on your workflow.
+        - The exact required fields may vary per DCT release; errors will surface from API.
+        """
+        # Current DCT release returns 501 Not Implemented for job creation.
+        # Return a clear, structured response consistent with other unsupported operations.
+        return {
+            "error": "not_supported",
+            "message": "Profile job creation is not supported on this DCT release.",
+            "details": "The API operation 'COMPLIANCE_JOB_CREATE' is not implemented (HTTP 501) on this environment.",
+            "status": "feature_unavailable",
+            "suggestions": [
+                "Create the profiling job via the DCT UI.",
+                "Verify DCT version supports compliance job API operations.",
+                "Upgrade to a newer DCT version if API-based creation is required.",
+            ],
+        }
+
+    @mcp.tool()
+    async def update_profile_job(
+        job_id: str,
+        name: Optional[str] = None,
+        ruleset_id: Optional[str] = None,
+        rule_set_id: Optional[str] = None,
+        profile_set_id: Optional[str] = None,
+        policy_id: Optional[str] = None,
+        schedule: Optional[Dict[str, Any]] = None,
+        options: Optional[Dict[str, Any]] = None,
+        description: Optional[str] = None,
+        status: Optional[str] = None,
+        job_type: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Update an existing profile job.
+
+        Sends PATCH to 'compliance-jobs/{job_id}' with provided fields.
+        """
+        # Current DCT release indicates job update operations are not available.
+        return {
+            "error": "not_supported",
+            "message": "Profile job update is not supported on this DCT release.",
+            "details": "The API operation 'COMPLIANCE_JOB_UPDATE' is not implemented on this environment.",
+            "job_id": job_id,
+            "status": "feature_unavailable",
+            "suggestions": [
+                "Modify the profiling job via the DCT UI.",
+                "Verify DCT version supports compliance job update operations.",
+                "Upgrade to a newer DCT version if API-based updates are required.",
+            ],
+        }
+
+    logger.info("Jobs tools registered successfully (continuous_compliance)")

--- a/src/dxi_mcp_server/tools/continuous_compliance/logs.py
+++ b/src/dxi_mcp_server/tools/continuous_compliance/logs.py
@@ -1,0 +1,177 @@
+"""
+Logs tools (Continuous Compliance)
+
+Provides access to job logs and an explanation helper.
+"""
+
+import logging
+from typing import Any, Dict, Optional
+
+from mcp.server.fastmcp import FastMCP
+
+from ...client import DCTAPIClient
+
+logger = logging.getLogger(__name__)
+
+
+def register_logs_tools(mcp: FastMCP, client: DCTAPIClient):
+    @mcp.tool()
+    async def get_job_logs(job_id: str, path_override: Optional[str] = None) -> Dict[str, Any]:
+        """Get logs for a job.
+
+        Tries multiple known path patterns since DCT releases differ:
+        - compliance-jobs/{job_id}/logs
+        - jobs/{job_id}/logs
+        - job-executions/{job_id}/logs
+        - executions/{job_id}/logs
+
+        Pass path_override to use a specific path.
+        """
+        candidates = [
+            path_override or f"compliance-jobs/{job_id}/logs",
+            f"jobs/{job_id}/logs",
+            f"job-executions/{job_id}/logs",
+            f"executions/{job_id}/logs",
+        ]
+        last_error: Optional[Dict[str, Any]] = None
+        for p in candidates:
+            try:
+                return await client.make_request("GET", p)
+            except Exception as e:
+                # Capture and try next candidate
+                last_error = {"error": str(e), "path": p}
+                continue
+        return {
+            "error": "not_found",
+            "message": "No logs endpoint found for this job on current DCT release.",
+            "tried_paths": candidates,
+            "last_error": last_error,
+            "suggestions": [
+                "Use path_override to specify the exact logs endpoint for your DCT.",
+                "List executions for the job and try get_execution with /logs if supported.",
+                "Check DCT documentation for logs API paths for this version.",
+            ],
+        }
+
+    @mcp.tool()
+    async def explain_job_latest_logs(job_id: str) -> Dict[str, Any]:
+        """Fetch the most recent execution for a job and explain its logs.
+
+        Strategy:
+        - List executions filtered by job_id using 'executions' endpoint
+        - Select the latest by end_time or start_time
+        - Build a readable log_text from execution metadata and task_events
+        - Return an explanation summary similar to explain_job_logs
+        """
+        try:
+            # Fetch executions for the given job
+            exec_resp = await client.make_request("GET", "executions", params={"job_id": job_id, "limit": 50})
+            items = exec_resp.get("items") or exec_resp.get("results") or []
+            if not items:
+                return {
+                    "error": "no_executions",
+                    "message": "No executions found for the specified job.",
+                    "job_id": job_id,
+                }
+
+            def _ts(ex):
+                return ex.get("end_time") or ex.get("start_time") or ex.get("submit_time") or ""
+
+            # Pick latest by lexicographic ISO timestamp (assumes ISO8601)
+            latest = sorted(items, key=_ts, reverse=True)[0]
+
+            # Build a concise textual representation from execution and task_events
+            header_lines = []
+            for k in (
+                "id",
+                "status",
+                "engine_name",
+                "masking_job_name",
+                "start_time",
+                "end_time",
+                "run_duration",
+                "total_duration",
+            ):
+                if k in latest and latest[k] is not None:
+                    header_lines.append(f"{k}: {latest[k]}")
+
+            events = latest.get("task_events") or []
+            event_lines = [
+                f"{e.get('event','')} - {e.get('status','')}" for e in events if isinstance(e, dict)
+            ]
+
+            log_text = "\n".join(header_lines + ["-- events --"] + event_lines)
+
+            # Perform the same lightweight analysis as explain_job_logs
+            lines = log_text.splitlines()
+            errors = [l for l in lines if "ERROR" in l or "Error" in l]
+            warnings = [l for l in lines if "WARN" in l or "Warning" in l]
+            failed = [l for l in lines if "FAIL" in l or "failed" in l.lower()]
+
+            summary = {
+                "job_id": job_id,
+                "execution_id": latest.get("id"),
+                "status": latest.get("status"),
+                "total_lines": len(lines),
+                "error_count": len(errors),
+                "warning_count": len(warnings),
+                "failed_markers": len(failed),
+                "common_patterns": {
+                    "constraint": any("constraint" in l.lower() for l in errors),
+                    "timeout": any("timeout" in l.lower() for l in errors + warnings),
+                    "auth": any("auth" in l.lower() or "permission" in l.lower() for l in errors + warnings),
+                },
+                "sample_errors": errors[:5],
+                "sample_warnings": warnings[:5],
+                "recommendations": [
+                    "Check connector credentials and network reachability for auth/timeouts.",
+                    "Verify ruleset domains/algorithms for columns flagged in errors.",
+                    "Review job configuration for invalid parameters or missing resources.",
+                    "Search KB with top error phrases for known resolutions.",
+                ],
+            }
+            return {"summary": summary, "raw": {"execution": latest, "text": log_text}}
+        except Exception as e:
+            return {"error": "explain_latest_failed", "message": str(e), "job_id": job_id}
+
+    logger.info("Logs tools registered successfully (continuous_compliance)")
+
+
+def register_log_explanation_tools(mcp: FastMCP):
+    @mcp.tool()
+    async def explain_job_logs(log_text: str) -> Dict[str, Any]:
+        """Explain job logs: summarize and extract errors/warnings.
+
+        Args:
+            log_text: Raw log text or JSON string from job logs.
+        Returns:
+            Summary with counts and suggested next steps.
+        """
+        try:
+            lines = log_text.splitlines()
+            errors = [l for l in lines if "ERROR" in l or "Error" in l]
+            warnings = [l for l in lines if "WARN" in l or "Warning" in l]
+            failed = [l for l in lines if "FAIL" in l or "failed" in l.lower()]
+
+            summary = {
+                "total_lines": len(lines),
+                "error_count": len(errors),
+                "warning_count": len(warnings),
+                "failed_markers": len(failed),
+                "common_patterns": {
+                    "constraint": any("constraint" in l.lower() for l in errors),
+                    "timeout": any("timeout" in l.lower() for l in errors + warnings),
+                    "auth": any("auth" in l.lower() or "permission" in l.lower() for l in errors + warnings),
+                },
+                "sample_errors": errors[:5],
+                "sample_warnings": warnings[:5],
+                "recommendations": [
+                    "Check connector credentials and network reachability for auth/timeouts.",
+                    "Verify ruleset domains/algorithms for columns flagged in errors.",
+                    "Review job configuration for invalid parameters or missing resources.",
+                    "Search KB with top error phrases for known resolutions.",
+                ],
+            }
+            return {"summary": summary}
+        except Exception as e:
+            return {"error": "explain_failed", "message": str(e)}

--- a/src/dxi_mcp_server/tools/continuous_compliance/rulesets.py
+++ b/src/dxi_mcp_server/tools/continuous_compliance/rulesets.py
@@ -1,0 +1,66 @@
+"""
+Ruleset tools (Continuous Compliance)
+"""
+
+import logging
+from typing import Any, Dict, Optional
+
+from mcp.server.fastmcp import FastMCP
+
+from ...client import DCTAPIClient
+
+logger = logging.getLogger(__name__)
+
+
+def register_ruleset_tools(mcp: FastMCP, client: DCTAPIClient):
+    @mcp.tool()
+    async def list_rulesets(limit: Optional[int] = None, cursor: Optional[str] = None, sort: Optional[str] = None) -> Dict[str, Any]:
+        params = {}
+        if limit is not None:
+            params["limit"] = limit
+        if cursor is not None:
+            params["cursor"] = cursor
+        if sort is not None:
+            params["sort"] = sort
+        return await client.make_request("GET", "rule-sets", params=params)
+
+    @mcp.tool()
+    async def search_rulesets(
+        search_criteria: Dict[str, Any],
+        limit: Optional[int] = None,
+        cursor: Optional[str] = None,
+        sort: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        params = {}
+        if limit is not None:
+            params["limit"] = limit
+        if cursor is not None:
+            params["cursor"] = cursor
+        if sort is not None:
+            params["sort"] = sort
+        return await client.make_request("POST", "rule-sets/search", data={"filter_expression": search_criteria}, params=params)
+
+    @mcp.tool()
+    async def get_ruleset(ruleset_id: str) -> Dict[str, Any]:
+        return await client.make_request("GET", f"rule-sets/{ruleset_id}")
+
+    @mcp.tool()
+    async def create_ruleset(*args, **kwargs) -> Dict[str, Any]:
+        return {
+            "error": "not_supported",
+            "message": "Ruleset creation is not currently supported on this DCT instance.",
+            "details": "The operation 'RULE_SET_CREATE' is not supported on this DCT release.",
+            "status": "feature_unavailable",
+        }
+
+    @mcp.tool()
+    async def update_ruleset(ruleset_id: str, *args, **kwargs) -> Dict[str, Any]:
+        return {
+            "error": "not_supported",
+            "message": "Ruleset updates are not currently supported on this DCT instance.",
+            "details": "The operation 'RULE_SET_UPDATE' is not supported on this DCT release.",
+            "ruleset_id": ruleset_id,
+            "status": "feature_unavailable",
+        }
+
+    logger.info("Ruleset tools registered successfully (continuous_compliance)")

--- a/start_mcp_server_python.sh
+++ b/start_mcp_server_python.sh
@@ -3,6 +3,12 @@
 # Navigate to the project directory
 cd "$(dirname "$0")"
 
+# Load .env file if it exists
+if [ -f .env ]; then
+    echo "Loading environment from .env file..."
+    source .env
+fi
+
 # Set environment variables from .env file or system environment
 # Note: Set DCT_API_KEY, DCT_BASE_URL, DCT_VERIFY_SSL, DCT_LOG_LEVEL in your environment
 export PYTHONPATH=src

--- a/start_mcp_server_uv.sh
+++ b/start_mcp_server_uv.sh
@@ -3,6 +3,12 @@
 # Navigate to the project directory
 cd "$(dirname "$0")"
 
+# Load .env file if it exists
+if [ -f .env ]; then
+    echo "Loading environment from .env file..."
+    export $(cat .env | grep -v '^#' | xargs)
+fi
+
 # Set environment variables from .env file or system environment
 # Note: Set DCT_API_KEY, DCT_BASE_URL, DCT_VERIFY_SSL, DCT_LOG_LEVEL in your environment
 export PYTHONPATH=src


### PR DESCRIPTION
<details open>
<summary><h2> Background </h2></summary>

This change introduces a continuous_compliance toolkit for the DCT MCP server, consolidating:
- rulesets,
- connectors,
- jobs,
- executions,
- and logs
under a dedicated subpackage.

Additionally, facilitated server startup for Claude Desktop via a dedicated entrypoint.
</details>

<details open>
<summary><h2> Problem </h2></summary>

The MCP server didn’t have these Continuous Compliance tools or Claude entrypoint.
</details>

<details open>
<summary><h2> Solution </h2></summary>

Implemented and organized the missing pieces:
- Added `continuous_compliance` with rulesets, connectors, jobs, executions, logs, and explainers.
- Standardized “not_supported” handling for unsupported DCT endpoints (e.g., profile job create).
- Entry script to stabilize imports and environment (Claude now connects).
- Registered new tools in main.py/tools/__init__.py.
</details>

<details>
<summary><h2> Testing Done </h2></summary>

Local execution via uv confirms server startup and tool registration.

In Claude Desktop, the server connects successfully and returns real job/execution data:
- explain_job_latest_logs produces accurate summaries from task events.
- Logs endpoint variations are handled gracefully through probing.
- Profile job create/update returns explicit not_supported responses consistent with 501 behavior on this DCT release.
</details>
