### PR TITLE
DLPXECO-13796 Failed to update the source config's field of `allow linking`

### DIFF
--- a/src/dct_mcp_server/config/toolsets/continuous_data_admin.txt
+++ b/src/dct_mcp_server/config/toolsets/continuous_data_admin.txt
@@ -306,6 +306,8 @@ POST|/sources/ase|create_ase_source
 PATCH|/sources/ase/{sourceId}|update_ase_source
 POST|/sources/appdata|create_appdata_source
 PATCH|/sources/appdata/{sourceId}|update_appdata_source
+POST|/sources/mssql|create_mssql_source
+PATCH|/sources/mssql/{sourceId}|update_mssql_source
 
 # ----------------------------------------------------------------------------
 # TOOL 10: replication_tool - Replication, Namespaces & Retention

--- a/src/dct_mcp_server/toolsgenerator/driver.py
+++ b/src/dct_mcp_server/toolsgenerator/driver.py
@@ -107,6 +107,34 @@ TOOLKIT_SCHEMA_HINT_PROVISION = (
     "For Oracle, MSSQL, PostgreSQL, or other non-AppData types, skip this step."
 )
 
+# Action-level domain hints injected into the per-action docstring section.
+# Use these when a specific action has Delphix-domain semantics that the raw
+# OpenAPI summary/parameter descriptions don't convey — e.g. distinguishing
+# between credential fields that look interchangeable or flagging that a
+# parameter toggles a concept the user typically names differently.
+ACTION_DOMAIN_HINTS: dict[str, str] = {
+    "create_environment": (
+        "IMPORTANT — SAP ASE discovery credentials (ONLY relevant when the user "
+        "has explicitly asked to enable SAP ASE discovery on the environment; "
+        "otherwise IGNORE this hint and DO NOT prompt for any ase_db_* fields):\n"
+        "    • ase_db_username / ase_db_password are credentials for the SAP ASE "
+        "*database instance* and are SEPARATE from username / password (which are "
+        "the OS SSH credentials for the host).\n"
+        "    • If — and only if — the user has asked to enable SAP ASE discovery "
+        "and has NOT explicitly provided ASE DB credentials, STOP and ask for "
+        "them. Do NOT reuse the OS username/password as ASE DB credentials — "
+        "they are almost always different and silently copying them will cause "
+        "discovery to fail.\n"
+        "    • The same separation applies to the vault-based ASE credential "
+        "fields (ase_db_vault, ase_db_vault_username, ase_db_hashicorp_vault_*, "
+        "ase_db_azure_vault_*, ase_db_cyberark_vault_query_string) — these are "
+        "ASE-specific and must not be inferred from the host credential fields.\n"
+        "    • For non-ASE environments (Oracle, MSSQL, PostgreSQL, AppData, "
+        "plain UNIX/Windows hosts, etc.), skip all ase_db_* fields entirely — "
+        "do not ask the user about them."
+    ),
+}
+
 
 def load_api_endpoints_from_toolsets():
     """
@@ -906,6 +934,13 @@ def _generate_unified_tool(tool_name: str, apis: list, api_spec: dict) -> str:
         elif hint_group == "provision":
             docstring_lines.append("")
             docstring_lines.append(f"    {TOOLKIT_SCHEMA_HINT_PROVISION}")
+
+        # Inject action-level domain hints for actions whose OpenAPI description
+        # does not make Delphix-specific semantics (e.g. credential separation)
+        # clear to the LLM.
+        if action_name in ACTION_DOMAIN_HINTS:
+            docstring_lines.append("")
+            docstring_lines.append(f"    {ACTION_DOMAIN_HINTS[action_name]}")
 
     # =========================================================================
     # PARAMETERS SECTION (grouped by database type)

--- a/src/dct_mcp_server/toolsgenerator/driver.py
+++ b/src/dct_mcp_server/toolsgenerator/driver.py
@@ -1026,6 +1026,7 @@ def _generate_unified_tool(tool_name: str, apis: list, api_spec: dict) -> str:
         func_code += f"            return conf\n"
 
         # Handle request body
+        body_var = None
         if details["has_filter"] and method == "POST":
             func_code += "        body = {'filter_expression': filter_expression} if filter_expression else {}\n"
             body_var = "body"


### PR DESCRIPTION
<details open>
  <summary><h2> Problem </h2></summary>

  Two separate bugs surfaced while exercising the DCT MCP server against DCT 2026.3:

  **1. DLPXECO-13815 — `set_environment_primary_user` crashes with `UnboundLocalError`**

  Attempting to set the primary user on an environment (e.g. promoting `oracle` to primary on a RAC cluster environment) fails in the MCP layer before the DCT API is ever called.

  *Reproduce:*
  1. Register an environment via MCP.
  2. Add a second environment user.
  3. Now ask mcp to set this second env user as primary user for the environment.                                                                                                    
                                                                                                                                                                                                                 
  *Expected:* DCT returns a job that flips the primary user.                                                                                                                                                     
  *Actual:*                                                                                                                                                                                                      
  UnboundLocalError: cannot access local variable 'body' where it is not associated with a value                                                                                                               
    File ".../tools/environment_endpoints_tool.py", line 1013, in environment_source_tool                                                                                                                        
      return await make_api_request('POST', endpoint, params=params, json_body=body if body else None)                                                                                                         
                                                                                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                 
  **2. DLPXECO-13796 — cannot update an MSSQL source's `allow linking` field**                                                                                                                                 

  The MSSQL source create/update endpoints (`POST /sources/mssql`, `PATCH /sources/mssql/{sourceId}`) were missing from the `continuous_data_admin` and `platform_admin` toolsets. As a result, users could not  
  modify MSSQL-specific fields such as `allow linking` through the MCP server and had to fall back to the DCT UI or a raw API call. Oracle, ASE, Postgres, and AppData source endpoints were all present — only
  MSSQL was omitted.                                                                                                                                                                                             
                                                                                                                                                                                                               
  </details>


  <details open>
  <summary><h2> Testing Done </h2></summary>

  Tested locally with Claude Desktop connected to `dct-mcp-server` running from this branch against DCT 2026.3 in engine `skdct.dlpxdc.co`.                                                              
                                                                                                                                                                                                                 
  </details>