### PR TITLE
DLPXECO-13809 Missing delete tag actions in continuous_data_admin and…

### DIFF
--- a/src/dct_mcp_server/config/toolsets/continuous_data_admin.txt
+++ b/src/dct_mcp_server/config/toolsets/continuous_data_admin.txt
@@ -49,7 +49,7 @@ GET|/vdbs/{vdbId}/deletion-dependencies|get_vdb_deletion_dependencies
 POST|/vdbs/{vdbId}/jdbc-check|verify_vdb_jdbc_connection
 GET|/vdbs/{vdbId}/tags|get_vdb_tags
 POST|/vdbs/{vdbId}/tags|add_vdb_tags
-DELETE|/vdbs/{vdbId}/tags/delete|delete_vdb_tags
+POST|/vdbs/{vdbId}/tags/delete|delete_vdb_tags
 POST|/vdbs/{vdbId}/in-place-export|export_vdb_in_place
 POST|/vdbs/{vdbId}/asm-in-place-export|export_vdb_asm_in_place
 POST|/vdbs/{vdbId}/export-by-snapshot|export_vdb_by_snapshot
@@ -87,7 +87,7 @@ GET|/vdb-groups/{vdbGroupId}/bookmarks|list_vdb_group_bookmarks
 POST|/vdb-groups/{vdbGroupId}/bookmarks/search|search_vdb_group_bookmarks
 GET|/vdb-groups/{vdbGroupId}/tags|get_vdb_group_tags
 POST|/vdb-groups/{vdbGroupId}/tags|add_vdb_group_tags
-DELETE|/vdb-groups/{vdbGroupId}/tags/delete|delete_vdb_group_tags
+POST|/vdb-groups/{vdbGroupId}/tags/delete|delete_vdb_group_tags
 # dSource Operations
 GET|/dsources|list_dsources
 POST|/dsources/search|search_dsources

--- a/src/dct_mcp_server/config/toolsets/self_service_provision.txt
+++ b/src/dct_mcp_server/config/toolsets/self_service_provision.txt
@@ -21,7 +21,7 @@ POST|/vdbs/{vdbId}/switch_timeflow|switch_timeflow
 POST|/vdbs/{vdbId}/undo_refresh|undo_refresh
 GET|/vdbs/{vdbId}/deletion-dependencies|get_deletion_dependencies
 POST|/vdbs/{vdbId}/tags|add_tags
-DELETE|/vdbs/{vdbId}/tags/delete|delete_tags
+POST|/vdbs/{vdbId}/tags/delete|delete_tags
 
 # ----------------------------------------------------------------------------
 # TOOL 2: vdb_group_tool - Extended with CRUD (inherits from self_service)
@@ -32,7 +32,7 @@ DELETE|/vdb-groups/{vdbGroupId}|delete
 POST|/vdb-groups/provision_from_bookmark|provision_from_bookmark
 GET|/vdb-groups/{vdbGroupId}/latest-snapshots|get_latest_snapshots
 POST|/vdb-groups/{vdbGroupId}/tags|add_tags
-DELETE|/vdb-groups/{vdbGroupId}/tags/delete|delete_tags
+POST|/vdb-groups/{vdbGroupId}/tags/delete|delete_tags
 
 # Inherited: TOOL 3: bookmark_tool (from self_service)
 # Inherited: TOOL 4: snapshot_tool (from self_service)


### PR DESCRIPTION
Fix DELETE→POST HTTP method for /tags/delete endpoints in continuous_data_admin and self_service_provision toolsets. The DCT API uses POST to a /tags/delete sub-resource (not a true HTTP DELETE), so tool_factory.py was sending tag filter params as query strings instead of a JSON body.
