### PR TITLE
DLPXECO-13635 Add Docker container support for MCP server

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,50 @@
+# Virtual environments
+.venv/
+
+# Runtime logs — generated inside the container, not needed in image
+logs/
+
+# Python caches
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.Python
+
+# Environment files — secrets must be passed at runtime via -e flags
+.env
+.env.*
+
+# Git worktrees directory (feature branches)
+.worktrees/
+
+# Generated docs and spec docs (not needed at runtime)
+docs/
+
+# Windows scripts (container runs Linux)
+*.bat
+
+# Shell startup scripts (not used inside the container)
+*.sh
+
+# Version control
+.git/
+.gitignore
+
+# Editor and IDE files
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# CI/CD and GitHub-specific files
+.github/
+
+# Claude AI project files
+.claude/
+CLAUDE.md
+
+# Test and development artifacts
+*.egg-info/
+dist/
+build/

--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ mcp_server_setup_logfile.txt
 
 # Local docs (not part of review)
 docs/
+
+# Git worktrees (project-local isolation)
+.worktrees/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Copy source into the working directory
+COPY . .
+
+# Install the package in editable mode so the source tree stays at /app/src.
+# This ensures that logging.py's _get_project_root() (parents[3] from
+# src/dct_mcp_server/core/logging.py) resolves to /app, placing log files
+# under /app/logs instead of inside site-packages.
+RUN pip install --no-cache-dir -e .
+
+# Create the logs directory that the logging module writes to
+RUN mkdir -p /app/logs
+
+# The server communicates over stdio — no port to expose
+CMD ["dct-mcp-server"]

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The Delphix DCT MCP Server provides a robust Model Context Protocol (MCP) interf
 - [Videos](#videos)
 - [Environment Variables](#environment-variables)
 - [MCP Client Configuration](#mcp-client-configuration)
+- [Running with Docker](#running-with-docker)
 - [Advanced Installation](#advanced-installation)
 - [Toolsets](#toolsets)
 - [Available Tools](#available-tools)
@@ -300,6 +301,82 @@ See below for the full JSON configuration examples for each client.
 
 > **Note**: VS Code, Eclipse, and IntelliJ all use the same configuration format (servers object).
 </details>
+
+## Running with Docker
+
+Docker is the easiest way to run the MCP server in a consistent, isolated environment on Linux, macOS, or Windows (via Docker Desktop).
+
+### Build the Image
+
+```bash
+docker build -t dct-mcp-server .
+```
+
+### Run the Container
+
+The server uses stdio transport, so the `-i` flag is required to keep stdin open:
+
+```bash
+docker run -i \
+  -e DCT_API_KEY=your-api-key-here \
+  -e DCT_BASE_URL=https://your-dct-host.company.com \
+  dct-mcp-server
+```
+
+Optional environment variables can be passed the same way:
+
+```bash
+docker run -i \
+  -e DCT_API_KEY=your-api-key-here \
+  -e DCT_BASE_URL=https://your-dct-host.company.com \
+  -e DCT_TOOLSET=continuous_data_admin \
+  -e DCT_VERIFY_SSL=true \
+  -e DCT_LOG_LEVEL=DEBUG \
+  dct-mcp-server
+```
+
+> **Important**: The `-i` flag is required. Without it the container exits immediately because the MCP stdio transport needs an open stdin to communicate with the client.
+
+### MCP Client Configuration
+
+Configure your MCP client to launch the container instead of running the server directly:
+
+```json
+{
+  "mcpServers": {
+    "delphix-dct": {
+      "command": "docker",
+      "args": [
+        "run", "--rm", "-i",
+        "-e", "DCT_API_KEY=your-api-key-here",
+        "-e", "DCT_BASE_URL=https://your-dct-host.company.com",
+        "-e", "DCT_TOOLSET=self_service",
+        "dct-mcp-server"
+      ]
+    }
+  }
+}
+```
+
+### Using a Pre-Built Image
+
+A pre-built image will be available once published:
+
+```bash
+# Pull the latest image (URL will be updated once the image is published)
+docker pull ghcr.io/delphix/dct-mcp-server:latest
+
+docker run -i \
+  -e DCT_API_KEY=your-api-key-here \
+  -e DCT_BASE_URL=https://your-dct-host.company.com \
+  ghcr.io/delphix/dct-mcp-server:latest
+```
+
+### Windows Docker Desktop Note
+
+Docker Desktop for Windows runs Linux containers by default. The standard Linux image built from this `Dockerfile` works without any changes on Windows — no Windows-specific image is needed.
+
+---
 
 ## Advanced Installation
 


### PR DESCRIPTION
## What changed

- **`Dockerfile`** — Added new Dockerfile using `python:3.11-slim` base image. Performs an editable install (`pip install -e .`), sets WORKDIR to `/app`, creates `/app/logs` for log output, and starts the server via the `dct-mcp-server` CLI entry point.
- **`.dockerignore`** — Added to exclude development artifacts from the Docker build context: `.venv/`, `logs/`, `__pycache__/`, `.env`, `.worktrees/`, `.git/`, `.github/`, `.claude/`, `*.bat`, `*.sh`, and build artifacts.
- **`README.md`** — Added a "Running with Docker" section covering: image build and run commands, MCP client JSON config snippet, the required `-i` flag for stdio transport, a Windows Docker Desktop note, and the `ghcr.io/delphix/dct-mcp-server:latest` placeholder for future image publishing.

## Why

Users and teams that prefer container-based deployments (CI/CD pipelines, shared environments, air-gapped systems) currently have no first-class path to run the MCP server in Docker. This change adds a minimal, reproducible Docker setup so the server can be hosted in a container without requiring a local Python environment or manual dependency management.

## Testing

Testing is done by connecting an MCP client to the running Docker container. No automated test suite exists.

**To verify:**
1. Build the image: `docker build -t dct-mcp-server .`
2. Run the container: `docker run -i -e DCT_API_KEY=<key> -e DCT_BASE_URL=<url> dct-mcp-server`
3. Configure an MCP client (Claude Desktop, Cursor) with:
   ```json
   {
     "mcpServers": {
       "delphix-dct": {
         "command": "docker",
         "args": ["run", "-i", "--rm", "-e", "DCT_API_KEY=<key>", "-e", "DCT_BASE_URL=<url>", "dct-mcp-server"]
       }
     }
   }
   ```
4. Confirm the toolset tools appear in the client and a sample action (e.g. `vdb_tool(action="search")`) returns a valid DCT API response.