### PR TITLE
DLPXECO-13921 Fuzzy endpoint discovery + spec-chunk fetcher for auto mode

### DIFF
--- a/.claude/evals/DLPXECO-13921-test-evidence.md
+++ b/.claude/evals/DLPXECO-13921-test-evidence.md
@@ -1,0 +1,74 @@
+# Test Evidence — DLPXECO-13921
+
+> Fuzzy endpoint discovery + spec-chunk fetcher meta-tools for auto mode.
+
+## Environment
+
+| Item | Value |
+|---|---|
+| Branch | `dlpx/pr/shreyaskulkarni/DLPXECO-13921-improve-auto-mode-fuzzy-endpoint-discovery` |
+| Toolset | `auto` (only mode where the new meta-tools are registered) |
+| OpenAPI spec | Bundled `api-external.yaml` from the repo root, injected directly into `tool_factory._openapi_spec` |
+| DCT instance | Not exercised in this evidence run — tests are spec-only and do not call DCT |
+| MCP client | None — invoked the tool functions directly via Python to exercise the discovery/resolver logic |
+
+End-to-end MCP-client testing against a live DCT instance is still pending and is the next gate before merge.
+
+## What was tested
+
+### 1. Imports and registration shape
+
+```text
+from dct_mcp_server.tools.core.meta_tools import find_endpoint, get_spec_chunk, register_meta_tools
+from dct_mcp_server.tools.core.endpoint_discovery import (
+    build_corpus_from_spec, extract_hot_keywords_from_spec, rank_candidates,
+)
+# imports OK
+```
+
+Meta-tool count updated 6 → 8 in `register_meta_tools`, `enable_toolset.total_available_tools`, `disable_toolset.remaining_tools`, and the module docstring.
+
+### 2. `find_endpoint` — fuzzy ranking
+
+| Query | `method_types` | Top result | Score | `suggested_toolset` |
+|---|---|---|---|---|
+| `list all dsources` | `["GET","POST"]` | `GET /dsources` | 0.885 | `continuous_data_admin` |
+| `list all dsources` | `["GET","POST"]` | `GET /cdb-dsources` | 0.860 | `continuous_data_admin` |
+| `find vdb with most snapshots` | `["GET","POST"]` | `GET /snapshots/find_by_timestamp` | 0.459 | `continuous_data_admin` |
+| `list all compliance connectors` | (none) | `GET /compliance-job-collections` | 0.554 | `null` (not exposed by any persona) |
+| `list all compliance connectors` | (none) | `GET /compliance-jobs/{complianceJobId}/connectors` | 0.535 | `null` |
+| `delete a bookmark` | `["DELETE"]` | `DELETE /bookmarks/{bookmarkId}` | 0.785 | `continuous_data_admin`, `confirmation_level=manual` |
+
+Observations:
+- The user's worked example (`list all compliance connectors`) returns the right endpoints with `suggested_toolset=null`, demonstrating the spec-only + auto-enable-hint path: no persona exposes compliance, so the LLM must call `execute_action` directly with the spec path.
+- Confirmation levels are correctly enriched per candidate (`manual` for `DELETE /bookmarks/{bookmarkId}`).
+- POST `/*/search` endpoints are folded into the GET-equivalent set when `method_types=["GET"]`.
+
+### 3. `get_spec_chunk` — `$ref` resolution
+
+| Input ref | Outcome |
+|---|---|
+| `#/components/parameters/limit` | resolved → `value.name == "limit"` |
+| `#/components/parameters/cursor` | resolved → `value.name == "cursor"` |
+| `/components/parameters/limit` (no leading `#`) | resolved (plain JSON pointer form accepted) |
+| `#/components/parameters/nonexistent_xyz` | `error: ref segment 'nonexistent_xyz' not found in spec` |
+
+This covers the explicit user example: `/dsources/search` references `#/components/parameters/limit`, and the LLM can fetch that fragment with one round-trip via `get_spec_chunk`.
+
+### 4. Error / edge cases
+
+| Case | Behaviour |
+|---|---|
+| `find_endpoint("")` | `error: query is required`, `candidates: []`, no exception |
+| `find_endpoint(...)` with no cached spec | `error: OpenAPI spec not available; cannot perform fuzzy discovery.`, `candidates: []` |
+| `get_spec_chunk("")` / non-string | `error: ref is required (string)` |
+| `get_spec_chunk("not-a-pointer")` | `error: ref must be a JSON pointer like '#/components/parameters/limit' …` |
+| `get_spec_chunk(...)` with no cached spec | `error: OpenAPI spec not available` |
+
+All clean dicts — no bare exceptions raised, no global state mutated.
+
+## Pending / out of scope for this evidence run
+
+- **Live MCP-client exercise** with `DCT_TOOLSET=auto` against a real DCT instance (`/list_available_toolsets` instructions text now mentions `find_endpoint` first; `tools/list_changed` is unaffected).
+- The `.claude/rules/testing/auto.md` prompts were not extended in this commit — see follow-up task to append fuzzy-discovery prompts (steps 58+).
+- Regression check that all 57 existing auto-mode prompts still pass — also pending live-client run.

--- a/src/dct_mcp_server/tools/core/endpoint_discovery.py
+++ b/src/dct_mcp_server/tools/core/endpoint_discovery.py
@@ -1,0 +1,140 @@
+"""Fuzzy endpoint discovery helpers for auto-mode find_endpoint meta-tool."""
+
+from __future__ import annotations
+import re
+from difflib import SequenceMatcher
+from typing import Any
+
+from dct_mcp_server.core.logging import get_logger
+
+logger = get_logger(__name__)
+
+_TOKEN_RE = re.compile(r"[a-z0-9]+")
+_PATH_TOKEN_RE = re.compile(r"[A-Za-z0-9]+")
+
+
+def _tokenize(text: str) -> set[str]:
+    return set(_TOKEN_RE.findall(text.lower()))
+
+
+def _path_tokens(path: str) -> set[str]:
+    no_braces = re.sub(r"\{[^}]+\}", " ", path)
+    parts = _PATH_TOKEN_RE.findall(no_braces)
+    out: set[str] = set()
+    for p in parts:
+        out.update(re.findall(r"[a-z]+|[A-Z][a-z]*|[0-9]+", p) or [p])
+    return {t.lower() for t in out if t}
+
+
+def extract_hot_keywords_from_spec(spec: dict[str, Any]) -> frozenset[str]:
+    """Derive domain hot-keywords from spec tags and operationId tokens.
+
+    Tags are weighted 3× since they are the spec's canonical resource labels.
+    Returns tokens that appear in at least 3 operations (genuinely domain-relevant).
+    """
+    freq: dict[str, int] = {}
+    paths = spec.get("paths", {}) or {}
+    for _path, item in paths.items():
+        if not isinstance(item, dict):
+            continue
+        for method, op in item.items():
+            if method.lower() not in {"get", "post", "put", "patch", "delete"}:
+                continue
+            if not isinstance(op, dict):
+                continue
+            for tag in op.get("tags", []):
+                for t in _TOKEN_RE.findall(tag.lower()):
+                    freq[t] = freq.get(t, 0) + 3
+            op_id = op.get("operationId", "") or ""
+            for t in re.findall(r"[a-z]+|[A-Z][a-z]*", op_id):
+                freq[t.lower()] = freq.get(t.lower(), 0) + 1
+    return frozenset(k for k, v in freq.items() if v >= 3 and len(k) > 2)
+
+
+def build_corpus_from_spec(spec: dict[str, Any]) -> list[dict[str, Any]]:
+    """Flatten spec.paths into a list of candidate dicts."""
+    out: list[dict[str, Any]] = []
+    paths = spec.get("paths", {}) or {}
+    for path, item in paths.items():
+        if not isinstance(item, dict):
+            continue
+        for method, op in item.items():
+            if method.lower() not in {"get", "post", "put", "patch", "delete"}:
+                continue
+            if not isinstance(op, dict):
+                continue
+            out.append({
+                "method": method.upper(),
+                "path": path,
+                "operation_id": op.get("operationId", "") or "",
+                "summary": op.get("summary", "") or "",
+                "description": op.get("description", "") or "",
+                "tags": op.get("tags", []) or [],
+            })
+    return out
+
+
+def score_candidate(
+    query_tokens: set[str],
+    hot_keywords: frozenset[str],
+    candidate: dict[str, Any],
+) -> float:
+    """Weighted score in [0, 1] combining keyword overlap, path similarity, and hot-keyword boost."""
+    if not query_tokens:
+        return 0.0
+    cand_tokens = (
+        _path_tokens(candidate["path"])
+        | _tokenize(candidate["summary"])
+        | _tokenize(candidate.get("operation_id", ""))
+        | {t.lower() for tag in candidate.get("tags", []) for t in _TOKEN_RE.findall(tag)}
+    )
+    overlap = len(query_tokens & cand_tokens) / max(len(query_tokens), 1)
+    ratio = SequenceMatcher(
+        None,
+        " ".join(sorted(query_tokens)),
+        candidate["path"].lower(),
+    ).ratio()
+    hot_hits = (query_tokens & cand_tokens) & hot_keywords
+    hot_boost = min(0.2, 0.05 * len(hot_hits))
+    return min(1.0, (0.55 * overlap) + (0.30 * ratio) + hot_boost)
+
+
+def rank_candidates(
+    corpus: list[dict[str, Any]],
+    query: str,
+    method_types: list[str] | None,
+    min_score: float,
+    limit: int,
+    hot_keywords: frozenset[str],
+) -> list[dict[str, Any]]:
+    """Return up to `limit` scored candidates sorted by (-score, len(path))."""
+    qtokens = _tokenize(query)
+    methods_norm = {
+        m.upper() for m in (method_types or [])
+        if m and m.upper() in {"GET", "POST", "PUT", "PATCH", "DELETE"}
+    }
+
+    def passes_method(c: dict[str, Any]) -> bool:
+        if not methods_norm:
+            return True
+        if c["method"] in methods_norm:
+            return True
+        # POST /*/search is treated as GET-equivalent when GET is requested
+        if "GET" in methods_norm and c["method"] == "POST" and c["path"].endswith("/search"):
+            return True
+        return False
+
+    scored: list[dict[str, Any]] = []
+    for cand in corpus:
+        if not passes_method(cand):
+            continue
+        try:
+            s = score_candidate(qtokens, hot_keywords, cand)
+        except Exception as exc:
+            logger.warning("scoring failed for %s %s: %s", cand.get("method"), cand.get("path"), exc)
+            continue
+        if s >= min_score:
+            scored.append({**cand, "score": round(s, 4)})
+
+    scored.sort(key=lambda c: (-c["score"], len(c["path"])))
+    return scored[:limit]

--- a/src/dct_mcp_server/tools/core/meta_tools.py
+++ b/src/dct_mcp_server/tools/core/meta_tools.py
@@ -4,13 +4,15 @@ Meta-tools for DCT MCP Server toolset discovery and selection.
 These tools are available in "auto" mode (DCT_TOOLSET=auto) and allow
 the LLM to dynamically discover and work with available toolsets.
 
-Meta-tools (6):
+Meta-tools (8):
 - list_available_toolsets: List all available toolsets with descriptions
 - get_toolset_tools: Get detailed list of tools in a specific toolset
 - enable_toolset: Enable a toolset at runtime (no restart required)
 - disable_toolset: Disable current toolset, return to auto mode
 - check_operation_confirmation: Check if operation needs confirmation
 - execute_action: Execute any DCT action directly without tool list refresh
+- find_endpoint: Fuzzy-match user intent against the OpenAPI spec
+- get_spec_chunk: Resolve a $ref pointer from the cached OpenAPI spec
 
 Runtime Registration Pattern (GitHub MCP Server style):
 - Pre-load all tool modules into ToolInventory at startup
@@ -39,6 +41,13 @@ from .tool_factory import (
     register_toolset_tools,
     get_cached_spec,
 )
+from .endpoint_discovery import (
+    build_corpus_from_spec,
+    extract_hot_keywords_from_spec,
+    rank_candidates,
+)
+
+HARD_LIMIT = 25
 
 logger = logging.getLogger(__name__)
 
@@ -124,9 +133,12 @@ def list_available_toolsets() -> Dict[str, Any]:
             "toolsets": toolsets_list,
             "total_count": len(toolsets_list),
             "instructions": (
-                "Use 'get_toolset_tools' with a toolset name to see the detailed list of tools. "
-                "Use 'enable_toolset' to register domain tools, or 'execute_action' to call any "
-                "action directly without enabling a toolset."
+                "For a single user-intent request, prefer 'find_endpoint' first — it fuzzy-matches "
+                "the user's query against the OpenAPI spec and returns the best endpoint(s) with a "
+                "suggested_toolset hint. Use 'get_spec_chunk' to resolve $ref pointers (parameters, "
+                "schemas) on demand. Otherwise use 'get_toolset_tools' to browse a toolset, "
+                "'enable_toolset' to register domain tools, or 'execute_action' to call any action "
+                "directly without enabling a toolset."
             ),
         }
     except Exception as e:
@@ -247,7 +259,7 @@ async def enable_toolset(toolset_name: str, ctx: Context) -> Dict[str, Any]:
             "status": "enabled",
             "description": metadata.get("description", "No description"),
             "tools_registered": tools_registered,
-            "total_available_tools": tools_registered + 6,  # domain tools + 6 meta-tools
+            "total_available_tools": tools_registered + 8,  # domain tools + 8 meta-tools
             "previous_toolset": previous_toolset,
             "message": f"Toolset '{toolset_name}' is now active with {tools_registered} domain tools. No restart required.",
         }
@@ -279,7 +291,7 @@ async def disable_toolset(ctx: Context) -> Dict[str, Any]:
             return {
                 "status": "already_minimal",
                 "message": "No toolset is currently active. Already in meta-tools only mode.",
-                "remaining_tools": 6,
+                "remaining_tools": 8,
             }
 
         disabled_name = _current_toolset
@@ -298,8 +310,8 @@ async def disable_toolset(ctx: Context) -> Dict[str, Any]:
             "status": "disabled",
             "disabled_toolset": disabled_name,
             "tools_removed": tools_removed,
-            "remaining_tools": 6,
-            "message": f"Toolset '{disabled_name}' disabled. Now in auto mode with 6 meta-tools.",
+            "remaining_tools": 8,
+            "message": f"Toolset '{disabled_name}' disabled. Now in auto mode with 8 meta-tools.",
         }
     except Exception as e:
         logger.error(f"Error in disable_toolset: {e}")
@@ -540,14 +552,195 @@ async def execute_action(
         return {"error": str(e)}
 
 
+@log_tool_execution
+def find_endpoint(
+    query: str,
+    method_types: Optional[List[str]] = None,
+    limit: int = 10,
+    min_score: float = 0.15,
+) -> Dict[str, Any]:
+    """
+    Find the best-matching DCT API endpoint(s) for a free-text user intent
+    by fuzzy-matching against the cached OpenAPI spec.
+
+    The OpenAPI spec is the source of truth. Each candidate result includes
+    method, path, operation_id, summary, tags, score, confirmation level,
+    and a `suggested_toolset` hint pointing to the persona that exposes the
+    endpoint (if any) — call enable_toolset() with that name, or use
+    execute_action() directly if you already have the path.
+
+    Use `get_spec_chunk(ref)` afterwards to resolve any $ref pointers
+    (parameters, schemas, requestBodies) on demand.
+
+    Args:
+        query: Free-text user intent (e.g. "list all compliance connectors")
+        method_types: Optional HTTP method filter, e.g. ["GET"], ["POST"].
+            When ["GET"] is given, POST /*/search endpoints are also included
+            (semantically read-equivalent).
+        limit: Max candidates to return (default 10, hard cap 25).
+        min_score: Drop candidates below this score (default 0.15).
+
+    Returns:
+        {"candidates": [...], "source": "openapi_spec", ...} on success, or
+        {"error": "...", "candidates": []} on failure.
+    """
+    if not query or not query.strip():
+        return {
+            "error": "query is required",
+            "hint": "Provide a free-text user intent, e.g. 'list all compliance connectors'",
+            "candidates": [],
+        }
+
+    spec = get_cached_spec()
+    if spec is None:
+        return {
+            "error": "OpenAPI spec not available; cannot perform fuzzy discovery.",
+            "hint": "Spec is cached at startup; ensure DCT_BASE_URL is reachable.",
+            "candidates": [],
+        }
+
+    capped_limit = max(1, min(int(limit) if limit else 10, HARD_LIMIT))
+
+    try:
+        corpus = build_corpus_from_spec(spec)
+        hot = extract_hot_keywords_from_spec(spec)
+        ranked = rank_candidates(
+            corpus, query, method_types, float(min_score), capped_limit, hot
+        )
+    except Exception as e:
+        logger.error(f"find_endpoint ranking failed: {e}", exc_info=True)
+        return {"error": str(e), "candidates": []}
+
+    available_toolsets = get_available_toolsets()
+    enriched: List[Dict[str, Any]] = []
+    for cand in ranked:
+        method, path = cand["method"], cand["path"]
+        try:
+            confirmation = get_confirmation_for_operation(method, path)
+            level = confirmation.get("level", "none")
+        except Exception as ce:
+            logger.warning(f"confirmation lookup failed for {method} {path}: {ce}")
+            level = "none"
+
+        suggested_toolset = None
+        for ts in available_toolsets:
+            try:
+                grouped = load_toolset_grouped_apis(ts)
+            except Exception:
+                continue
+            for tool_info in grouped.values():
+                for api in tool_info.get("apis", []):
+                    if api.get("method") == method and api.get("path") == path:
+                        suggested_toolset = ts
+                        break
+                if suggested_toolset:
+                    break
+            if suggested_toolset:
+                break
+
+        enriched.append({
+            "score": cand["score"],
+            "method": method,
+            "path": path,
+            "operation_id": cand.get("operation_id", ""),
+            "summary": cand.get("summary", ""),
+            "tags": cand.get("tags", []),
+            "requires_confirmation": level != "none",
+            "confirmation_level": level,
+            "suggested_toolset": suggested_toolset,
+        })
+
+    logger.info(
+        f"find_endpoint query='{query}' method_types={method_types} "
+        f"returned={len(enriched)} source=openapi_spec"
+    )
+
+    if not enriched:
+        return {
+            "candidates": [],
+            "source": "openapi_spec",
+            "hint": (
+                "No fuzzy match. Try list_available_toolsets to browse personas, "
+                "or refine the query."
+            ),
+        }
+
+    return {
+        "candidates": enriched,
+        "source": "openapi_spec",
+        "count": len(enriched),
+        "instructions": (
+            "Inspect candidates and pick the best match. If suggested_toolset "
+            "is set, call enable_toolset(name) then use the domain tool, or "
+            "call execute_action(toolset_name=suggested_toolset, ...) directly. "
+            "Use get_spec_chunk(ref) to resolve $ref pointers from the spec."
+        ),
+    }
+
+
+@log_tool_execution
+def get_spec_chunk(ref: str) -> Dict[str, Any]:
+    """
+    Resolve a JSON-pointer / OpenAPI $ref against the cached spec.
+
+    Use this after find_endpoint to fetch parameter, schema, or requestBody
+    definitions on demand — e.g. resolving "#/components/parameters/limit"
+    referenced by /dsources/search.
+
+    Args:
+        ref: JSON pointer string. Accepts the leading "#/" form (standard
+             OpenAPI $ref) or a plain "/components/parameters/limit" form.
+
+    Returns:
+        {"ref": "...", "value": <resolved object>} on success, or
+        {"error": "...", "ref": "..."} on failure.
+    """
+    if not ref or not isinstance(ref, str):
+        return {"error": "ref is required (string)", "ref": ref}
+
+    spec = get_cached_spec()
+    if spec is None:
+        return {"error": "OpenAPI spec not available", "ref": ref}
+
+    pointer = ref.lstrip("#")
+    if not pointer.startswith("/"):
+        return {
+            "error": (
+                "ref must be a JSON pointer like '#/components/parameters/limit' "
+                "or '/components/parameters/limit'"
+            ),
+            "ref": ref,
+        }
+
+    parts = [
+        p.replace("~1", "/").replace("~0", "~")
+        for p in pointer.split("/")[1:]
+        if p != ""
+    ]
+
+    node: Any = spec
+    for part in parts:
+        if isinstance(node, dict) and part in node:
+            node = node[part]
+        elif isinstance(node, list):
+            try:
+                node = node[int(part)]
+            except (ValueError, IndexError):
+                return {"error": f"ref segment '{part}' not resolvable", "ref": ref}
+        else:
+            return {"error": f"ref segment '{part}' not found in spec", "ref": ref}
+
+    return {"ref": ref, "value": node}
+
+
 def register_meta_tools(app):
     """
-    Register the 6 meta-tools for auto mode.
+    Register the 8 meta-tools for auto mode.
 
     Args:
         app: FastMCP application instance
     """
-    logger.info("Registering 6 meta-tools for auto mode...")
+    logger.info("Registering 8 meta-tools for auto mode...")
 
     try:
         app.add_tool(list_available_toolsets, name="list_available_toolsets")
@@ -568,7 +761,13 @@ def register_meta_tools(app):
         app.add_tool(execute_action, name="execute_action")
         logger.info("  Registered: execute_action")
 
-        logger.info("Meta-tools registration completed (6 tools).")
+        app.add_tool(find_endpoint, name="find_endpoint")
+        logger.info("  Registered: find_endpoint")
+
+        app.add_tool(get_spec_chunk, name="get_spec_chunk")
+        logger.info("  Registered: get_spec_chunk")
+
+        logger.info("Meta-tools registration completed (8 tools).")
     except Exception as e:
         logger.error(f"Error registering meta-tools: {e}")
         raise


### PR DESCRIPTION
## Summary
- Auto mode now uses the OpenAPI spec as the source of truth for endpoint discovery instead of scanning persona `.txt` toolsets.
- Adds `find_endpoint(query, method_types, limit, min_score)` — fuzzy-ranks spec endpoints by path/summary/operationId/tag overlap, difflib path similarity, and a hot-keyword boost derived from spec tags. Returns method, path, operation_id, summary, tags, score, confirmation level, and a `suggested_toolset` hint.
- Adds `get_spec_chunk(ref)` — resolves a JSON pointer / `$ref` (e.g. `#/components/parameters/limit`) against the cached spec so the LLM can lazily fetch parameter, schema, and requestBody definitions.
- Meta-tool count: 6 → 8. `list_available_toolsets` now recommends `find_endpoint` as the first call for a single-intent request. Execution stays on the existing `execute_action` tool.

## Test evidence
Full test evidence at [`.claude/evals/DLPXECO-13921-test-evidence.md`](./.claude/evals/DLPXECO-13921-test-evidence.md).

## Test plan
- [x] `find_endpoint("list all dsources", ["GET","POST"])` → top hit `GET /dsources` (score 0.885), `suggested_toolset=continuous_data_admin`
- [x] `find_endpoint("list all compliance connectors")` → `/compliance-job-collections`, `/compliance-jobs/{id}/connectors` (suggested_toolset=null — not exposed by any persona)
- [x] `find_endpoint("delete a bookmark", ["DELETE"])` → `DELETE /bookmarks/{bookmarkId}`, `confirmation_level=manual`
- [x] `get_spec_chunk("#/components/parameters/limit")` → resolved (also accepts plain `/components/...` form)
- [x] Empty query, missing spec, malformed `$ref` → clean error dicts, no exceptions
- [ ] End-to-end MCP-client run with `DCT_TOOLSET=auto` against a live DCT instance — pending. Smoke tests above used the bundled `api-external.yaml` directly via the cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
