### PR TITLE
DLPXECO-13799 Failed to add a hook in an MSSQL VDB

### DIFF
--- a/.claude/evals/DLPXECO-13799-build-evaluation.md
+++ b/.claude/evals/DLPXECO-13799-build-evaluation.md
@@ -1,0 +1,86 @@
+# DLPXECO-13799 — Build & Test Evaluation
+
+## Build
+
+This is a Python 3.11+ project built with hatchling. There is no separate compile step; "build" means importing the package cleanly. `CLAUDE.md` documents `./start_mcp_server_uv.sh` and `./start_mcp_server_python.sh` as the run-time entry points but no build command per se.
+
+### Command(s) used
+
+```bash
+python -c "import dct_mcp_server.tools.core.tool_factory as t; print('import ok'); print('valid:', sorted(t._VALID_HOOK_TYPES)[:3]); print('snake:', t._camel_to_snake('configureClone'))"
+```
+
+### Outcome
+
+**Success.** Module imports cleanly, the new `_VALID_HOOK_TYPES` enum is populated, and the `_camel_to_snake` helper produces the expected output (`configureClone` → `configure_clone`).
+
+### Output excerpt
+
+```
+import ok
+valid: ['configure_clone', 'post_refresh', 'post_rollback']
+snake: configure_clone
+```
+
+### Action taken
+
+None — first run was clean.
+
+## Unit tests
+
+### Setup
+
+This is the first ticket to add automated unit tests to the repo. Added:
+- `pytest>=8.0` under `[project.optional-dependencies].dev` in `pyproject.toml`.
+- `[tool.pytest.ini_options]` with `testpaths = ["tests"]` and `pythonpath = ["src"]`.
+- `tests/__init__.py` (empty package marker).
+- `tests/test_tool_factory_hooks.py` (12 tests).
+
+### Command
+
+```bash
+python -m pip install pytest -q
+python -m pytest tests/ -v
+```
+
+### Result
+
+```
+============================= test session starts ==============================
+platform darwin -- Python 3.12.11, pytest-9.0.3, pluggy-1.6.0
+configfile: pyproject.toml
+plugins: anyio-4.11.0
+collected 12 items
+
+tests/test_tool_factory_hooks.py::test_normalize_hooks_camelcase_keys_rewritten PASSED
+tests/test_tool_factory_hooks.py::test_normalize_hooks_snake_case_passthrough PASSED
+tests/test_tool_factory_hooks.py::test_normalize_hooks_mixed_keys PASSED
+tests/test_tool_factory_hooks.py::test_normalize_hooks_unknown_key_returns_error PASSED
+tests/test_tool_factory_hooks.py::test_normalize_hooks_no_hooks_field PASSED
+tests/test_tool_factory_hooks.py::test_normalize_hooks_non_dict_value PASSED
+tests/test_tool_factory_hooks.py::test_normalize_hooks_empty_dict PASSED
+tests/test_tool_factory_hooks.py::test_normalize_hooks_none_body PASSED
+tests/test_tool_factory_hooks.py::test_all_known_camelcase_variants_normalize PASSED
+tests/test_tool_factory_hooks.py::test_camel_to_snake_helper PASSED
+tests/test_tool_factory_hooks.py::test_valid_hook_types_matches_spec PASSED
+tests/test_tool_factory_hooks.py::test_normalize_hooks_duplicate_after_rewrite_returns_error PASSED
+
+============================== 12 passed in 0.32s ==============================
+```
+
+**12 / 12 passed in 0.32s.**
+
+### Coverage notes
+
+The 12 tests cover every branch of `_normalize_hooks_in_body`:
+
+- camelCase → snake_case rewrite (single key, mixed keys, every known variant)
+- snake_case passthrough (unchanged)
+- non-dict / `None` / empty / missing `hooks` field (all no-ops)
+- unknown key (error returned, no HTTP call would proceed)
+- duplicate-after-normalization collision (error returned)
+- helper sanity (`_camel_to_snake`, `_VALID_HOOK_TYPES`)
+
+### Integration coverage
+
+End-to-end coverage relies on the existing prompt suite in `.claude/rules/testing/continuous_data_admin.md` (items around `update_vdb` and `update_*_dsource`). Integration testing is run via an MCP client per the project's existing convention; called out in the PR description for the reviewer.

--- a/.claude/evals/DLPXECO-13799-design.md
+++ b/.claude/evals/DLPXECO-13799-design.md
@@ -1,0 +1,51 @@
+# DLPXECO-13799 — Design
+
+## High-level approach
+
+Add a small normalization step in `tool_factory.py:_create_grouped_tool_function`'s `grouped_tool` closure, immediately before the request is dispatched to `DCTAPIClient.make_request`. If the assembled `json_body` contains a top-level `hooks` key whose value is a `dict`, walk its keys and:
+
+1. If a key is already a valid snake_case hook type — leave it alone.
+2. If a key matches a known camelCase form (`configureClone`, `preRefresh`, etc.) — rewrite it to snake_case in place.
+3. If a key is neither — return an error response listing the valid hook types, so the caller sees an explicit failure instead of a silently-discarded hook.
+
+The valid hook types are a fixed enum (taken from the OpenAPI `VirtualizationHooks` schema): `pre_refresh, post_refresh, pre_self_refresh, post_self_refresh, pre_rollback, post_rollback, configure_clone, pre_snapshot, post_snapshot, pre_start, post_start, pre_stop, post_stop`.
+
+The normalizer lives as a module-private helper in `tool_factory.py` (no new file) and runs once per request, so cost is negligible.
+
+## Design decisions
+
+**Where to normalize — dynamic factory only.**
+The pre-built `vdb_tool` and `dsource_tool` modules in `dataset_endpoints_tool.py` do not implement `update_vdb` / `update_*_dsource` (only the dynamic factory does), so a single fix in `tool_factory.py` covers every affected action today. Putting the normalizer in the HTTP client (`dct_client/client.py`) was considered and rejected: the client is intentionally generic and shouldn't know about VDB/dsource semantics. Putting it in a request-body interceptor at the FastMCP layer was rejected for the same reason.
+
+**Normalize, don't reject, for known camelCase.**
+The ticket's failure mode is silent dropping. Auto-correcting `configureClone` → `configure_clone` (and friends) is safe because the mapping is unambiguous and it directly resolves the user-visible bug. Strict rejection of camelCase would also fix the bug but pushes the same correction burden onto every caller and every prompt template — worse UX for no functional gain.
+
+**Reject unknown keys.**
+If a key is neither valid snake_case nor a known camelCase variant, we return `{"error": ..., "valid_hook_types": [...]}`. This is the only way to make a typo (`configre_clone`) loud rather than silent.
+
+**Static enum, not OpenAPI lookup.**
+We could read `VirtualizationHooks` from the cached OpenAPI spec at request time. Rejected: it adds spec-resolution code paths to the hot path for a list that changes maybe once a year. The enum is a constant in `tool_factory.py` with a comment pointing at the spec section so future spec changes are easy to mirror.
+
+## Architectural changes
+
+None. One new private function and one ~10-line block inserted into the existing `grouped_tool` closure. No public API change, no config change, no new module. The pre-built tools in `tools/*_endpoints_tool.py` are untouched.
+
+## Test plan
+
+**Unit tests** (new file `tests/tools/test_tool_factory_hooks.py` — the repo has no existing test infra; see *Build & test* note below):
+
+1. `test_normalize_hooks_camelcase_keys_rewritten` — body `{"hooks": {"configureClone": [...]}}` → keys become `{"configure_clone": [...]}`; value list is preserved verbatim.
+2. `test_normalize_hooks_snake_case_passthrough` — body `{"hooks": {"configure_clone": [...]}}` → unchanged.
+3. `test_normalize_hooks_mixed_keys` — body containing both `configureClone` and `pre_refresh` — both end up snake_case, no duplication.
+4. `test_normalize_hooks_unknown_key_returns_error` — body `{"hooks": {"bogusHook": [...]}}` → returns an error dict mentioning the invalid key and the valid hook list; no HTTP call is made.
+5. `test_normalize_hooks_no_hooks_field` — body without `hooks` → unchanged, no error.
+6. `test_normalize_hooks_non_dict_value` — body with `hooks: None` or `hooks: []` → unchanged (defensive: not our schema, don't blow up).
+7. `test_all_known_camelcase_variants` — every camelCase form in the mapping table normalizes to its snake_case counterpart.
+
+Edge cases covered: empty hooks dict, hooks key present but value is `None`, repeated calls (idempotent), unknown key when other keys are valid (still rejects).
+
+**Integration coverage** — out of scope for this fix; it is exercised by the existing `continuous_data_admin` test prompt suite (`.claude/rules/testing/continuous_data_admin.md` items around `update_vdb` and `update_*_dsource`). PR description will note this for the reviewer.
+
+## Build & test note
+
+The project's `CLAUDE.md` states: *"No automated test suite exists. Testing is done by connecting an MCP client to the running server."* This ticket is the first to add unit tests under this repo. The Phase-5 test plan therefore also covers (a) adding `pytest` as a dev dependency and (b) creating `tests/` with a single `__init__.py` so future bug fixes can build on the same harness. We will confirm this approach with the user at the design-approval gate before scaffolding test infra.

--- a/.claude/evals/DLPXECO-13799-scope.md
+++ b/.claude/evals/DLPXECO-13799-scope.md
@@ -1,0 +1,40 @@
+# DLPXECO-13799 — Scope
+
+## Ticket summary
+
+- **Title:** Failed to add a hook in an MSSQL VDB
+- **Reporter / Assignee:** Shreyas Kulkarni
+- **Status:** In Progress
+- **URL:** https://perforce.atlassian.net/browse/DLPXECO-13799
+
+When a user calls `vdb_tool(action="update_vdb", ...)` (or the analogous dsource update actions) and supplies a `hooks` payload with camelCase keys (e.g. `configureClone`), the request is forwarded as-is to the Delphix Engine. The engine silently accepts the unknown key and discards the hook. The user sees a 200 OK but the hook is never installed. The expected snake_case key (`configure_clone`) works correctly.
+
+The ticket asks that this be fixed in the MCP server: normalize / validate hook keys before they hit the engine, so callers cannot silently drop hooks by passing the wrong casing.
+
+## What I found
+
+- `update_vdb` and `update_*_dsource` actions are **dynamically generated** by `src/dct_mcp_server/tools/core/tool_factory.py:_create_grouped_tool_function` (`grouped_tool` closure, lines ~351–415). The pre-built `vdb_tool` in `src/dct_mcp_server/tools/dataset_endpoints_tool.py` does not implement `update_vdb` — it falls through to the dynamic factory.
+- In `grouped_tool`, after path-param extraction and `filter_expression`/`body` handling, all remaining kwargs are merged into `json_body` (line 401-405). For PATCH/POST/PUT this body is passed verbatim to `DCTAPIClient.make_request`. There is no per-field normalization.
+- The OpenAPI spec (`api-external.yaml`) defines `VirtualizationHooks` with snake_case keys only:
+  `pre_refresh, post_refresh, pre_self_refresh, post_self_refresh, pre_rollback, post_rollback, configure_clone, pre_snapshot, post_snapshot, pre_start, post_start, pre_stop, post_stop`.
+- The dynamic tool's docstring exposes the hook field generically as `hooks: ...` (see `dataset_endpoints_tool.py:167` and `:1176` for the equivalent pre-built tool docstrings), so the LLM caller has no schema-level signal about the required casing.
+- Toolset config (`config/toolsets/continuous_data_admin.txt:13, 111, 122, 129`) maps the affected operations:
+  - `PATCH /vdbs/{vdbId}` → `update_vdb`
+  - `PATCH /dsources/oracle/{dsourceId}` → `update_oracle_dsource`
+  - `PATCH /dsources/appdata/{dsourceId}` → `update_appdata_dsource`
+  - `PATCH /dsources/mssql/{dsourceId}` → `update_mssql_dsource`
+
+## Root-cause hypothesis
+
+**High confidence.** The MCP server passes the JSON body through unchanged. The Delphix Engine API accepts unknown JSON properties silently (no strict-schema rejection) for PATCH endpoints, so `configureClone` is treated as an irrelevant field and the hook is dropped. The MCP server is the right place to enforce the spec since it is the schema-aware boundary.
+
+## What I need to proceed
+
+None — the ticket is self-contained and the fix surface is localized. Proceeding to design.
+
+## Implicit assumptions
+
+- The fix should apply to **any** request where the JSON body contains a top-level `hooks` object — not just `update_vdb`. dSource hook updates use the same field name and the same enum of hook types.
+- camelCase → snake_case mapping is a deterministic, lossless transform for the known hook keys; we will normalize in place rather than reject, so existing (correct) snake_case payloads remain unchanged.
+- An unknown hook key (neither valid snake_case nor a known camelCase variant) should be surfaced as an error rather than silently passed through — that preserves the bug-fix intent.
+- The companion DLPX-side bug (engine should reject unknown fields) is out of scope here; only the MCP-server-side normalization is being addressed.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,9 +15,18 @@ dependencies = [
 [project.scripts]
 dct-mcp-server = "dct_mcp_server.main:main"
 
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0",
+]
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/dct_mcp_server"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["src"]

--- a/src/dct_mcp_server/tools/core/tool_factory.py
+++ b/src/dct_mcp_server/tools/core/tool_factory.py
@@ -37,6 +37,63 @@ logger = logging.getLogger(__name__)
 _openapi_spec: Optional[Dict[str, Any]] = None
 _dct_client = None  # DCT API client reference
 
+# Valid VDB/dSource hook types from VirtualizationHooks schema in api-external.yaml.
+# The Delphix Engine silently ignores unknown keys, so we normalize camelCase
+# variants (which the LLM/user often produces) to the spec's snake_case form
+# and reject anything we can't map. See DLPXECO-13799.
+_VALID_HOOK_TYPES = frozenset({
+    "pre_refresh", "post_refresh",
+    "pre_self_refresh", "post_self_refresh",
+    "pre_rollback", "post_rollback",
+    "configure_clone",
+    "pre_snapshot", "post_snapshot",
+    "pre_start", "post_start",
+    "pre_stop", "post_stop",
+})
+
+
+def _camel_to_snake(name: str) -> str:
+    return re.sub(r"(?<!^)(?=[A-Z])", "_", name).lower()
+
+
+def _normalize_hooks_in_body(json_body: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+    """Rewrite camelCase hook keys (e.g. configureClone) to snake_case in place.
+
+    Returns an error dict if a hook key is neither a known snake_case nor a
+    recognizable camelCase variant — surfaces typos/unknown hooks loudly
+    instead of letting the engine drop them silently.
+    """
+    if not isinstance(json_body, dict):
+        return None
+    hooks = json_body.get("hooks")
+    if not isinstance(hooks, dict) or not hooks:
+        return None
+
+    rewritten: Dict[str, Any] = {}
+    for key, value in hooks.items():
+        if key in _VALID_HOOK_TYPES:
+            target = key
+        elif _camel_to_snake(key) in _VALID_HOOK_TYPES:
+            target = _camel_to_snake(key)
+        else:
+            return {
+                "error": (
+                    f"Unknown hook type '{key}' in 'hooks'. Valid hook types are: "
+                    f"{sorted(_VALID_HOOK_TYPES)}."
+                ),
+                "valid_hook_types": sorted(_VALID_HOOK_TYPES),
+            }
+        if target in rewritten:
+            return {
+                "error": (
+                    f"Duplicate hook type after normalization: '{key}' -> "
+                    f"'{target}' collides with another key in 'hooks'."
+                ),
+            }
+        rewritten[target] = value
+    json_body["hooks"] = rewritten
+    return None
+
 
 # =============================================================================
 # OPENAPI SPEC CACHING
@@ -406,7 +463,11 @@ Returns:
             query_params = {}
         else:
             query_params = remaining
-        
+
+        hook_err = _normalize_hooks_in_body(json_body)
+        if hook_err:
+            return hook_err
+
         return await _dct_client.make_request(
             method,
             final_path,

--- a/tests/test_tool_factory_hooks.py
+++ b/tests/test_tool_factory_hooks.py
@@ -1,0 +1,120 @@
+"""Unit tests for hook-key normalization in tool_factory (DLPXECO-13799)."""
+
+import pytest
+
+from dct_mcp_server.tools.core.tool_factory import (
+    _VALID_HOOK_TYPES,
+    _camel_to_snake,
+    _normalize_hooks_in_body,
+)
+
+
+def test_normalize_hooks_camelcase_keys_rewritten():
+    body = {"hooks": {"configureClone": [{"command": "echo hi"}]}}
+    err = _normalize_hooks_in_body(body)
+    assert err is None
+    assert body["hooks"] == {"configure_clone": [{"command": "echo hi"}]}
+
+
+def test_normalize_hooks_snake_case_passthrough():
+    body = {"hooks": {"configure_clone": [{"command": "echo hi"}]}}
+    original = {"configure_clone": [{"command": "echo hi"}]}
+    err = _normalize_hooks_in_body(body)
+    assert err is None
+    assert body["hooks"] == original
+
+
+def test_normalize_hooks_mixed_keys():
+    body = {
+        "hooks": {
+            "configureClone": [{"name": "a"}],
+            "pre_refresh": [{"name": "b"}],
+            "postSnapshot": [{"name": "c"}],
+        }
+    }
+    err = _normalize_hooks_in_body(body)
+    assert err is None
+    assert set(body["hooks"].keys()) == {"configure_clone", "pre_refresh", "post_snapshot"}
+    assert body["hooks"]["configure_clone"] == [{"name": "a"}]
+    assert body["hooks"]["pre_refresh"] == [{"name": "b"}]
+    assert body["hooks"]["post_snapshot"] == [{"name": "c"}]
+
+
+def test_normalize_hooks_unknown_key_returns_error():
+    body = {"hooks": {"bogusHook": [{"name": "x"}]}}
+    err = _normalize_hooks_in_body(body)
+    assert err is not None
+    assert "bogusHook" in err["error"]
+    assert "valid_hook_types" in err
+    # Body is left as-is on error (no partial mutation guarantee needed; just no crash).
+
+
+def test_normalize_hooks_no_hooks_field():
+    body = {"name": "test", "description": "no hooks here"}
+    err = _normalize_hooks_in_body(body)
+    assert err is None
+    assert body == {"name": "test", "description": "no hooks here"}
+
+
+def test_normalize_hooks_non_dict_value():
+    for value in (None, [], "configure_clone"):
+        body = {"hooks": value}
+        err = _normalize_hooks_in_body(body)
+        assert err is None
+        assert body["hooks"] == value
+
+
+def test_normalize_hooks_empty_dict():
+    body = {"hooks": {}}
+    err = _normalize_hooks_in_body(body)
+    assert err is None
+    assert body["hooks"] == {}
+
+
+def test_normalize_hooks_none_body():
+    assert _normalize_hooks_in_body(None) is None
+    assert _normalize_hooks_in_body({}) is None
+
+
+def test_all_known_camelcase_variants_normalize():
+    camel_to_snake = {
+        "preRefresh": "pre_refresh",
+        "postRefresh": "post_refresh",
+        "preSelfRefresh": "pre_self_refresh",
+        "postSelfRefresh": "post_self_refresh",
+        "preRollback": "pre_rollback",
+        "postRollback": "post_rollback",
+        "configureClone": "configure_clone",
+        "preSnapshot": "pre_snapshot",
+        "postSnapshot": "post_snapshot",
+        "preStart": "pre_start",
+        "postStart": "post_start",
+        "preStop": "pre_stop",
+        "postStop": "post_stop",
+    }
+    for camel, snake in camel_to_snake.items():
+        body = {"hooks": {camel: [{"name": camel}]}}
+        err = _normalize_hooks_in_body(body)
+        assert err is None, f"unexpected error for {camel}"
+        assert list(body["hooks"].keys()) == [snake]
+
+
+def test_camel_to_snake_helper():
+    assert _camel_to_snake("configureClone") == "configure_clone"
+    assert _camel_to_snake("preSelfRefresh") == "pre_self_refresh"
+    assert _camel_to_snake("already_snake") == "already_snake"
+    assert _camel_to_snake("simple") == "simple"
+
+
+def test_valid_hook_types_matches_spec():
+    # Sanity: every entry in our enum is snake_case.
+    for h in _VALID_HOOK_TYPES:
+        assert h.islower()
+        assert " " not in h
+
+
+def test_normalize_hooks_duplicate_after_rewrite_returns_error():
+    body = {"hooks": {"configureClone": [1], "configure_clone": [2]}}
+    err = _normalize_hooks_in_body(body)
+    assert err is not None
+    assert "configure_clone" in err["error"]


### PR DESCRIPTION
## Problem

When updating a VDB or dSource via the dynamically generated `update_vdb` / `update_*_dsource` actions, supplying a `hooks` payload with camelCase keys (e.g. `configureClone`) silently drops the hook. The Delphix Engine accepts unknown JSON fields without error and never installs the hook. The user sees a 200 OK but the hook is missing.

The OpenAPI `VirtualizationHooks` schema is exclusively snake_case (`configure_clone`, `pre_refresh`, ...) but neither the spec-driven docstring nor the engine itself surfaces a casing error, so the failure mode is invisible to the caller.

## Solution

In `tool_factory._create_grouped_tool_function.grouped_tool`, normalize the top-level `hooks` dict in the outgoing JSON body just before dispatch:

- keys already in the snake_case enum are left alone
- known camelCase variants are rewritten to snake_case in place
- anything else returns a structured error listing the valid hook types instead of silently passing through to the engine

Valid hook types are captured as a `frozenset` constant sourced from the OpenAPI `VirtualizationHooks` schema:

```
pre_refresh, post_refresh, pre_self_refresh, post_self_refresh,
pre_rollback, post_rollback, configure_clone,
pre_snapshot, post_snapshot, pre_start, post_start, pre_stop, post_stop
```

The fix lives in the dynamic factory only; the pre-built `vdb_tool` / `dsource_tool` modules don't implement the affected actions, so a single insertion covers every affected toolset entry today.

## Testing

This is the first ticket to add automated unit tests in this repo. Added `pytest>=8.0` as a dev extra in `pyproject.toml` and created `tests/` with `tests/test_tool_factory_hooks.py`.

```
$ python -m pytest tests/ -v
==================== 12 passed in 0.32s ====================
```

Coverage:

- camelCase rewrite (single key, mixed keys, every known variant)
- snake_case passthrough (unchanged)
- missing / empty / non-dict / `None` `hooks` values (all no-op)
- unknown key rejection (no HTTP call made)
- duplicate-after-normalization collision (rejected)
- helper sanity (`_camel_to_snake`, `_VALID_HOOK_TYPES`)

End-to-end coverage relies on the existing prompt suite in `.claude/rules/testing/continuous_data_admin.md` (items around `update_vdb` and `update_*_dsource`). Verified locally that import + helpers behave as expected; the live MCP-client run is recommended as part of review.

**MCP client tested:** N/A for unit-test verification — pytest-only for this PR.
**Toolset:** `continuous_data_admin` (where `update_vdb` / `update_*_dsource` are exposed).
**DCT version:** unit tests only; engine version not exercised.

## Jira

https://perforce.atlassian.net/browse/DLPXECO-13799

Co-authored by Claude