### PR TITLE
DLPXECO-14016 S2 Readiness [HG1]: Implement .github/workflows/ci.yml with pytest + coverage threshold gate

### DIFF
--- a/.claude/test/generated-test/test_DLPXECO-13984.py
+++ b/.claude/test/generated-test/test_DLPXECO-13984.py
@@ -14,11 +14,8 @@ from __future__ import annotations
 
 import asyncio
 import json
-import os
-import tempfile
-import types
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, patch, mock_open
+from unittest.mock import AsyncMock, MagicMock, patch
 from typing import Any
 
 import pytest
@@ -89,6 +86,7 @@ MINIMAL_SPEC: dict[str, Any] = {
 # S1-S6 — spec_cache.py tests
 # ===========================================================================
 
+
 class TestSpecCacheDownloadSuccess:
     """S1 — Spec download succeeds on first startup."""
 
@@ -114,8 +112,16 @@ class TestSpecCacheDownloadSuccess:
             "spec_cache_path": str(cache_file),
         }
 
-        with patch("dct_mcp_server.tools.core.spec_cache.get_dct_config", return_value=mock_config), \
-             patch("dct_mcp_server.tools.core.spec_cache.requests.get", return_value=mock_response):
+        with (
+            patch(
+                "dct_mcp_server.tools.core.spec_cache.get_dct_config",
+                return_value=mock_config,
+            ),
+            patch(
+                "dct_mcp_server.tools.core.spec_cache.requests.get",
+                return_value=mock_response,
+            ),
+        ):
             result = spec_cache.load_and_cache_spec()
 
         assert result is not None
@@ -143,6 +149,7 @@ class TestSpecCacheFreshCacheReused:
 
         # Write a fresh spec to cache with a current timestamp
         from datetime import datetime, timezone
+
         cache_file.parent.mkdir(parents=True, exist_ok=True)
         cache_file.write_text(yaml.dump(MINIMAL_SPEC))
         meta = {
@@ -161,8 +168,13 @@ class TestSpecCacheFreshCacheReused:
             "spec_cache_path": str(cache_file),
         }
 
-        with patch("dct_mcp_server.tools.core.spec_cache.get_dct_config", return_value=mock_config), \
-             patch("dct_mcp_server.tools.core.spec_cache.requests.get") as mock_get:
+        with (
+            patch(
+                "dct_mcp_server.tools.core.spec_cache.get_dct_config",
+                return_value=mock_config,
+            ),
+            patch("dct_mcp_server.tools.core.spec_cache.requests.get") as mock_get,
+        ):
             result = spec_cache.load_and_cache_spec()
             mock_get.assert_not_called()
 
@@ -189,8 +201,16 @@ class TestSpecCacheFailsOnNetworkError:
             "spec_cache_path": str(tmp_path / "api-external-dynamic.yaml"),
         }
 
-        with patch("dct_mcp_server.tools.core.spec_cache.get_dct_config", return_value=mock_config), \
-             patch("dct_mcp_server.tools.core.spec_cache.requests.get", side_effect=ConnectionError("timeout")):
+        with (
+            patch(
+                "dct_mcp_server.tools.core.spec_cache.get_dct_config",
+                return_value=mock_config,
+            ),
+            patch(
+                "dct_mcp_server.tools.core.spec_cache.requests.get",
+                side_effect=ConnectionError("timeout"),
+            ),
+        ):
             with pytest.raises(MCPError, match="SPEC_LOAD_FAILED"):
                 spec_cache.load_and_cache_spec()
 
@@ -220,8 +240,16 @@ class TestSpecCacheFailsOnInvalidYAML:
             "spec_cache_path": str(tmp_path / "api-external-dynamic.yaml"),
         }
 
-        with patch("dct_mcp_server.tools.core.spec_cache.get_dct_config", return_value=mock_config), \
-             patch("dct_mcp_server.tools.core.spec_cache.requests.get", return_value=mock_response):
+        with (
+            patch(
+                "dct_mcp_server.tools.core.spec_cache.get_dct_config",
+                return_value=mock_config,
+            ),
+            patch(
+                "dct_mcp_server.tools.core.spec_cache.requests.get",
+                return_value=mock_response,
+            ),
+        ):
             with pytest.raises(MCPError, match="SPEC_LOAD_FAILED"):
                 spec_cache.load_and_cache_spec()
 
@@ -246,8 +274,16 @@ class TestSpecCacheSpecLoadFailed:
             "spec_cache_path": str(tmp_path / "api-external-dynamic.yaml"),
         }
 
-        with patch("dct_mcp_server.tools.core.spec_cache.get_dct_config", return_value=mock_config), \
-             patch("dct_mcp_server.tools.core.spec_cache.requests.get", side_effect=ConnectionError("unreachable")):
+        with (
+            patch(
+                "dct_mcp_server.tools.core.spec_cache.get_dct_config",
+                return_value=mock_config,
+            ),
+            patch(
+                "dct_mcp_server.tools.core.spec_cache.requests.get",
+                side_effect=ConnectionError("unreachable"),
+            ),
+        ):
             with pytest.raises(MCPError, match="SPEC_LOAD_FAILED"):
                 spec_cache.load_and_cache_spec()
 
@@ -266,6 +302,7 @@ class TestSpecCacheCorruptedCacheRedownload:
 
         # Write corrupted cache AND a fresh meta (so cache age check passes)
         from datetime import datetime, timezone
+
         cache_file.write_text("<<< corrupted yaml")
         meta = {
             "downloaded_at": datetime.now(timezone.utc).isoformat(),
@@ -287,8 +324,16 @@ class TestSpecCacheCorruptedCacheRedownload:
             "spec_cache_path": str(cache_file),
         }
 
-        with patch("dct_mcp_server.tools.core.spec_cache.get_dct_config", return_value=mock_config), \
-             patch("dct_mcp_server.tools.core.spec_cache.requests.get", return_value=mock_response):
+        with (
+            patch(
+                "dct_mcp_server.tools.core.spec_cache.get_dct_config",
+                return_value=mock_config,
+            ),
+            patch(
+                "dct_mcp_server.tools.core.spec_cache.requests.get",
+                return_value=mock_response,
+            ),
+        ):
             result = spec_cache.load_and_cache_spec()
 
         # Should have succeeded via re-download
@@ -301,10 +346,12 @@ class TestSpecCacheCorruptedCacheRedownload:
 # S7-S13 — discovery tool tests (FR-002)
 # ===========================================================================
 
+
 def _make_discovery_fn(spec: dict[str, Any]):
     """Create a discovery function backed by the given spec (via spec_cache)."""
     from dct_mcp_server.tools.core.dynamic import _make_discovery_fn as _make
     from dct_mcp_server.tools.core import spec_cache
+
     spec_cache._cached_spec = spec
     mock_app = MagicMock()
     return _make(mock_app)
@@ -445,9 +492,7 @@ class TestDiscoveryCircularRef:
                 "schemas": {
                     "Node": {
                         "type": "object",
-                        "properties": {
-                            "child": {"$ref": "#/components/schemas/Node"}
-                        },
+                        "properties": {"child": {"$ref": "#/components/schemas/Node"}},
                     }
                 }
             },
@@ -486,14 +531,18 @@ class TestDiscoveryCircularRef:
         )
 
         # Should complete without recursion error; schema_truncated may be set
-        assert "status" not in result or result.get("status") != "error" or \
-               result.get("code") != "INFINITE_RECURSION"
+        assert (
+            "status" not in result
+            or result.get("status") != "error"
+            or result.get("code") != "INFINITE_RECURSION"
+        )
         # The response should not cause a RecursionError (test would blow up above)
 
 
 # ===========================================================================
 # S14-S23 — execute tool tests (FR-003)
 # ===========================================================================
+
 
 def _make_execute_fn(spec: dict[str, Any], dct_client=None):
     """Create an execute function with the given spec (via spec_cache) and dct_client.
@@ -503,6 +552,7 @@ def _make_execute_fn(spec: dict[str, Any], dct_client=None):
     """
     from dct_mcp_server.tools.core.dynamic import _make_execute_fn as _make
     from dct_mcp_server.tools.core import spec_cache
+
     spec_cache._cached_spec = spec
     mock_app = MagicMock()
     if dct_client is None:
@@ -634,7 +684,11 @@ class TestExecuteMissingRequiredField:
         fn = _make_execute_fn(spec_with_required, mock_client)
 
         with patch("dct_mcp_server.tools.core.dynamic.check_confirmation") as mock_cc:
-            mock_cc.return_value = {"requires_confirmation": False, "confirmation_level": None, "message_template": None}
+            mock_cc.return_value = {
+                "requires_confirmation": False,
+                "confirmation_level": None,
+                "message_template": None,
+            }
             result = fn(
                 path="/vdbs/provision",
                 method="POST",
@@ -701,11 +755,17 @@ class TestExecuteGetSuccess:
     def test_s21_get_returns_read_type(self):
         """S21: GET /vdbs/vdb-123 → status=success, operation_type=read."""
         mock_client = MagicMock()
-        mock_client.make_request = AsyncMock(return_value={"id": "vdb-123", "status": "running"})
+        mock_client.make_request = AsyncMock(
+            return_value={"id": "vdb-123", "status": "running"}
+        )
         fn = _make_execute_fn(MINIMAL_SPEC, mock_client)
 
         with patch("dct_mcp_server.tools.core.dynamic.check_confirmation") as mock_cc:
-            mock_cc.return_value = {"requires_confirmation": False, "confirmation_level": None, "message_template": None}
+            mock_cc.return_value = {
+                "requires_confirmation": False,
+                "confirmation_level": None,
+                "message_template": None,
+            }
             result = fn(
                 path="/vdbs/{vdbId}",
                 method="GET",
@@ -724,11 +784,17 @@ class TestExecuteDCTAPIError:
         from dct_mcp_server.core.exceptions import DCTClientError
 
         mock_client = MagicMock()
-        mock_client.make_request = AsyncMock(side_effect=DCTClientError("HTTP 404: Not Found"))
+        mock_client.make_request = AsyncMock(
+            side_effect=DCTClientError("HTTP 404: Not Found")
+        )
         fn = _make_execute_fn(MINIMAL_SPEC, mock_client)
 
         with patch("dct_mcp_server.tools.core.dynamic.check_confirmation") as mock_cc:
-            mock_cc.return_value = {"requires_confirmation": False, "confirmation_level": None, "message_template": None}
+            mock_cc.return_value = {
+                "requires_confirmation": False,
+                "confirmation_level": None,
+                "message_template": None,
+            }
             result = fn(
                 path="/vdbs/search",
                 method="POST",
@@ -753,7 +819,11 @@ class TestExecuteNonJSONResponse:
         fn = _make_execute_fn(MINIMAL_SPEC, mock_client)
 
         with patch("dct_mcp_server.tools.core.dynamic.check_confirmation") as mock_cc:
-            mock_cc.return_value = {"requires_confirmation": False, "confirmation_level": None, "message_template": None}
+            mock_cc.return_value = {
+                "requires_confirmation": False,
+                "confirmation_level": None,
+                "message_template": None,
+            }
             result = fn(
                 path="/vdbs/search",
                 method="POST",
@@ -761,12 +831,15 @@ class TestExecuteNonJSONResponse:
 
         assert result["status"] == "error"
         assert result["code"] == "DCT_API_ERROR"
-        assert "Non-JSON" in result.get("message", "") or "DCT" in result.get("message", "")
+        assert "Non-JSON" in result.get("message", "") or "DCT" in result.get(
+            "message", ""
+        )
 
 
 # ===========================================================================
 # S24-S28 — confirmation_resolver.py tests (FR-004)
 # ===========================================================================
+
 
 class TestConfirmationResolver:
     """S24-S28 — check_confirmation() tests."""
@@ -775,7 +848,9 @@ class TestConfirmationResolver:
         """S24: POST /vdbs/vdb-123/delete → requires_confirmation=True, level=manual."""
         from dct_mcp_server.tools.core.confirmation_resolver import check_confirmation
 
-        with patch("dct_mcp_server.tools.core.confirmation_resolver.get_confirmation_for_operation") as mock_gc:
+        with patch(
+            "dct_mcp_server.tools.core.confirmation_resolver.get_confirmation_for_operation"
+        ) as mock_gc:
             mock_gc.return_value = {
                 "level": "manual",
                 "message": "Delete VDB permanently?",
@@ -791,7 +866,9 @@ class TestConfirmationResolver:
         """S25: GET /vdbs/search → requires_confirmation=False."""
         from dct_mcp_server.tools.core.confirmation_resolver import check_confirmation
 
-        with patch("dct_mcp_server.tools.core.confirmation_resolver.get_confirmation_for_operation") as mock_gc:
+        with patch(
+            "dct_mcp_server.tools.core.confirmation_resolver.get_confirmation_for_operation"
+        ) as mock_gc:
             mock_gc.return_value = {
                 "level": "none",
                 "message": None,
@@ -807,7 +884,9 @@ class TestConfirmationResolver:
         """S26: retention_check:7 triggers when retention_days=3."""
         from dct_mcp_server.tools.core.confirmation_resolver import check_confirmation
 
-        with patch("dct_mcp_server.tools.core.confirmation_resolver.get_confirmation_for_operation") as mock_gc:
+        with patch(
+            "dct_mcp_server.tools.core.confirmation_resolver.get_confirmation_for_operation"
+        ) as mock_gc:
             mock_gc.return_value = {
                 "level": "retention_check",
                 "message": "Retention is too low",
@@ -815,7 +894,9 @@ class TestConfirmationResolver:
                 "threshold_days": 7,
             }
             # retention_days=3 < threshold 7 → should trigger
-            result = check_confirmation("DELETE", "/snapshots/snap-1", context={"retention_days": 3})
+            result = check_confirmation(
+                "DELETE", "/snapshots/snap-1", context={"retention_days": 3}
+            )
 
         assert result["requires_confirmation"] is True
 
@@ -823,14 +904,18 @@ class TestConfirmationResolver:
         """S26: retention_check:7 does NOT trigger when retention_days=30."""
         from dct_mcp_server.tools.core.confirmation_resolver import check_confirmation
 
-        with patch("dct_mcp_server.tools.core.confirmation_resolver.get_confirmation_for_operation") as mock_gc:
+        with patch(
+            "dct_mcp_server.tools.core.confirmation_resolver.get_confirmation_for_operation"
+        ) as mock_gc:
             mock_gc.return_value = {
                 "level": "retention_check",
                 "message": "Retention is too low",
                 "conditional": True,
                 "threshold_days": 7,
             }
-            result = check_confirmation("DELETE", "/snapshots/snap-1", context={"retention_days": 30})
+            result = check_confirmation(
+                "DELETE", "/snapshots/snap-1", context={"retention_days": 30}
+            )
 
         assert result["requires_confirmation"] is False
 
@@ -838,14 +923,20 @@ class TestConfirmationResolver:
         """S27: policy_impact_check:N triggers when affected_object_count > N."""
         from dct_mcp_server.tools.core.confirmation_resolver import check_confirmation
 
-        with patch("dct_mcp_server.tools.core.confirmation_resolver.get_confirmation_for_operation") as mock_gc:
+        with patch(
+            "dct_mcp_server.tools.core.confirmation_resolver.get_confirmation_for_operation"
+        ) as mock_gc:
             mock_gc.return_value = {
                 "level": "policy_impact_check",
                 "message": "Policy impacts many objects",
                 "conditional": True,
                 "threshold_days": 10,  # N=10
             }
-            result = check_confirmation("POST", "/policies/policy-1/apply", context={"affected_object_count": 15})
+            result = check_confirmation(
+                "POST",
+                "/policies/policy-1/apply",
+                context={"affected_object_count": 15},
+            )
 
         assert result["requires_confirmation"] is True
 
@@ -853,14 +944,18 @@ class TestConfirmationResolver:
         """S27: policy_impact_check:N does NOT trigger when affected_object_count <= N."""
         from dct_mcp_server.tools.core.confirmation_resolver import check_confirmation
 
-        with patch("dct_mcp_server.tools.core.confirmation_resolver.get_confirmation_for_operation") as mock_gc:
+        with patch(
+            "dct_mcp_server.tools.core.confirmation_resolver.get_confirmation_for_operation"
+        ) as mock_gc:
             mock_gc.return_value = {
                 "level": "policy_impact_check",
                 "message": "Policy impacts many objects",
                 "conditional": True,
                 "threshold_days": 10,
             }
-            result = check_confirmation("POST", "/policies/policy-1/apply", context={"affected_object_count": 5})
+            result = check_confirmation(
+                "POST", "/policies/policy-1/apply", context={"affected_object_count": 5}
+            )
 
         assert result["requires_confirmation"] is False
 
@@ -868,7 +963,9 @@ class TestConfirmationResolver:
         """S28: unknown path with no matching rule → requires_confirmation=False without error."""
         from dct_mcp_server.tools.core.confirmation_resolver import check_confirmation
 
-        with patch("dct_mcp_server.tools.core.confirmation_resolver.get_confirmation_for_operation") as mock_gc:
+        with patch(
+            "dct_mcp_server.tools.core.confirmation_resolver.get_confirmation_for_operation"
+        ) as mock_gc:
             mock_gc.return_value = {
                 "level": "none",
                 "message": None,
@@ -886,23 +983,33 @@ class TestConfirmationResolver:
 # S32 — Decision-gate report existence check
 # ===========================================================================
 
+
 class TestDecisionGateReportExists:
     """S32 — Decision-gate report file exists."""
 
     def test_s32_decision_gate_doc_exists(self):
         """S32: DLPXECO-13984-decision-gate.md exists and is non-empty."""
-        gate_path = Path(__file__).parent.parent.parent.parent / "docs" / "DLPXECO-13984" / "DLPXECO-13984-decision-gate.md"
+        gate_path = (
+            Path(__file__).parent.parent.parent.parent
+            / "docs"
+            / "DLPXECO-13984"
+            / "DLPXECO-13984-decision-gate.md"
+        )
         assert gate_path.exists(), f"Decision-gate report not found at {gate_path}"
         content = gate_path.read_text()
         assert len(content.strip()) > 0, "Decision-gate report is empty"
         # Check required sections
         assert "Executive Summary" in content or "Summary" in content
-        assert any(word in content for word in ("Recommendation", "ADOPT", "INVESTIGATE", "REVERT"))
+        assert any(
+            word in content
+            for word in ("Recommendation", "ADOPT", "INVESTIGATE", "REVERT")
+        )
 
 
 # ===========================================================================
 # S33 — Backward compatibility: existing test suite still passes
 # ===========================================================================
+
 
 class TestBackwardCompatibility:
     """S33 — Existing persona-based toolsets must not be broken."""
@@ -913,29 +1020,37 @@ class TestBackwardCompatibility:
             _normalize_hooks_in_body,
             _VALID_HOOK_TYPES,
         )
+
         assert callable(_normalize_hooks_in_body)
         assert len(_VALID_HOOK_TYPES) > 0
 
     def test_s33_dynamic_module_importable(self):
         """S33: dynamic.py importable; register_dynamic_tools is callable."""
         from dct_mcp_server.tools.core.dynamic import register_dynamic_tools
+
         assert callable(register_dynamic_tools)
 
     def test_s33_spec_cache_module_importable(self):
         """S33: spec_cache.py importable; load_and_cache_spec, get_cached_spec callable."""
-        from dct_mcp_server.tools.core.spec_cache import load_and_cache_spec, get_cached_spec
+        from dct_mcp_server.tools.core.spec_cache import (
+            load_and_cache_spec,
+            get_cached_spec,
+        )
+
         assert callable(load_and_cache_spec)
         assert callable(get_cached_spec)
 
     def test_s33_confirmation_resolver_importable(self):
         """S33: confirmation_resolver.py importable; check_confirmation callable."""
         from dct_mcp_server.tools.core.confirmation_resolver import check_confirmation
+
         assert callable(check_confirmation)
 
 
 # ===========================================================================
 # S34 — Telemetry decoration check
 # ===========================================================================
+
 
 class TestTelemetryDecoration:
     """S34 — discovery and execute must be decorated with @log_tool_execution."""

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,98 @@
+# CI gate for DLPXECO-14016 (S2 Maturity HG1 — "coverage enforced in CI").
+#
+# Public-repo-safe by design:
+#   - Uses only GitHub-authored actions (checkout, setup-python), so the org's
+#     "allowed actions" policy needs no allowlisting.
+#   - Needs NO secrets: tests are unit-level (no live DCT, no DCT_API_KEY).
+#   - GitHub-hosted runners are free/unlimited for public repos.
+#
+# Jobs: lint (advisory for now), test (+ coverage floor), build.
+name: ci
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+permissions:
+  contents: read          # least privilege; bump only if a step needs more
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: lint (ruff, advisory)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install ruff
+        run: python -m pip install --upgrade pip ruff
+      # Advisory until the existing 138 findings are cleaned up: annotate the
+      # PR but do not fail the gate. Flip to a hard `ruff check .` in a later
+      # PR once the backlog is burned down.
+      - name: Ruff (non-blocking)
+        run: ruff check . --output-format=github --exit-zero
+
+  test:
+    name: test + coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install package and test deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+          pip install pytest pytest-cov pytest-asyncio
+      # Coverage floor starts at the measured baseline (~5%) and is ratcheted
+      # toward 80% over subsequent sprints (see DLPXECO-14016 + follow-ups).
+      # A PR that drops coverage below the floor fails this job.
+      - name: Pytest with coverage gate
+        run: |
+          pytest \
+            --cov=src/dct_mcp_server \
+            --cov-report=term-missing \
+            --cov-report=xml \
+            --cov-fail-under=4
+      - name: Coverage summary
+        if: always()
+        run: |
+          echo "### Coverage" >> "$GITHUB_STEP_SUMMARY"
+          if [ -f coverage.xml ]; then
+            line_rate=$(grep -m1 -o 'line-rate="[0-9.]*"' coverage.xml | head -1 | grep -o '[0-9.]*')
+            pct=$(python -c "print(f'{float('${line_rate:-0}')*100:.2f}%')")
+            echo "Total line coverage: **$pct** (floor: 4%, target: 80%)" >> "$GITHUB_STEP_SUMMARY"
+          fi
+      - name: Upload coverage artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-xml
+          path: coverage.xml
+          if-no-files-found: ignore
+
+  build:
+    name: build (sdist + wheel)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Build the package
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build
+      - name: Upload dist artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,13 +64,17 @@ jobs:
             --cov-fail-under=4
       - name: Coverage summary
         if: always()
+        continue-on-error: true          # cosmetic — never fails the gate
         run: |
-          echo "### Coverage" >> "$GITHUB_STEP_SUMMARY"
-          if [ -f coverage.xml ]; then
-            line_rate=$(grep -m1 -o 'line-rate="[0-9.]*"' coverage.xml | head -1 | grep -o '[0-9.]*')
-            pct=$(python -c "print(f'{float('${line_rate:-0}')*100:.2f}%')")
-            echo "Total line coverage: **$pct** (floor: 4%, target: 80%)" >> "$GITHUB_STEP_SUMMARY"
-          fi
+          python - <<'PY' >> "$GITHUB_STEP_SUMMARY"
+          import xml.etree.ElementTree as ET
+          print("### Coverage")
+          try:
+              rate = float(ET.parse("coverage.xml").getroot().get("line-rate", 0))
+              print(f"Total line coverage: **{rate * 100:.2f}%** (floor: 4%, target: 80%)")
+          except Exception as exc:
+              print(f"(coverage.xml unavailable: {exc})")
+          PY
       - name: Upload coverage artifact
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@
 #   - Needs NO secrets: tests are unit-level (no live DCT, no DCT_API_KEY).
 #   - GitHub-hosted runners are free/unlimited for public repos.
 #
-# Jobs: lint (advisory for now), test (+ coverage floor), build.
+# Jobs: lint (ruff check + format, blocking), test (+ coverage floor), build.
 name: ci
 
 on:
@@ -24,7 +24,7 @@ concurrency:
 
 jobs:
   lint:
-    name: lint (ruff check + format, advisory)
+    name: lint (ruff check + format)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -32,19 +32,17 @@ jobs:
         with:
           python-version: "3.11"
       - name: Install ruff
-        run: python -m pip install --upgrade pip ruff
+        # Pinned to match .pre-commit-config.yaml so local and CI format/lint
+        # results are identical (avoids version-skew false failures).
+        run: python -m pip install --upgrade pip "ruff==0.15.17"
       # ruff replaces flake8 (lint) AND black (format) with one tool, run here
       # and in .pre-commit-config.yaml so local and CI checks are identical.
-      # Both steps are advisory until the existing findings are cleaned up:
-      # they annotate the PR but never fail the gate. Flip to hard
-      # `ruff check .` / `ruff format --check .` in a later PR once the backlog
-      # is burned down. The same flip should update .pre-commit-config.yaml.
-      - name: Ruff lint (flake8-equivalent, non-blocking)
-        run: ruff check . --output-format=github --exit-zero
-      - name: Ruff format check (black-equivalent, non-blocking)
-        run: |
-          ruff format --check . \
-            || echo "::warning::ruff format would reformat files — run 'ruff format .' locally before committing"
+      # Both steps are BLOCKING: a lint error or an unformatted file fails the
+      # gate. Rule config (per-file ignores, line length) lives in pyproject.toml.
+      - name: Ruff lint (flake8-equivalent)
+        run: ruff check . --output-format=github
+      - name: Ruff format check (black-equivalent)
+        run: ruff format --check .
 
   test:
     name: test + coverage (Python ${{ matrix.python-version }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ concurrency:
 
 jobs:
   lint:
-    name: lint (ruff, advisory)
+    name: lint (ruff check + format, advisory)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -33,11 +33,18 @@ jobs:
           python-version: "3.11"
       - name: Install ruff
         run: python -m pip install --upgrade pip ruff
-      # Advisory until the existing 138 findings are cleaned up: annotate the
-      # PR but do not fail the gate. Flip to a hard `ruff check .` in a later
-      # PR once the backlog is burned down.
-      - name: Ruff (non-blocking)
+      # ruff replaces flake8 (lint) AND black (format) with one tool, run here
+      # and in .pre-commit-config.yaml so local and CI checks are identical.
+      # Both steps are advisory until the existing findings are cleaned up:
+      # they annotate the PR but never fail the gate. Flip to hard
+      # `ruff check .` / `ruff format --check .` in a later PR once the backlog
+      # is burned down. The same flip should update .pre-commit-config.yaml.
+      - name: Ruff lint (flake8-equivalent, non-blocking)
         run: ruff check . --output-format=github --exit-zero
+      - name: Ruff format check (black-equivalent, non-blocking)
+        run: |
+          ruff format --check . \
+            || echo "::warning::ruff format would reformat files — run 'ruff format .' locally before committing"
 
   test:
     name: test + coverage (Python ${{ matrix.python-version }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,13 +40,16 @@ jobs:
         run: ruff check . --output-format=github --exit-zero
 
   test:
-    name: test + coverage
+    name: test + coverage (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: ${{ matrix.python-version }}
       - name: Install package and test deps
         run: |
           python -m pip install --upgrade pip
@@ -55,6 +58,7 @@ jobs:
       # Coverage floor starts at the measured baseline (~5%) and is ratcheted
       # toward 80% over subsequent sprints (see DLPXECO-14016 + follow-ups).
       # A PR that drops coverage below the floor fails this job.
+      # To raise the floor: update --cov-fail-under here AND in CONTRIBUTING.md.
       - name: Pytest with coverage gate
         run: |
           pytest \
@@ -79,7 +83,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-xml
+          name: coverage-xml-${{ matrix.python-version }}
           path: coverage.xml
           if-no-files-found: ignore
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,9 +7,8 @@
 # Install once:   pip install pre-commit && pre-commit install
 # Run manually:   pre-commit run --all-files
 #
-# Note: the existing codebase predates these checks, so the first local run will
-# report/auto-fix a large number of findings. CI keeps them advisory for now
-# (see ci.yml); this config lets you fix incrementally before pushing.
+# These checks are BLOCKING in CI (ci.yml), so run them before pushing.
+# Rule config (per-file ignores, line length) lives in pyproject.toml [tool.ruff].
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.17

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,21 @@
+# Pre-commit hooks for dxi-mcp-server.
+#
+# ruff replaces flake8 (lint) and black (format) with one fast tool — the same
+# checks run here locally AND in .github/workflows/ci.yml, so a green local run
+# means a green CI lint job.
+#
+# Install once:   pip install pre-commit && pre-commit install
+# Run manually:   pre-commit run --all-files
+#
+# Note: the existing codebase predates these checks, so the first local run will
+# report/auto-fix a large number of findings. CI keeps them advisory for now
+# (see ci.yml); this config lets you fix incrementally before pushing.
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.17
+    hooks:
+      # Linter (flake8-equivalent). --fix auto-applies safe fixes locally.
+      - id: ruff
+        args: [--fix]
+      # Formatter (black-equivalent).
+      - id: ruff-format

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,46 @@
+# Contributing to dxi-mcp-server
+
+Thank you for your interest in contributing. Please read the sections below before opening a pull request.
+
+## Getting Started
+
+1. Fork the repository and create a branch from `main` using the naming convention `dlpx/pr/<username>/<description>`.
+2. Make your change. Keep commits focused — separate config/toolset changes from source code changes where possible.
+3. Open a pull request against `main`. Include what changed, why, and how it was tested (MCP client used, toolset, DCT version).
+
+For the full contributor agreement and code of conduct, see [`.github/CONTRIBUTING.md`](.github/CONTRIBUTING.md).
+
+## Test Coverage
+
+### Current threshold
+
+The `test` job in `.github/workflows/ci.yml` enforces a minimum line-coverage floor via:
+
+```
+pytest --cov=src/dct_mcp_server --cov-fail-under=4
+```
+
+Current floor: **4%**. Target: **80%**.
+
+A pull request that drops measured coverage below the floor will fail the `test` CI job and cannot be merged until coverage is restored.
+
+### Ratchet schedule
+
+The floor is raised incrementally each sprint as new tests are added. The planned milestones are:
+
+| Sprint | Floor | Tracking ticket |
+|--------|-------|-----------------|
+| S2 (baseline) | 4% | DLPXECO-14016 |
+| S3 | ~15% | TBD |
+| S4 | ~30% | TBD |
+| S5 | ~50% | TBD |
+| S6+ | ~80% | TBD |
+
+### How to raise the floor (ratchet ticket authors)
+
+When a ratchet ticket lands, update **both** of the following files in the same commit:
+
+1. **`.github/workflows/ci.yml`** — change `--cov-fail-under=<old>` to `--cov-fail-under=<new>`.
+2. **`CONTRIBUTING.md`** (this file) — update the "Current floor" value above and add a row to the ratchet schedule table.
+
+Keeping both files in sync ensures contributors always see the correct threshold in documentation and that CI enforces it. A PR that raises only one of the two files will be rejected during review.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 ![Support](https://img.shields.io/badge/Support-Community-yellow.svg)
 ![Python](https://img.shields.io/badge/Python-3.11+-blue.svg)
 ![License](https://img.shields.io/badge/License-MIT-green.svg)
+[![Coverage](https://img.shields.io/badge/coverage-5%25-yellow.svg)](https://github.com/delphix/dxi-mcp-server/actions/workflows/ci.yml)
 
 # Delphix DCT MCP Server
 

--- a/evals/bench_find_endpoint.py
+++ b/evals/bench_find_endpoint.py
@@ -67,7 +67,9 @@ def _load_cached_spec() -> dict:
     Start the server once with DCT_TOOLSET=dynamic to download and cache the
     DCT OpenAPI spec, then re-run this benchmark.
     """
-    spec_path = Path(tempfile.gettempdir()) / "dct_mcp_tools" / "api-external-dynamic.yaml"
+    spec_path = (
+        Path(tempfile.gettempdir()) / "dct_mcp_tools" / "api-external-dynamic.yaml"
+    )
     if not spec_path.exists():
         raise SystemExit(
             f"Spec not found at {spec_path}. Start the server once in dynamic mode "
@@ -157,11 +159,18 @@ def main() -> int:
 
     # ---- correctness ---------------------------------------------------- #
     rank_mismatch = sum(
-        _strip_rank(rank_old(spec, q)) != _strip_rank(rank_new(spec, q)) for q in QUERIES
+        _strip_rank(rank_old(spec, q)) != _strip_rank(rank_new(spec, q))
+        for q in QUERIES
     )
-    full_mismatch = sum(full_old(spec, q, toolsets) != full_new(spec, q) for q in QUERIES)
-    print(f"Correctness — ranking:   {len(QUERIES) - rank_mismatch}/{len(QUERIES)} identical")
-    print(f"Correctness — end-to-end: {len(QUERIES) - full_mismatch}/{len(QUERIES)} identical\n")
+    full_mismatch = sum(
+        full_old(spec, q, toolsets) != full_new(spec, q) for q in QUERIES
+    )
+    print(
+        f"Correctness — ranking:   {len(QUERIES) - rank_mismatch}/{len(QUERIES)} identical"
+    )
+    print(
+        f"Correctness — end-to-end: {len(QUERIES) - full_mismatch}/{len(QUERIES)} identical\n"
+    )
 
     calls = iters * len(QUERIES)
 
@@ -177,11 +186,17 @@ def main() -> int:
     f_old = _time(lambda q: full_old(spec, q, toolsets), iters)
     f_new = _time(lambda q: full_new(spec, q), iters)
 
-    print(f"Iterations: {iters}  |  Queries/iter: {len(QUERIES)}  |  Total calls: {calls}\n")
+    print(
+        f"Iterations: {iters}  |  Queries/iter: {len(QUERIES)}  |  Total calls: {calls}\n"
+    )
     print(f"{'Layer':<14}{'OLD ms/call':>14}{'NEW ms/call':>14}{'Speedup':>12}")
     print("-" * 54)
-    print(f"{'ranking':<14}{r_old / calls * 1000:>14.3f}{r_new / calls * 1000:>14.3f}{r_old / r_new:>11.1f}x")
-    print(f"{'end-to-end':<14}{f_old / calls * 1000:>14.3f}{f_new / calls * 1000:>14.3f}{f_old / f_new:>11.1f}x")
+    print(
+        f"{'ranking':<14}{r_old / calls * 1000:>14.3f}{r_new / calls * 1000:>14.3f}{r_old / r_new:>11.1f}x"
+    )
+    print(
+        f"{'end-to-end':<14}{f_old / calls * 1000:>14.3f}{f_new / calls * 1000:>14.3f}{f_old / f_new:>11.1f}x"
+    )
 
     return 1 if (rank_mismatch or full_mismatch) else 0
 

--- a/evals/bench_prefilter_delta.py
+++ b/evals/bench_prefilter_delta.py
@@ -47,7 +47,6 @@ from dct_mcp_server.tools.core.endpoint_discovery import (  # noqa: E402
     _tokenize,
     get_discovery_index,
     rank_candidates,
-    score_candidate,
 )
 
 # Representative intents spanning multiple domains (read, mutate, destructive).
@@ -109,7 +108,9 @@ def main() -> int:
     ap.add_argument("--limit", type=int, default=10)
     args = ap.parse_args()
 
-    spec_path = Path(tempfile.gettempdir()) / "dct_mcp_tools" / "api-external-dynamic.yaml"
+    spec_path = (
+        Path(tempfile.gettempdir()) / "dct_mcp_tools" / "api-external-dynamic.yaml"
+    )
     if not spec_path.exists():
         raise SystemExit(
             f"Spec not found at {spec_path}. Start the server once in dynamic mode "
@@ -120,8 +121,10 @@ def main() -> int:
     index = get_discovery_index(spec)
     corpus, hot = index["corpus"], index["hot_keywords"]
     inv = _build_inverted_index(corpus)
-    print(f"Spec: {len(spec.get('paths', {}))} paths  |  {len(corpus)} operations  |  "
-          f"{len(inv)} index tokens")
+    print(
+        f"Spec: {len(spec.get('paths', {}))} paths  |  {len(corpus)} operations  |  "
+        f"{len(inv)} index tokens"
+    )
     print(f"min_score={args.min_score}  limit={args.limit}  queries={len(QUERIES)}\n")
 
     # ---- behavioural delta --------------------------------------------- #
@@ -143,17 +146,22 @@ def main() -> int:
         else:
             # Endpoints present in FULL top-N but missing from PREFILTER top-N.
             pre_set = set(pre_keys)
-            lost = [(c["method"], c["path"], c["score"]) for c in full
-                    if (c["method"], c["path"]) not in pre_set]
+            lost = [
+                (c["method"], c["path"], c["score"])
+                for c in full
+                if (c["method"], c["path"]) not in pre_set
+            ]
             dropped_rows += len(lost)
             diffs.append((q, lost))
 
     print("=== Behavioural delta (FULL vs PREFILTER) ===")
     print(f"Queries with identical top-{args.limit}: {identical}/{len(QUERIES)}")
     print(f"Total result rows dropped by prefilter:  {dropped_rows}")
-    print(f"Avg candidates scored / query: FULL={total_scored_full // len(QUERIES)}  "
-          f"PREFILTER={total_scored_pre // len(QUERIES)}  "
-          f"(SequenceMatcher calls reduced ~{total_scored_full / max(total_scored_pre, 1):.0f}x)\n")
+    print(
+        f"Avg candidates scored / query: FULL={total_scored_full // len(QUERIES)}  "
+        f"PREFILTER={total_scored_pre // len(QUERIES)}  "
+        f"(SequenceMatcher calls reduced ~{total_scored_full / max(total_scored_pre, 1):.0f}x)\n"
+    )
 
     if diffs:
         print("Queries whose results would change:")

--- a/evals/integration_test_dynamic.py
+++ b/evals/integration_test_dynamic.py
@@ -22,6 +22,7 @@ Usage:
 
 FR-001..FR-004, epic §5.1 (DLPXECO-13984)
 """
+
 from __future__ import annotations
 
 import asyncio
@@ -44,7 +45,9 @@ _results: list[dict] = []
 
 
 def _rec(sid: str, fr: str, name: str, status: str, detail: str) -> None:
-    _results.append({"id": sid, "fr": fr, "name": name, "status": status, "detail": detail})
+    _results.append(
+        {"id": sid, "fr": fr, "name": name, "status": status, "detail": detail}
+    )
     print(f"[{status:4}] {sid} ({fr}) {name} — {detail}")
 
 
@@ -74,10 +77,21 @@ async def main() -> int:
     try:
         spec = spec_cache.load_and_cache_spec()
         n = len(spec.get("paths", {}))
-        _rec("S1", "FR-001", "Spec download + cache from live DCT",
-             "PASS" if n > 0 else "FAIL", f"{n} paths cached")
+        _rec(
+            "S1",
+            "FR-001",
+            "Spec download + cache from live DCT",
+            "PASS" if n > 0 else "FAIL",
+            f"{n} paths cached",
+        )
     except Exception as exc:
-        _rec("S1", "FR-001", "Spec download + cache from live DCT", "FAIL", f"{type(exc).__name__}: {exc}")
+        _rec(
+            "S1",
+            "FR-001",
+            "Spec download + cache from live DCT",
+            "FAIL",
+            f"{type(exc).__name__}: {exc}",
+        )
         return 1
 
     discovery = _make_discovery_fn(app)
@@ -88,61 +102,115 @@ async def main() -> int:
         # --- S2 / FR-002: discovery list_tags -----------------------------
         r = discovery(action="list_tags")
         tags = r.get("tags", [])
-        _rec("S2", "FR-002", "discovery(list_tags)",
-             "PASS" if tags else "FAIL", f"{len(tags)} tags; sample={[t.get('name') for t in tags[:5]]}")
+        _rec(
+            "S2",
+            "FR-002",
+            "discovery(list_tags)",
+            "PASS" if tags else "FAIL",
+            f"{len(tags)} tags; sample={[t.get('name') for t in tags[:5]]}",
+        )
 
         # --- S3 / FR-002: filtered list_operations ------------------------
         r = discovery(action="list_operations", keyword="engine", method="GET")
-        _rec("S3", "FR-002", "discovery(list_operations, keyword=engine, GET)",
-             "PASS" if r.get("total_count", 0) > 0 else "FAIL",
-             f"total_count={r.get('total_count')} ; first={(r.get('operations') or [{}])[0].get('path')}")
+        _rec(
+            "S3",
+            "FR-002",
+            "discovery(list_operations, keyword=engine, GET)",
+            "PASS" if r.get("total_count", 0) > 0 else "FAIL",
+            f"total_count={r.get('total_count')} ; first={(r.get('operations') or [{}])[0].get('path')}",
+        )
 
         # --- S4 / FR-002: get_operation_schema ----------------------------
-        r = discovery(action="get_operation_schema", path="/management/engines", operation_method="GET")
+        r = discovery(
+            action="get_operation_schema",
+            path="/management/engines",
+            operation_method="GET",
+        )
         ok = isinstance(r, dict) and r.get("status") != "error"
-        _rec("S4", "FR-002", "discovery(get_operation_schema /management/engines GET)",
-             "PASS" if ok else "FAIL", _short(list(r.keys()) if isinstance(r, dict) else r, 200))
+        _rec(
+            "S4",
+            "FR-002",
+            "discovery(get_operation_schema /management/engines GET)",
+            "PASS" if ok else "FAIL",
+            _short(list(r.keys()) if isinstance(r, dict) else r, 200),
+        )
 
         # --- S5 / FR-003: execute a live GET read -------------------------
         r = await execute(method="GET", path="/management/engines")
-        engines = _first_items(r.get("response")) if r.get("status") == "success" else []
-        _rec("S5", "FR-003", "execute(GET /management/engines)",
-             "PASS" if r.get("status") == "success" else "FAIL",
-             f"status={r.get('status')} ; operation_type={r.get('operation_type')} ; engines={len(engines)}")
+        engines = (
+            _first_items(r.get("response")) if r.get("status") == "success" else []
+        )
+        _rec(
+            "S5",
+            "FR-003",
+            "execute(GET /management/engines)",
+            "PASS" if r.get("status") == "success" else "FAIL",
+            f"status={r.get('status')} ; operation_type={r.get('operation_type')} ; engines={len(engines)}",
+        )
 
         # --- S6 / FR-004: confirmation gate (no mutation) ----------------
         # DELETE /management/engines/{engineId} has a `manual` rule. With confirmed=False
         # execute must return confirmation_required and NOT dispatch (nothing is deleted).
-        eid = (engines[0].get("id") if engines and isinstance(engines[0], dict) else "eng-0")
-        r = await execute(method="DELETE", path="/management/engines/{engineId}",
-                          path_params={"engineId": str(eid)}, confirmed=False)
+        eid = (
+            engines[0].get("id")
+            if engines and isinstance(engines[0], dict)
+            else "eng-0"
+        )
+        r = await execute(
+            method="DELETE",
+            path="/management/engines/{engineId}",
+            path_params={"engineId": str(eid)},
+            confirmed=False,
+        )
         gated = r.get("status") == "confirmation_required"
-        _rec("S6", "FR-004", "execute destructive w/o confirmed -> gated (no dispatch)",
-             "PASS" if gated else "WARN",
-             f"status={r.get('status')} ; level={r.get('confirmation_level')}")
+        _rec(
+            "S6",
+            "FR-004",
+            "execute destructive w/o confirmed -> gated (no dispatch)",
+            "PASS" if gated else "WARN",
+            f"status={r.get('status')} ; level={r.get('confirmation_level')}",
+        )
 
         # --- S7 / §5.1: poll an EXISTING job to a terminal state ----------
         rj = await execute(method="GET", path="/jobs")
         jobs = _first_items(rj.get("response")) if rj.get("status") == "success" else []
         if not jobs:
-            _rec("S7", "§5.1", "poll existing job to terminal state", "SKIP", "no jobs available on this DCT")
+            _rec(
+                "S7",
+                "§5.1",
+                "poll existing job to terminal state",
+                "SKIP",
+                "no jobs available on this DCT",
+            )
         else:
             jid = jobs[0].get("id")
             last = None
             for _ in range(5):
-                rp = await execute(method="GET", path="/jobs/{jobId}", path_params={"jobId": str(jid)})
+                rp = await execute(
+                    method="GET", path="/jobs/{jobId}", path_params={"jobId": str(jid)}
+                )
                 body = rp.get("response") if rp.get("status") == "success" else {}
                 last = (body or {}).get("status")
                 if last in TERMINAL:
                     break
                 await asyncio.sleep(2)
-            _rec("S7", "§5.1", f"poll job {jid} to terminal state",
-                 "PASS" if last in TERMINAL else "WARN", f"final job status={last}")
+            _rec(
+                "S7",
+                "§5.1",
+                f"poll job {jid} to terminal state",
+                "PASS" if last in TERMINAL else "WARN",
+                f"final job status={last}",
+            )
 
         # --- S8: error path — unknown path -> OPERATION_NOT_FOUND ---------
         r = await execute(method="GET", path="/this/does/not/exist")
-        _rec("S8", "FR-003", "execute(unknown path) -> OPERATION_NOT_FOUND",
-             "PASS" if r.get("code") == "OPERATION_NOT_FOUND" else "FAIL", f"code={r.get('code')}")
+        _rec(
+            "S8",
+            "FR-003",
+            "execute(unknown path) -> OPERATION_NOT_FOUND",
+            "PASS" if r.get("code") == "OPERATION_NOT_FOUND" else "FAIL",
+            f"code={r.get('code')}",
+        )
     finally:
         await client.close()
 
@@ -150,8 +218,10 @@ async def main() -> int:
     os.environ["DCT_TOOLSET"] = "auto"
     import importlib
     import dct_mcp_server.config.loader as loader
+
     importlib.reload(loader)
     from dct_mcp_server.tools import register_all_tools
+
     auto_app = FastMCP(name="auto-check")
 
     class _C:  # dummy client; auto registration does not call the network
@@ -160,19 +230,30 @@ async def main() -> int:
     register_all_tools(auto_app, _C())
     auto_tools = sorted(t.name for t in await auto_app.list_tools())
     leaked = {"discovery", "execute"} & set(auto_tools)
-    _rec("S9", "additivity", "auto mode unchanged; dynamic tools do not leak",
-         "PASS" if (auto_tools and not leaked) else "FAIL",
-         f"auto tools={len(auto_tools)} ; leaked={sorted(leaked)}")
+    _rec(
+        "S9",
+        "additivity",
+        "auto mode unchanged; dynamic tools do not leak",
+        "PASS" if (auto_tools and not leaked) else "FAIL",
+        f"auto tools={len(auto_tools)} ; leaked={sorted(leaked)}",
+    )
     os.environ["DCT_TOOLSET"] = "dynamic"
 
     _write_evidence(base, spec_paths=len(spec.get("paths", {})))
     failed = [r for r in _results if r["status"] == "FAIL"]
-    print(f"\n{'='*60}\n{len(_results)-len(failed)}/{len(_results)} scenarios non-FAIL ; FAIL={len(failed)}")
+    print(
+        f"\n{'=' * 60}\n{len(_results) - len(failed)}/{len(_results)} scenarios non-FAIL ; FAIL={len(failed)}"
+    )
     return 1 if failed else 0
 
 
 def _write_evidence(base_url: str, spec_paths: int) -> None:
-    out = _REPO_ROOT / "docs" / "DLPXECO-13984" / "DLPXECO-13984-integration-test-evidence.md"
+    out = (
+        _REPO_ROOT
+        / "docs"
+        / "DLPXECO-13984"
+        / "DLPXECO-13984-integration-test-evidence.md"
+    )
     now = datetime.datetime.now().strftime("%Y-%m-%d %H:%M %Z").strip()
     npass = sum(1 for r in _results if r["status"] == "PASS")
     nfail = sum(1 for r in _results if r["status"] == "FAIL")
@@ -181,7 +262,7 @@ def _write_evidence(base_url: str, spec_paths: int) -> None:
         "# DLPXECO-13984 — Integration Test Evidence (Dynamic Mode)",
         "",
         f"- **Date**: {now}",
-        f"- **Mode**: `DCT_TOOLSET=dynamic`",
+        "- **Mode**: `DCT_TOOLSET=dynamic`",
         f"- **DCT instance**: `{base_url}` (live)",
         "- **API key**: redacted",
         f"- **Spec**: downloaded from live DCT — {spec_paths} paths",
@@ -195,7 +276,9 @@ def _write_evidence(base_url: str, spec_paths: int) -> None:
     ]
     for r in _results:
         detail = r["detail"].replace("|", "\\|")
-        lines.append(f"| {r['id']} | {r['fr']} | {r['name']} | **{r['status']}** | {detail} |")
+        lines.append(
+            f"| {r['id']} | {r['fr']} | {r['name']} | **{r['status']}** | {detail} |"
+        )
     lines += [
         "",
         "## Layer B — LLM-client transcript (manual addendum)",
@@ -204,7 +287,7 @@ def _write_evidence(base_url: str, spec_paths: int) -> None:
         "end-user (LLM-driven) flow — including automatic async-job polling — connect Claude Desktop/Cursor to the "
         "server in `DCT_TOOLSET=dynamic` and run test queries, each prefixed with the standard pre-prompt:",
         "",
-        "> *\"Poll the job if it is async and let me know if it succeeds.\"*",
+        '> *"Poll the job if it is async and let me know if it succeeds."*',
         "",
         "Paste the client transcript/screenshots here.",
     ]

--- a/evals/llm_eval_harness.py
+++ b/evals/llm_eval_harness.py
@@ -72,8 +72,10 @@ SCENARIOS: list[dict[str, Any]] = [
         "type": "discovery",
         "action": "get_operation_schema",
         "params": {"path": "/vdbs/{vdbId}/delete", "operation_method": "POST"},
-        "expect": lambda r: r.get("requires_confirmation") is True
-                           and r.get("confirmation_level") == "manual",
+        "expect": lambda r: (
+            r.get("requires_confirmation") is True
+            and r.get("confirmation_level") == "manual"
+        ),
     },
     {
         "id": "S04",
@@ -82,8 +84,7 @@ SCENARIOS: list[dict[str, Any]] = [
         "type": "discovery",
         "action": "get_operation_schema",
         "params": {"path": "/vdbs/search", "operation_method": "POST"},
-        "expect": lambda r: r.get("requires_confirmation") is False
-                           and "path" in r,
+        "expect": lambda r: r.get("requires_confirmation") is False and "path" in r,
     },
     {
         "id": "S05",
@@ -149,8 +150,9 @@ SCENARIOS: list[dict[str, Any]] = [
             "path": "/nonexistent/endpoint/xyz",
             "operation_method": "GET",
         },
-        "expect": lambda r: r.get("code") == "OPERATION_NOT_FOUND"
-                           or r.get("status") == "error",
+        "expect": lambda r: (
+            r.get("code") == "OPERATION_NOT_FOUND" or r.get("status") == "error"
+        ),
     },
 ]
 
@@ -158,6 +160,7 @@ SCENARIOS: list[dict[str, Any]] = [
 # ---------------------------------------------------------------------------
 # Harness runner
 # ---------------------------------------------------------------------------
+
 
 class ScenarioResult:
     def __init__(
@@ -180,7 +183,11 @@ class ScenarioResult:
 def _load_spec() -> dict[str, Any] | None:
     """Load spec via the dynamic-mode spec cache (downloads from DCT if needed)."""
     try:
-        from dct_mcp_server.tools.core.spec_cache import get_cached_spec, load_and_cache_spec
+        from dct_mcp_server.tools.core.spec_cache import (
+            get_cached_spec,
+            load_and_cache_spec,
+        )
+
         spec = get_cached_spec()
         if spec:
             return spec
@@ -192,8 +199,10 @@ def _load_spec() -> dict[str, Any] | None:
 
 class MockApp:
     """Minimal mock app that provides app.state.openapi_spec."""
+
     class _State:
         openapi_spec: dict | None = None
+
     state = _State()
 
 
@@ -251,7 +260,7 @@ def _run_execute_dry_scenario(
     expect_no_confirmation = scenario.get("expect_no_confirmation", False)
 
     # Substitute path params
-    import re
+
     resolved_path = path
     for k, v in path_params.items():
         resolved_path = resolved_path.replace(f"{{{k}}}", str(v))
@@ -296,7 +305,7 @@ def _run_execute_dry_scenario(
 
 def run_all_scenarios(dry_run: bool = True) -> list[ScenarioResult]:
     """Run all 10 scenarios and return results."""
-    print(f"\nLoading OpenAPI spec…")
+    print("\nLoading OpenAPI spec…")
     spec = _load_spec()
     if spec is None:
         print("  ERROR: Could not load OpenAPI spec. Aborting.")
@@ -336,6 +345,7 @@ def run_all_scenarios(dry_run: bool = True) -> list[ScenarioResult]:
 # Report generation
 # ---------------------------------------------------------------------------
 
+
 def _compute_recommendation(success_rate: float) -> str:
     if success_rate >= 0.80:
         return "ADOPT"
@@ -354,36 +364,38 @@ def _write_eval_results(results: list[ScenarioResult], output_path: Path) -> Non
     recommendation = _compute_recommendation(success_rate)
 
     lines: list[str] = []
-    lines.append(f"# DLPXECO-13984 LLM Evaluation Results")
-    lines.append(f"")
-    lines.append(f"**Run date**: {datetime.datetime.now(datetime.timezone.utc).isoformat()}")
-    lines.append(f"**Harness**: evals/llm_eval_harness.py")
-    lines.append(f"**Mode**: dry-run (discovery + confirmation resolver)")
-    lines.append(f"")
-    lines.append(f"## Summary")
-    lines.append(f"")
-    lines.append(f"| Metric | Value |")
-    lines.append(f"|--------|-------|")
+    lines.append("# DLPXECO-13984 LLM Evaluation Results")
+    lines.append("")
+    lines.append(
+        f"**Run date**: {datetime.datetime.now(datetime.timezone.utc).isoformat()}"
+    )
+    lines.append("**Harness**: evals/llm_eval_harness.py")
+    lines.append("**Mode**: dry-run (discovery + confirmation resolver)")
+    lines.append("")
+    lines.append("## Summary")
+    lines.append("")
+    lines.append("| Metric | Value |")
+    lines.append("|--------|-------|")
     lines.append(f"| Total scenarios | {total_count} |")
     lines.append(f"| Passed | {success_count} |")
     lines.append(f"| Failed | {total_count - success_count} |")
     lines.append(f"| Success rate | {success_rate:.0%} |")
     lines.append(f"| Recommendation | **{recommendation}** |")
-    lines.append(f"")
-    lines.append(f"## Per-Scenario Results")
-    lines.append(f"")
-    lines.append(f"| ID | Scenario | Status | Notes |")
-    lines.append(f"|----|----------|--------|-------|")
+    lines.append("")
+    lines.append("## Per-Scenario Results")
+    lines.append("")
+    lines.append("| ID | Scenario | Status | Notes |")
+    lines.append("|----|----------|--------|-------|")
     for r in results:
         status_str = "PASS" if r.status == "success" else "FAIL"
         notes = (r.failure_reason or "").replace("|", " ").replace("\n", " ")[:80]
         lines.append(f"| {r.scenario_id} | {r.name} | {status_str} | {notes} |")
 
-    lines.append(f"")
-    lines.append(f"### Step: implement")
-    lines.append(f"")
-    lines.append(f"Eval harness run completed.")
-    lines.append(f"")
+    lines.append("")
+    lines.append("### Step: implement")
+    lines.append("")
+    lines.append("Eval harness run completed.")
+    lines.append("")
 
     output_path.write_text("\n".join(lines) + "\n")
     print(f"\nEval results written to: {output_path}")
@@ -398,7 +410,8 @@ def _write_decision_gate(results: list[ScenarioResult], output_path: Path) -> No
     success_rate = success_count / total_count if total_count else 0.0
     recommendation = _compute_recommendation(success_rate)
 
-    content = textwrap.dedent(f"""
+    content = (
+        textwrap.dedent(f"""
     # DLPXECO-13984 Phase 1 Decision Gate
 
     **Date**: {datetime.datetime.now(datetime.timezone.utc).date().isoformat()}
@@ -432,13 +445,20 @@ def _write_decision_gate(results: list[ScenarioResult], output_path: Path) -> No
 
     **{recommendation}**
 
-    {"The discovery and execute tools pass all dry-run schema validation scenarios. The confirmation resolver correctly identifies destructive operations. Proceed to Phase 2 pending live DCT integration testing." if recommendation == "ADOPT" else "Success rate below the 80% adopt threshold. Review failure scenarios and address before committing to full migration."}
+    {
+            "The discovery and execute tools pass all dry-run schema validation scenarios. The confirmation resolver correctly identifies destructive operations. Proceed to Phase 2 pending live DCT integration testing."
+            if recommendation == "ADOPT"
+            else "Success rate below the 80% adopt threshold. Review failure scenarios and address before committing to full migration."
+        }
 
     ---
 
     ## Migration Plan (if ADOPT)
 
-    {"N/A — Investigate/Revert path" if recommendation != "ADOPT" else textwrap.dedent("""
+    {
+            "N/A — Investigate/Revert path"
+            if recommendation != "ADOPT"
+            else textwrap.dedent('''
     **Timeline**: Persona-based toolsets (`self_service`, `continuous_data_admin`, etc.) remain
     fully supported until Phase 2 (PPM-1129) is complete and validated.
 
@@ -448,7 +468,8 @@ def _write_decision_gate(results: list[ScenarioResult], output_path: Path) -> No
     4. Backward-compatibility window: persona toolsets remain available for 6 months after sunset
        announcement
     5. Removal: persona toolsets removed in a major version bump
-    """).strip()}
+    ''').strip()
+        }
 
     ---
 
@@ -480,7 +501,9 @@ def _write_decision_gate(results: list[ScenarioResult], output_path: Path) -> No
     - Eval results: `docs/DLPXECO-13984/DLPXECO-13984-eval-results.md`
     - Design: `docs/DLPXECO-13984/DLPXECO-13984-design.md`
     - Functional spec: `docs/DLPXECO-13984/DLPXECO-13984-functional.md`
-    """).strip() + "\n"
+    """).strip()
+        + "\n"
+    )
 
     output_path.write_text(content)
     print(f"Decision gate report written to: {output_path}")
@@ -489,6 +512,7 @@ def _write_decision_gate(results: list[ScenarioResult], output_path: Path) -> No
 # ---------------------------------------------------------------------------
 # CLI entry point
 # ---------------------------------------------------------------------------
+
 
 def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
@@ -565,10 +589,12 @@ def main() -> int:
 
     success_count = sum(1 for r in results if r.status == "success")
     total = len(results)
-    print(f"\n{'='*60}")
+    print(f"\n{'=' * 60}")
     print(f"Results: {success_count}/{total} passed")
-    print(f"Recommendation: {_compute_recommendation(success_count / total if total else 0)}")
-    print(f"{'='*60}")
+    print(
+        f"Recommendation: {_compute_recommendation(success_count / total if total else 0)}"
+    )
+    print(f"{'=' * 60}")
 
     return 0 if success_count == total else 1
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,3 +30,14 @@ packages = ["src/dct_mcp_server"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 pythonpath = ["src"]
+
+[tool.ruff]
+# Pinned to ruff 0.15.x in ci.yml and .pre-commit-config.yaml so format/lint
+# results are identical locally and in CI.
+line-length = 88
+target-version = "py311"
+
+[tool.ruff.lint.per-file-ignores]
+# __init__.py modules are re-export hubs: the "unused" imports are intentional
+# public API surface, not dead code.
+"__init__.py" = ["F401"]

--- a/src/dct_mcp_server/config/config.py
+++ b/src/dct_mcp_server/config/config.py
@@ -21,7 +21,9 @@ def get_dct_config() -> Dict[str, Any]:
         "timeout": int(os.getenv("DCT_TIMEOUT", "30")),
         "max_retries": int(os.getenv("DCT_MAX_RETRIES", "3")),
         "log_level": os.getenv("DCT_LOG_LEVEL", "INFO").upper(),
-        "is_local_telemetry_enabled": os.getenv("IS_LOCAL_TELEMETRY_ENABLED", "false").lower()
+        "is_local_telemetry_enabled": os.getenv(
+            "IS_LOCAL_TELEMETRY_ENABLED", "false"
+        ).lower()
         == "true",
         "toolset": os.getenv("DCT_TOOLSET", "dynamic").lower().strip(),
         # Dynamic mode (DCT_TOOLSET=dynamic) spec cache settings
@@ -66,30 +68,18 @@ def print_config_help():
     print(
         "  IS_LOCAL_TELEMETRY_ENABLED Enable local telemetry data collection (default: false)"
     )
-    print(
-        "  DCT_TOOLSET      Active toolset (default: dynamic). Options:"
-    )
+    print("  DCT_TOOLSET      Active toolset (default: dynamic). Options:")
     print(
         "                   - dynamic: 2-tool mode (discovery + execute) driven by live OpenAPI spec (default)"
     )
-    print(
-        "                   - auto: Dynamic discovery mode with meta-tools"
-    )
-    print(
-        "                   - self_service: Basic VDB operations for developers/QA"
-    )
+    print("                   - auto: Dynamic discovery mode with meta-tools")
+    print("                   - self_service: Basic VDB operations for developers/QA")
     print(
         "                   - self_service_provision: Extended self-service with provisioning"
     )
-    print(
-        "                   - continuous_data_admin: Full DBA/CD admin operations"
-    )
-    print(
-        "                   - platform_admin: System administration tools"
-    )
-    print(
-        "                   - reporting_insights: Read-only reporting and analytics"
-    )
+    print("                   - continuous_data_admin: Full DBA/CD admin operations")
+    print("                   - platform_admin: System administration tools")
+    print("                   - reporting_insights: Read-only reporting and analytics")
     print()
     print("Dynamic mode (DCT_TOOLSET=dynamic) optional variables:")
     print(

--- a/src/dct_mcp_server/config/loader.py
+++ b/src/dct_mcp_server/config/loader.py
@@ -32,38 +32,39 @@ META_TOOLS = ["list_available_toolsets", "get_toolset_tools", "execute_action"]
 # TOOLSET LOADING FUNCTIONS
 # ============================================================================
 
+
 @lru_cache(maxsize=10)
 def load_toolset_apis(toolset_name: str) -> Tuple[Dict[str, str], ...]:
     """
     Load all APIs for a toolset from text file.
-    
+
     Args:
         toolset_name: Name of the toolset (e.g., "self_service")
-        
+
     Returns:
         Tuple of dicts: ({"method": "GET", "path": "/vdbs/{id}", "action": "get"}, ...)
-        
+
     Raises:
         ValueError: If toolset file doesn't exist
     """
     toolset_file = TOOLSETS_DIR / f"{toolset_name}.txt"
-    
+
     if not toolset_file.exists():
         raise ValueError(f"Unknown toolset: {toolset_name}")
-    
+
     apis = []
-    
-    with open(toolset_file, 'r') as f:
+
+    with open(toolset_file, "r") as f:
         for line in f:
             line = line.strip()
-            
+
             # Skip empty lines and comments
-            if not line or line.startswith('#'):
+            if not line or line.startswith("#"):
                 continue
-            
+
             # Handle inheritance
-            if line.startswith('@inherit:'):
-                parent_toolset = line.split(':')[1].strip()
+            if line.startswith("@inherit:"):
+                parent_toolset = line.split(":")[1].strip()
                 # Validate parent exists before loading
                 parent_file = TOOLSETS_DIR / f"{parent_toolset}.txt"
                 if not parent_file.exists():
@@ -74,16 +75,18 @@ def load_toolset_apis(toolset_name: str) -> Tuple[Dict[str, str], ...]:
                 parent_apis = load_toolset_apis(parent_toolset)
                 apis.extend(parent_apis)
                 continue
-            
+
             # Parse METHOD|/path|action format
-            parts = line.split('|')
+            parts = line.split("|")
             if len(parts) >= 3:
-                apis.append({
-                    "method": parts[0].strip(),
-                    "path": parts[1].strip(),
-                    "action": parts[2].strip()
-                })
-    
+                apis.append(
+                    {
+                        "method": parts[0].strip(),
+                        "path": parts[1].strip(),
+                        "action": parts[2].strip(),
+                    }
+                )
+
     return tuple(apis)
 
 
@@ -91,67 +94,69 @@ def load_toolset_apis(toolset_name: str) -> Tuple[Dict[str, str], ...]:
 def load_toolset_grouped_apis(toolset_name: str) -> Dict[str, Dict[str, Any]]:
     """
     Load APIs for a toolset grouped by tool name from # TOOL headers.
-    
+
     Parses toolset files that have structure like:
         # TOOL 1: vdb_tool - VDB Operations
         POST|/vdbs/search|search_vdbs
         GET|/vdbs/{vdbId}|get_vdb
         # TOOL 2: dsource_tool - dSource Operations
         POST|/dsources/search|search_dsources
-    
+
     Args:
         toolset_name: Name of the toolset (e.g., "continuous_data_admin")
-        
+
     Returns:
         Dict mapping tool_name to {description, apis: [{method, path, action}]}
-        
+
     Raises:
         ValueError: If toolset file doesn't exist
     """
     toolset_file = TOOLSETS_DIR / f"{toolset_name}.txt"
-    
+
     if not toolset_file.exists():
         raise ValueError(f"Unknown toolset: {toolset_name}")
-    
+
     grouped = {}
     current_tool = None
     current_description = ""
-    
-    with open(toolset_file, 'r') as f:
+
+    with open(toolset_file, "r") as f:
         for line in f:
             line = line.strip()
-            
+
             # Skip empty lines
             if not line:
                 continue
-            
+
             # Parse TOOL header: # TOOL N: tool_name - Description
-            if line.startswith('# TOOL') and ':' in line:
+            if line.startswith("# TOOL") and ":" in line:
                 # Extract tool name and description
                 # Format: # TOOL 1: vdb_tool - VDB Operations
-                after_colon = line.split(':', 1)[1].strip()  # "vdb_tool - VDB Operations"
-                if ' - ' in after_colon:
-                    current_tool, current_description = after_colon.split(' - ', 1)
+                after_colon = line.split(":", 1)[
+                    1
+                ].strip()  # "vdb_tool - VDB Operations"
+                if " - " in after_colon:
+                    current_tool, current_description = after_colon.split(" - ", 1)
                     current_tool = current_tool.strip()
                     current_description = current_description.strip()
                 else:
                     current_tool = after_colon.strip()
                     current_description = ""
-                
+
                 if current_tool and current_tool not in grouped:
                     grouped[current_tool] = {
                         "description": current_description,
-                        "apis": []
+                        "apis": [],
                     }
                 continue
-            
+
             # Skip other comments
-            if line.startswith('#'):
+            if line.startswith("#"):
                 continue
-            
+
             # Handle inheritance - load parent's grouped APIs
-            if line.startswith('@inherit:'):
-                parent_toolset = line.split(':')[1].strip()
+            if line.startswith("@inherit:"):
+                parent_toolset = line.split(":")[1].strip()
                 parent_file = TOOLSETS_DIR / f"{parent_toolset}.txt"
                 if not parent_file.exists():
                     raise ValueError(
@@ -161,57 +166,62 @@ def load_toolset_grouped_apis(toolset_name: str) -> Dict[str, Dict[str, Any]]:
                 parent_grouped = load_toolset_grouped_apis(parent_toolset)
                 for tool_name, tool_data in parent_grouped.items():
                     if tool_name not in grouped:
-                        grouped[tool_name] = {"description": tool_data["description"], "apis": []}
+                        grouped[tool_name] = {
+                            "description": tool_data["description"],
+                            "apis": [],
+                        }
                     grouped[tool_name]["apis"].extend(tool_data["apis"])
                 continue
-            
+
             # Parse METHOD|/path|action format
-            parts = line.split('|')
+            parts = line.split("|")
             if len(parts) >= 3 and current_tool:
                 api_entry = {
                     "method": parts[0].strip(),
                     "path": parts[1].strip(),
-                    "action": parts[2].strip()
+                    "action": parts[2].strip(),
                 }
                 grouped[current_tool]["apis"].append(api_entry)
-    
+
     return grouped
 
 
 def load_toolset_metadata(toolset_name: str) -> Optional[Dict[str, Any]]:
     """
     Load toolset metadata by parsing headers from the toolset file.
-    
+
     Each toolset file has headers like:
         # Self Service Toolset - 6 Tools
         # Description: Perform classic Self Service activities
         # Target users: Developers, QA engineers who need to work with VDBs
-        
+
     Args:
         toolset_name: Name of the toolset
-        
+
     Returns:
         Dict with name, description, tool_count, primary_use_case or None if not found
     """
     toolset_file = TOOLSETS_DIR / f"{toolset_name}.txt"
-    
+
     if not toolset_file.exists():
         return None
-    
+
     metadata = {"name": toolset_name}
     tool_count = 0
-    
-    with open(toolset_file, 'r') as f:
+
+    with open(toolset_file, "r") as f:
         for line in f:
             line = line.strip()
-            
-            if line.startswith('# Description:'):
-                metadata["description"] = line.replace('# Description:', '').strip()
-            elif line.startswith('# Target users:'):
-                metadata["primary_use_case"] = line.replace('# Target users:', '').strip()
-            elif line.startswith('# TOOL') and ':' in line:
+
+            if line.startswith("# Description:"):
+                metadata["description"] = line.replace("# Description:", "").strip()
+            elif line.startswith("# Target users:"):
+                metadata["primary_use_case"] = line.replace(
+                    "# Target users:", ""
+                ).strip()
+            elif line.startswith("# TOOL") and ":" in line:
                 tool_count += 1
-    
+
     metadata["tool_count"] = tool_count
     return metadata
 
@@ -219,18 +229,18 @@ def load_toolset_metadata(toolset_name: str) -> Optional[Dict[str, Any]]:
 def load_all_toolsets_metadata() -> Dict[str, Dict[str, Any]]:
     """
     Load metadata for all available toolsets by scanning the toolsets directory.
-    
+
     Returns:
         Dict mapping toolset names to their metadata
     """
     toolsets = {}
-    
+
     for toolset_file in TOOLSETS_DIR.glob("*.txt"):
         toolset_name = toolset_file.stem  # e.g., "self_service"
         metadata = load_toolset_metadata(toolset_name)
         if metadata:
             toolsets[toolset_name] = metadata
-    
+
     return toolsets
 
 
@@ -238,56 +248,59 @@ def load_all_toolsets_metadata() -> Dict[str, Dict[str, Any]]:
 # MANUAL CONFIRMATION FUNCTIONS
 # ============================================================================
 
+
 @lru_cache(maxsize=1)
 def load_manual_confirmation_rules() -> Tuple[Dict[str, Any], ...]:
     """
     Load manual confirmation rules.
-    
+
     Format: METHOD|path_pattern|confirmation_level|message_template
-    
+
     Returns:
         Tuple of rule dicts with method, path_pattern, level, and message
     """
     rules = []
     config_file = MAPPINGS_DIR / "manual_confirmation.txt"
-    
+
     if not config_file.exists():
         logger.warning(f"Manual confirmation file not found: {config_file}")
         return tuple(rules)
-    
-    with open(config_file, 'r') as f:
+
+    with open(config_file, "r") as f:
         for line in f:
             line = line.strip()
-            
+
             # Skip empty lines and comments
-            if not line or line.startswith('#'):
+            if not line or line.startswith("#"):
                 continue
-            
-            parts = line.split('|')
+
+            parts = line.split("|")
             if len(parts) >= 4:
-                rules.append({
-                    "method": parts[0].strip(),
-                    "path_pattern": parts[1].strip(),
-                    "level": parts[2].strip(),
-                    "message": parts[3].strip()
-                })
-    
+                rules.append(
+                    {
+                        "method": parts[0].strip(),
+                        "path_pattern": parts[1].strip(),
+                        "level": parts[2].strip(),
+                        "message": parts[3].strip(),
+                    }
+                )
+
     return tuple(rules)
 
 
 def _path_matches(path: str, pattern: str) -> bool:
     """
     Check if a path matches a pattern with path parameters.
-    
+
     Args:
         path: Actual API path (e.g., "/vdbs/vdb-123/delete")
         pattern: Pattern with placeholders (e.g., "/vdbs/{vdbId}/delete")
-        
+
     Returns:
         True if path matches pattern
     """
     # Convert path parameters to regex
-    regex_pattern = re.sub(r'\{[^}]+\}', r'[^/]+', pattern)
+    regex_pattern = re.sub(r"\{[^}]+\}", r"[^/]+", pattern)
     regex_pattern = f"^{regex_pattern}$"
     return bool(re.match(regex_pattern, path))
 
@@ -295,45 +308,50 @@ def _path_matches(path: str, pattern: str) -> bool:
 def get_confirmation_for_operation(method: str, path: str) -> Dict[str, Any]:
     """
     Get confirmation requirements for an API operation.
-    
+
     Args:
         method: HTTP method (GET, POST, DELETE, etc.)
         path: API endpoint path
-        
+
     Returns:
         Dict with level, message, conditional flag, and threshold_days
     """
     rules = load_manual_confirmation_rules()
-    
+
     for rule in rules:
         # Check method match (wildcard * matches any method)
         if rule["method"] != "*" and rule["method"] != method:
             continue
-        
+
         # Check path match
         if _path_matches(path, rule["path_pattern"]):
             level = rule["level"]
             conditional = ":" in level
-            
+
             return {
                 "level": level.split(":")[0] if conditional else level,
                 "message": rule["message"],
                 "conditional": conditional,
-                "threshold_days": int(level.split(":")[1]) if conditional else None
+                "threshold_days": int(level.split(":")[1]) if conditional else None,
             }
-    
+
     # No matching rule - no confirmation needed
-    return {"level": "none", "message": None, "conditional": False, "threshold_days": None}
+    return {
+        "level": "none",
+        "message": None,
+        "conditional": False,
+        "threshold_days": None,
+    }
 
 
 def requires_confirmation(method: str, path: str) -> bool:
     """
     Quick check if an operation requires any form of confirmation.
-    
+
     Args:
         method: HTTP method
         path: API endpoint path
-        
+
     Returns:
         True if confirmation is required
     """
@@ -345,10 +363,11 @@ def requires_confirmation(method: str, path: str) -> bool:
 # TOOLSET SELECTION FUNCTIONS
 # ============================================================================
 
+
 def get_available_toolsets() -> List[str]:
     """
     Get list of available toolsets by scanning the toolsets directory.
-    
+
     Returns:
         List of toolset names (e.g., ["self_service", "platform_admin"])
     """
@@ -358,9 +377,9 @@ def get_available_toolsets() -> List[str]:
 def get_configured_toolset() -> str:
     """
     Get the configured toolset from environment variable.
-    
+
     Environment Variable: DCT_TOOLSET
-    
+
     Returns:
         Toolset name or 'dynamic' as default
 
@@ -368,7 +387,7 @@ def get_configured_toolset() -> str:
         ValueError: If invalid toolset name specified
     """
     toolset = os.environ.get("DCT_TOOLSET", "dynamic").lower().strip()
-    
+
     if toolset in ("auto", "dynamic"):
         return toolset
 
@@ -406,21 +425,22 @@ def is_dynamic_mode() -> bool:
 # TOOLSET TOOLS EXTRACTION
 # ============================================================================
 
+
 def get_tools_for_toolset(toolset_name: str) -> List[Dict[str, Any]]:
     """
     Get list of tools available in a toolset with their actions.
-    
+
     Uses the # TOOL X: headers from the toolset file for accurate grouping.
-    
+
     Args:
         toolset_name: Name of the toolset
-        
+
     Returns:
         List of tool dicts with name, description, and actions
     """
     # Use the grouped API loader that parses # TOOL headers
     grouped_apis = load_toolset_grouped_apis(toolset_name)
-    
+
     # Build result list
     tools = []
     for tool_name, tool_data in grouped_apis.items():
@@ -428,23 +448,23 @@ def get_tools_for_toolset(toolset_name: str) -> List[Dict[str, Any]]:
         tool_info = {
             "name": tool_name,
             "description": tool_data.get("description", ""),
-            "actions": sorted(set(actions))  # Remove duplicates and sort
+            "actions": sorted(set(actions)),  # Remove duplicates and sort
         }
         tools.append(tool_info)
-    
+
     return sorted(tools, key=lambda t: t["name"])
 
 
 def get_modules_for_toolset(toolset_name: str) -> List[str]:
     """
     Get the list of tool module names required for a toolset.
-    
+
     This maps toolset logical tools to their implementation modules.
     Used by register_all_tools to filter which modules to load.
-    
+
     Args:
         toolset_name: Name of the toolset
-        
+
     Returns:
         List of module names (e.g., ["dataset_endpoints_tool", "job_endpoints_tool"])
     """
@@ -462,55 +482,43 @@ def get_modules_for_toolset(toolset_name: str) -> List[str]:
         "data_tool": "dataset_endpoints_tool",  # Merged tool
         "snapshot_bookmark_tool": "dataset_endpoints_tool",  # Merged tool
         "timeflow_tool": "dataset_endpoints_tool",
-        
         # Job operations
         "job_tool": "job_endpoints_tool",
-        
         # Environment operations
         "environment_tool": "environment_endpoints_tool",
         "environment_source_tool": "environment_endpoints_tool",  # Merged tool
-        
         # Toolkit operations (AppData plugin schemas)
         "toolkit_tool": "environment_endpoints_tool",
-
         # Engine operations
         "engine_tool": "engine_endpoints_tool",
-        
         # Compliance operations
         "masking_tool": "compliance_endpoints_tool",
         "connector_tool": "compliance_endpoints_tool",
         "execution_tool": "compliance_endpoints_tool",
-        
         # Reports operations
         "reporting_tool": "reports_endpoints_tool",
-        
         # IAM operations (if we have the module)
         "iam_tool": "iam_endpoints_tool",
         "tag_tool": "iam_endpoints_tool",
-        
         # Template operations (if we have the module)
         "database_template_tool": "template_endpoints_tool",
         "hook_template_tool": "template_endpoints_tool",
-        
         # Policy operations (if we have the module)
         "virtualization_policy_tool": "policy_endpoints_tool",
         "replication_tool": "policy_endpoints_tool",
-        
         # Platform admin merged tool
         "admin_platform_tool": "admin_endpoints_tool",
-
         # Instance tools (CDB/vCDB)
         "instance_tool": "misc_endpoints_tool",
-
         # Dynamic 2-tool mode tools (DCT_TOOLSET=dynamic)
         "discovery": "dynamic",
         "execute": "dynamic",
     }
-    
+
     # Get the tools used by this toolset
     tools = get_tools_for_toolset(toolset_name)
     tool_names = [t["name"] for t in tools]
-    
+
     # Map to modules
     modules = set()
     for tool_name in tool_names:
@@ -518,13 +526,14 @@ def get_modules_for_toolset(toolset_name: str) -> List[str]:
             modules.add(TOOL_TO_MODULE[tool_name])
         else:
             logger.warning(f"No module mapping for tool: {tool_name}")
-    
+
     return list(modules)
 
 
 # ============================================================================
 # CACHE MANAGEMENT
 # ============================================================================
+
 
 def clear_cache():
     """
@@ -542,47 +551,48 @@ def clear_cache():
 # VALIDATION FUNCTIONS
 # ============================================================================
 
+
 def validate_toolset_config(toolset_name: str) -> List[str]:
     """
     Validate a toolset configuration file.
-    
+
     Args:
         toolset_name: Name of the toolset to validate
-        
+
     Returns:
         List of validation errors (empty if valid)
     """
     errors = []
-    
+
     try:
         apis = load_toolset_apis(toolset_name)
-        
+
         if not apis:
             errors.append(f"Toolset '{toolset_name}' has no APIs defined")
-                
+
     except ValueError as e:
         errors.append(str(e))
     except Exception as e:
         errors.append(f"Error loading toolset: {e}")
-    
+
     return errors
 
 
 def validate_all_configs() -> Dict[str, List[str]]:
     """
     Validate all configuration files.
-    
+
     Returns:
         Dict mapping config names to list of errors
     """
     results = {}
-    
+
     # Validate each toolset
     for toolset_name in get_available_toolsets():
         errors = validate_toolset_config(toolset_name)
         if errors:
             results[f"toolset:{toolset_name}"] = errors
-    
+
     # Validate confirmation rules
     try:
         rules = load_manual_confirmation_rules()
@@ -590,5 +600,5 @@ def validate_all_configs() -> Dict[str, List[str]]:
             results["manual_confirmation.txt"] = ["No confirmation rules defined"]
     except Exception as e:
         results["manual_confirmation.txt"] = [str(e)]
-    
+
     return results

--- a/src/dct_mcp_server/core/__init__.py
+++ b/src/dct_mcp_server/core/__init__.py
@@ -10,6 +10,7 @@ from .session import (
     log_tool_call,
     get_current_session_id,
 )
+
 __all__ = [
     "get_logger",
     "setup_logging",

--- a/src/dct_mcp_server/core/decorators.py
+++ b/src/dct_mcp_server/core/decorators.py
@@ -16,6 +16,7 @@ def log_tool_execution(func):
     Supports both sync and async tool functions.
     """
     if inspect.iscoroutinefunction(func):
+
         @functools.wraps(func)
         async def wrapper(*args, **kwargs):
             logger = get_logger(func.__module__)
@@ -37,6 +38,7 @@ def log_tool_execution(func):
                 tool_data["error"] = str(e)
                 log_tool_call(tool_data)
                 raise
+
         return wrapper
 
     @functools.wraps(func)

--- a/src/dct_mcp_server/core/logging.py
+++ b/src/dct_mcp_server/core/logging.py
@@ -99,8 +99,12 @@ class GlobalLogger:
             )
 
         # Add console handler for global logs
-        console_formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
-        self._add_handler(root_logger, logging.StreamHandler(sys.stderr), console_formatter)
+        console_formatter = logging.Formatter(
+            "%(asctime)s - %(levelname)s - %(message)s"
+        )
+        self._add_handler(
+            root_logger, logging.StreamHandler(sys.stderr), console_formatter
+        )
 
     def _suppress_noisy_loggers(self) -> None:
         """Suppress commonly noisy third-party loggers."""
@@ -108,7 +112,10 @@ class GlobalLogger:
             logging.getLogger(logger_name).setLevel(logging.WARNING)
 
     def _add_handler(
-        self, logger: logging.Logger, handler: logging.Handler, formatter: logging.Formatter
+        self,
+        logger: logging.Logger,
+        handler: logging.Handler,
+        formatter: logging.Formatter,
     ) -> None:
         """Helper function to configure and add a handler to the logger."""
         handler.setFormatter(formatter)

--- a/src/dct_mcp_server/core/session.py
+++ b/src/dct_mcp_server/core/session.py
@@ -1,11 +1,11 @@
 """
 Session logging configuration for DCT MCP server telemetry
 """
+
 import json
 import logging
 import os
 import platform
-import sys
 import threading
 import uuid
 import getpass
@@ -161,9 +161,7 @@ class SessionManager:
         # This assumes this file is at src/dct_mcp_server/core/session.py
         # and the root is 3 levels up.
         return Path(
-            os.path.abspath(
-                os.path.join(os.path.dirname(__file__), "..", "..", "..")
-            )
+            os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
         )
 
 
@@ -219,9 +217,7 @@ def get_session_logger(
     return _session_manager.get_session_logger(session_id)
 
 
-def log_tool_call(
-    tool_data: Dict[str, Any], session_id: Optional[str] = None
-) -> None:
+def log_tool_call(tool_data: Dict[str, Any], session_id: Optional[str] = None) -> None:
     """Log tool call data to session log"""
     _session_manager.log_tool_call(tool_data, session_id)
 

--- a/src/dct_mcp_server/dct_client/client.py
+++ b/src/dct_mcp_server/dct_client/client.py
@@ -5,7 +5,6 @@ DCT API Client module
 import asyncio
 import contextlib
 import importlib.metadata
-import logging
 from typing import Any, Dict, Optional
 from urllib.parse import urljoin
 

--- a/src/dct_mcp_server/main.py
+++ b/src/dct_mcp_server/main.py
@@ -100,7 +100,9 @@ def setup_signal_handlers():
     """Set up signal handlers for graceful shutdown."""
     loop = asyncio.get_event_loop()
     for sig in (signal.SIGINT, signal.SIGTERM):
-        loop.add_signal_handler(sig, lambda s=sig: asyncio.create_task(handle_shutdown(s)))
+        loop.add_signal_handler(
+            sig, lambda s=sig: asyncio.create_task(handle_shutdown(s))
+        )
 
 
 async def _load_dynamic_spec(app: FastMCP) -> None:
@@ -115,6 +117,7 @@ async def _load_dynamic_spec(app: FastMCP) -> None:
     """
     try:
         from .tools.core.spec_cache import load_and_cache_spec
+
         logger.info("Dynamic mode: loading OpenAPI spec…")
         spec = await asyncio.to_thread(load_and_cache_spec)
         path_count = len(spec.get("paths", {}))
@@ -125,7 +128,9 @@ async def _load_dynamic_spec(app: FastMCP) -> None:
     except MCPError:
         raise
     except Exception as exc:
-        logger.error("Dynamic mode: unexpected error loading spec: %s", exc, exc_info=True)
+        logger.error(
+            "Dynamic mode: unexpected error loading spec: %s", exc, exc_info=True
+        )
         raise MCPError(f"SPEC_LOAD_FAILED: {exc}") from exc
 
 
@@ -144,16 +149,20 @@ async def async_main():
             toolset = get_configured_toolset()
             available = get_available_toolsets()
             if is_auto_mode():
-                logger.info(f"Toolset mode: AUTO (meta-tools only)")
+                logger.info("Toolset mode: AUTO (meta-tools only)")
                 logger.info(f"Available toolsets for discovery: {available}")
             elif is_dynamic_mode():
-                logger.info("Toolset mode: DYNAMIC (discovery + execute — 2-tool architecture)")
+                logger.info(
+                    "Toolset mode: DYNAMIC (discovery + execute — 2-tool architecture)"
+                )
             else:
                 logger.info(f"Toolset mode: FIXED ({toolset})")
                 # Validate configuration files
                 validation_errors = validate_all_configs()
                 if validation_errors:
-                    logger.warning(f"Configuration validation warnings: {validation_errors}")
+                    logger.warning(
+                        f"Configuration validation warnings: {validation_errors}"
+                    )
         except Exception as e:
             logger.warning(f"Could not determine toolset configuration: {e}")
 

--- a/src/dct_mcp_server/tools/__init__.py
+++ b/src/dct_mcp_server/tools/__init__.py
@@ -43,9 +43,13 @@ def register_meta_tools_only(app, dct_client=None):
         initialize_tool_inventory(app, dct_client)
         logger.info("Tool inventory initialized for runtime toolset switching")
     else:
-        logger.warning("DCT client not provided - runtime toolset switching will be limited")
+        logger.warning(
+            "DCT client not provided - runtime toolset switching will be limited"
+        )
 
-    logger.info("Auto mode: 6 meta-tools registered. Use list_available_toolsets to discover toolsets.")
+    logger.info(
+        "Auto mode: 6 meta-tools registered. Use list_available_toolsets to discover toolsets."
+    )
 
 
 def register_all_tools(app, dct_client):
@@ -59,13 +63,13 @@ def register_all_tools(app, dct_client):
     Priority for tool loading in fixed mode:
     1. Generated tools from temp directory (fresh from DCT API)
     2. Fallback to pre-built tools from package directory
-    
+
     Any module that defines a function:
         register_tools(app, dct_client)
     will be automatically imported and executed.
     """
     logger.info("Starting dynamic tool registration...")
-    
+
     # Check toolset configuration
     try:
         toolset = get_configured_toolset()
@@ -74,10 +78,12 @@ def register_all_tools(app, dct_client):
         logger.error(f"Invalid toolset configuration: {e}")
         logger.info("Falling back to 'auto' mode")
         toolset = "auto"
-    
+
     # In auto mode, register only meta-tools
     if toolset == "auto":
-        logger.info("Running in AUTO mode - registering meta-tools with runtime switching support")
+        logger.info(
+            "Running in AUTO mode - registering meta-tools with runtime switching support"
+        )
         register_meta_tools_only(app, dct_client)
         return
 
@@ -86,6 +92,7 @@ def register_all_tools(app, dct_client):
         logger.info("Running in DYNAMIC mode - registering discovery + execute tools")
         try:
             from .core.dynamic import register_dynamic_tools
+
             register_dynamic_tools(app, dct_client)
         except Exception as exc:
             logger.error("Failed to register dynamic tools: %s", exc, exc_info=True)
@@ -94,7 +101,7 @@ def register_all_tools(app, dct_client):
 
     # Fixed toolset mode - register only the tools for this toolset
     logger.info(f"Running in FIXED mode with toolset: {toolset}")
-    
+
     # Log toolset info
     try:
         metadata = load_toolset_metadata(toolset)
@@ -116,29 +123,33 @@ def register_all_tools(app, dct_client):
         package_search_paths = list(__path__)
         temp_tools_dir = None
         registered_modules = set()  # Track what we've successfully registered
-        
+
         # For package installations, check temp directory first for generated tools
-        if 'site-packages' in __file__:
+        if "site-packages" in __file__:
             temp_tools_dir = os.path.join(tempfile.gettempdir(), "dct_mcp_tools")
-            
+
         # PRIORITY 1: Try generated tools from temp directory first
         if temp_tools_dir and os.path.exists(temp_tools_dir):
             logger.debug(f"Attempting to load generated tools from: {temp_tools_dir}")
             # Add temp directory to sys.path for imports
             if temp_tools_dir not in sys.path:
                 sys.path.insert(0, temp_tools_dir)
-                
-            for module_finder, module_name, ispkg in pkgutil.iter_modules([temp_tools_dir]):
+
+            for module_finder, module_name, ispkg in pkgutil.iter_modules(
+                [temp_tools_dir]
+            ):
                 if ispkg:
                     continue
-                
+
                 # Skip meta_tools as they're for auto mode only
                 if module_name == "meta_tools":
                     continue
-                
+
                 # Filter: Only load modules required by this toolset
                 if required_modules is not None and module_name not in required_modules:
-                    logger.debug(f"Skipping '{module_name}' - not required for toolset '{toolset}'")
+                    logger.debug(
+                        f"Skipping '{module_name}' - not required for toolset '{toolset}'"
+                    )
                     continue
 
                 try:
@@ -147,35 +158,51 @@ def register_all_tools(app, dct_client):
                     register_func = getattr(module, "register_tools", None)
 
                     if callable(register_func):
-                        logger.debug(f"Successfully loading generated tools from '{module_name}'...")
+                        logger.debug(
+                            f"Successfully loading generated tools from '{module_name}'..."
+                        )
                         register_func(app, dct_client)
-                        registered_modules.add(module_name)  # Mark as successfully registered
+                        registered_modules.add(
+                            module_name
+                        )  # Mark as successfully registered
                     else:
-                        logger.debug(f"Generated module '{module_name}' has no 'register_tools' function.")
-                        
+                        logger.debug(
+                            f"Generated module '{module_name}' has no 'register_tools' function."
+                        )
+
                 except Exception as e:
-                    logger.debug(f"Failed to load generated tools from '{module_name}': {e}")
+                    logger.debug(
+                        f"Failed to load generated tools from '{module_name}': {e}"
+                    )
                     # Continue to fallback for this module
 
         # PRIORITY 2: Fallback to pre-built tools from package directory
-        logger.debug(f"Loading pre-built tools from package directory: {package_search_paths}")
+        logger.debug(
+            f"Loading pre-built tools from package directory: {package_search_paths}"
+        )
         for search_path in package_search_paths:
-            for module_finder, module_name, ispkg in pkgutil.iter_modules([search_path]):
+            for module_finder, module_name, ispkg in pkgutil.iter_modules(
+                [search_path]
+            ):
                 if ispkg:
                     continue
-                
+
                 # Skip meta_tools in fixed toolset mode
                 if module_name == "meta_tools":
                     continue
-                
+
                 # Filter: Only load modules required by this toolset
                 if required_modules is not None and module_name not in required_modules:
-                    logger.debug(f"Skipping '{module_name}' - not required for toolset '{toolset}'")
+                    logger.debug(
+                        f"Skipping '{module_name}' - not required for toolset '{toolset}'"
+                    )
                     continue
-                    
+
                 # Skip if we already successfully registered this module from temp directory
                 if module_name in registered_modules:
-                    logger.debug(f"Skipping pre-built '{module_name}' - already loaded from generated tools")
+                    logger.debug(
+                        f"Skipping pre-built '{module_name}' - already loaded from generated tools"
+                    )
                     continue
 
                 try:
@@ -189,13 +216,19 @@ def register_all_tools(app, dct_client):
                         register_func(app, dct_client)
                         registered_modules.add(module_name)
                     else:
-                        logger.debug(f"Pre-built module '{module_name}' has no 'register_tools' function.")
-                        
-                except Exception as e:
-                    logger.exception(f"Failed to load pre-built tools from '{module_name}': {e}")
+                        logger.debug(
+                            f"Pre-built module '{module_name}' has no 'register_tools' function."
+                        )
 
-        logger.info(f"Tool registration completed for toolset '{toolset}'. Registered {len(registered_modules)} tool modules.")
-                    
+                except Exception as e:
+                    logger.exception(
+                        f"Failed to load pre-built tools from '{module_name}': {e}"
+                    )
+
+        logger.info(
+            f"Tool registration completed for toolset '{toolset}'. Registered {len(registered_modules)} tool modules."
+        )
+
     except NameError:
         logger.error(
             f"Package {__name__} has no __path__; "

--- a/src/dct_mcp_server/tools/core/confirmation_resolver.py
+++ b/src/dct_mcp_server/tools/core/confirmation_resolver.py
@@ -117,6 +117,7 @@ def check_confirmation(
 # Helpers
 # --------------------------------------------------------------------------- #
 
+
 def _reconstruct_level_string(level: str, threshold: int | None, raw: dict) -> str:
     """Re-build the raw level string (e.g. 'retention_check:7') from parsed pieces."""
     if threshold is not None:
@@ -128,7 +129,7 @@ def _reconstruct_level_string(level: str, threshold: int | None, raw: dict) -> s
 def _parse_threshold(level_str: str, prefix: str) -> int:
     """Extract the integer threshold from a conditional level string."""
     try:
-        return int(level_str[len(prefix):])
+        return int(level_str[len(prefix) :])
     except (ValueError, IndexError):
         logger.warning("Could not parse threshold from '%s'", level_str)
         return 0

--- a/src/dct_mcp_server/tools/core/dynamic.py
+++ b/src/dct_mcp_server/tools/core/dynamic.py
@@ -38,6 +38,7 @@ _MAX_PAGE_SIZE = 50
 # Public registration entry point
 # =========================================================================== #
 
+
 def register_dynamic_tools(app: FastMCP, dct_client: Any) -> None:
     """
     Register the `discovery` and `execute` tools on the FastMCP app.
@@ -66,6 +67,7 @@ def register_dynamic_tools(app: FastMCP, dct_client: Any) -> None:
 # =========================================================================== #
 # Tool factory functions (return decorated callables)
 # =========================================================================== #
+
 
 def _get_spec(app: FastMCP) -> dict[str, Any] | None:
     """Return the OpenAPI spec from the spec_cache module-level cache.
@@ -240,7 +242,9 @@ def _make_execute_fn(app: FastMCP, dct_client: Any):
         # Step 2 — Look up operation in spec
         # ---------------------------------------------------------------- #
         # Try to find by the resolved path first, then by the template path
-        path_item = _find_path_item(paths_map, resolved_path) or _find_path_item(paths_map, path)
+        path_item = _find_path_item(paths_map, resolved_path) or _find_path_item(
+            paths_map, path
+        )
         if path_item is None:
             # Also try without leading /dct/v3 prefix in case caller included it
             stripped = re.sub(r"^/dct/v3", "", resolved_path)
@@ -259,7 +263,8 @@ def _make_execute_fn(app: FastMCP, dct_client: Any):
         operation = path_item.get(method_upper.lower())
         if operation is None:
             available_methods = [
-                m.upper() for m in path_item
+                m.upper()
+                for m in path_item
                 if m.lower() in {"get", "post", "put", "patch", "delete"}
             ]
             return {
@@ -275,8 +280,12 @@ def _make_execute_fn(app: FastMCP, dct_client: Any):
         # Step 3 — Validate required parameters
         # ---------------------------------------------------------------- #
         validation_error = _validate_required_params(
-            operation, path_params or {}, query_params or {}, body,
-            resolved_path=resolved_path, spec=spec,
+            operation,
+            path_params or {},
+            query_params or {},
+            body,
+            resolved_path=resolved_path,
+            spec=spec,
         )
         if validation_error:
             return validation_error
@@ -338,7 +347,12 @@ def _make_execute_fn(app: FastMCP, dct_client: Any):
                 "message": str(exc),
             }
         except Exception as exc:
-            logger.error("Unexpected error dispatching %s %s: %s", method_upper, resolved_path, exc)
+            logger.error(
+                "Unexpected error dispatching %s %s: %s",
+                method_upper,
+                resolved_path,
+                exc,
+            )
             return {
                 "status": "error",
                 "code": "DCT_API_ERROR",
@@ -352,6 +366,7 @@ def _make_execute_fn(app: FastMCP, dct_client: Any):
 # =========================================================================== #
 # Discovery action implementations
 # =========================================================================== #
+
 
 def _action_list_tags(paths_map: dict[str, Any]) -> dict[str, Any]:
     """Extract all unique tags from spec paths with operation counts."""
@@ -417,20 +432,20 @@ def _action_list_operations(
             # Confirmation flag
             conf = check_confirmation(m_upper, path)
 
-            operations.append({
-                "method": m_upper,
-                "path": path,
-                "operationId": op_id,
-                "summary": summary,
-                "tags": op_tags,
-                "requires_confirmation": conf["requires_confirmation"],
-            })
+            operations.append(
+                {
+                    "method": m_upper,
+                    "path": path,
+                    "operationId": op_id,
+                    "summary": summary,
+                    "tags": op_tags,
+                    "requires_confirmation": conf["requires_confirmation"],
+                }
+            )
 
     # Sort: GET before mutating, then alphabetically by path
     _METHOD_ORDER = {"GET": 0, "POST": 1, "PUT": 2, "PATCH": 3, "DELETE": 4}
-    operations.sort(
-        key=lambda o: (_METHOD_ORDER.get(o["method"], 9), o["path"])
-    )
+    operations.sort(key=lambda o: (_METHOD_ORDER.get(o["method"], 9), o["path"]))
 
     # Paginate
     total_count = len(operations)
@@ -474,7 +489,8 @@ def _action_get_operation_schema(
     op = path_item.get(operation_method.lower())
     if op is None:
         available = [
-            m.upper() for m in path_item
+            m.upper()
+            for m in path_item
             if m.lower() in {"get", "post", "put", "patch", "delete"}
         ]
         return {
@@ -506,7 +522,9 @@ def _action_get_operation_schema(
     request_body_fields: list[dict] = []
     request_body = op.get("requestBody", {}) or {}
     if request_body:
-        resolved_rb, truncated = _resolve_refs(request_body, spec, depth=0, visited=frozenset())
+        resolved_rb, truncated = _resolve_refs(
+            request_body, spec, depth=0, visited=frozenset()
+        )
         if truncated:
             schema_truncated = True
         request_body_fields = _flatten_request_body(resolved_rb)
@@ -514,7 +532,9 @@ def _action_get_operation_schema(
     # Resolve $ref in responses
     responses: dict = {}
     for status_code, resp_obj in (op.get("responses", {}) or {}).items():
-        resolved_resp, truncated = _resolve_refs(resp_obj, spec, depth=0, visited=frozenset())
+        resolved_resp, truncated = _resolve_refs(
+            resp_obj, spec, depth=0, visited=frozenset()
+        )
         if truncated:
             schema_truncated = True
         responses[str(status_code)] = resolved_resp
@@ -544,6 +564,7 @@ def _action_get_operation_schema(
 # Execute helper functions
 # =========================================================================== #
 
+
 def _substitute_path_params(
     path: str, path_params: dict[str, Any]
 ) -> tuple[str, list[str]]:
@@ -565,9 +586,7 @@ def _substitute_path_params(
     return resolved, missing
 
 
-def _find_path_item(
-    paths_map: dict[str, Any], path: str
-) -> dict[str, Any] | None:
+def _find_path_item(paths_map: dict[str, Any], path: str) -> dict[str, Any] | None:
     """
     Find the path item in the spec for the given resolved path.
 
@@ -701,6 +720,7 @@ def _extract_http_status(error_message: str) -> int | None:
 # $ref resolution helpers
 # =========================================================================== #
 
+
 def _resolve_refs(
     obj: Any,
     spec: dict[str, Any],
@@ -725,7 +745,11 @@ def _resolve_refs(
     if "$ref" in obj:
         ref = obj["$ref"]
         if ref in visited:
-            return {"$ref_truncated": True, "reason": "cycle_detected", "ref": ref}, True
+            return {
+                "$ref_truncated": True,
+                "reason": "cycle_detected",
+                "ref": ref,
+            }, True
         try:
             resolved_target = _lookup_ref(ref, spec)
             resolved, truncated = _resolve_refs(
@@ -750,7 +774,9 @@ def _resolve_refs(
         elif isinstance(v, list):
             resolved_list: list[Any] = []
             for item in v:
-                resolved_item, child_truncated = _resolve_refs(item, spec, depth + 1, visited)
+                resolved_item, child_truncated = _resolve_refs(
+                    item, spec, depth + 1, visited
+                )
                 if child_truncated:
                     truncated = True
                 resolved_list.append(resolved_item)
@@ -772,7 +798,9 @@ def _lookup_ref(ref: str, spec: dict[str, Any]) -> Any:
     return node
 
 
-def _flatten_request_body(resolved_request_body: dict[str, Any]) -> list[dict[str, Any]]:
+def _flatten_request_body(
+    resolved_request_body: dict[str, Any],
+) -> list[dict[str, Any]]:
     """
     Flatten a resolved requestBody into a list of field descriptors.
 
@@ -790,12 +818,14 @@ def _flatten_request_body(resolved_request_body: dict[str, Any]) -> list[dict[st
             for name, prop in properties.items():
                 if not isinstance(prop, dict):
                     continue
-                fields.append({
-                    "name": name,
-                    "required": name in required_fields,
-                    "type": prop.get("type", "object"),
-                    "description": prop.get("description", ""),
-                })
+                fields.append(
+                    {
+                        "name": name,
+                        "required": name in required_fields,
+                        "type": prop.get("type", "object"),
+                        "description": prop.get("description", ""),
+                    }
+                )
             break  # Only process first media type
     except Exception as exc:
         logger.debug("Could not flatten requestBody fields: %s", exc)

--- a/src/dct_mcp_server/tools/core/dynamic_confirmation.py
+++ b/src/dct_mcp_server/tools/core/dynamic_confirmation.py
@@ -63,10 +63,17 @@ def _none() -> Dict[str, Any]:
 
 
 def _confirm(level: str, message: str) -> Dict[str, Any]:
-    return {"level": level, "message": message, "conditional": False, "threshold_days": None}
+    return {
+        "level": level,
+        "message": message,
+        "conditional": False,
+        "threshold_days": None,
+    }
 
 
-def _lookup_operation(spec: Dict[str, Any], method: str, path: str) -> Optional[Dict[str, Any]]:
+def _lookup_operation(
+    spec: Dict[str, Any], method: str, path: str
+) -> Optional[Dict[str, Any]]:
     """Return the OpenAPI operation object for (method, path), or None."""
     if not spec:
         return None
@@ -114,6 +121,7 @@ def get_confirmation_for_operation_dynamic(
     if spec is None:
         # Lazy import avoids a circular import with tool_factory.
         from .tool_factory import get_cached_spec
+
         spec = get_cached_spec()
 
     operation = _lookup_operation(spec, method_u, path) or {}

--- a/src/dct_mcp_server/tools/core/endpoint_discovery.py
+++ b/src/dct_mcp_server/tools/core/endpoint_discovery.py
@@ -63,14 +63,16 @@ def build_corpus_from_spec(spec: dict[str, Any]) -> list[dict[str, Any]]:
                 continue
             if not isinstance(op, dict):
                 continue
-            out.append({
-                "method": method.upper(),
-                "path": path,
-                "operation_id": op.get("operationId", "") or "",
-                "summary": op.get("summary", "") or "",
-                "description": op.get("description", "") or "",
-                "tags": op.get("tags", []) or [],
-            })
+            out.append(
+                {
+                    "method": method.upper(),
+                    "path": path,
+                    "operation_id": op.get("operationId", "") or "",
+                    "summary": op.get("summary", "") or "",
+                    "description": op.get("description", "") or "",
+                    "tags": op.get("tags", []) or [],
+                }
+            )
     return out
 
 
@@ -84,7 +86,11 @@ def _candidate_tokens(candidate: dict[str, Any]) -> frozenset[str]:
         _path_tokens(candidate["path"])
         | _tokenize(candidate.get("summary", ""))
         | _tokenize(candidate.get("operation_id", ""))
-        | {t.lower() for tag in candidate.get("tags", []) for t in _TOKEN_RE.findall(tag)}
+        | {
+            t.lower()
+            for tag in candidate.get("tags", [])
+            for t in _TOKEN_RE.findall(tag)
+        }
     )
 
 
@@ -158,7 +164,8 @@ def rank_candidates(
     """Return up to `limit` scored candidates sorted by (-score, len(path))."""
     qtokens = _tokenize(query)
     methods_norm = {
-        m.upper() for m in (method_types or [])
+        m.upper()
+        for m in (method_types or [])
         if m and m.upper() in {"GET", "POST", "PUT", "PATCH", "DELETE"}
     }
 
@@ -168,7 +175,11 @@ def rank_candidates(
         if c["method"] in methods_norm:
             return True
         # POST /*/search is treated as GET-equivalent when GET is requested
-        if "GET" in methods_norm and c["method"] == "POST" and c["path"].endswith("/search"):
+        if (
+            "GET" in methods_norm
+            and c["method"] == "POST"
+            and c["path"].endswith("/search")
+        ):
             return True
         return False
 
@@ -179,7 +190,12 @@ def rank_candidates(
         try:
             s = score_candidate(qtokens, hot_keywords, cand)
         except Exception as exc:
-            logger.warning("scoring failed for %s %s: %s", cand.get("method"), cand.get("path"), exc)
+            logger.warning(
+                "scoring failed for %s %s: %s",
+                cand.get("method"),
+                cand.get("path"),
+                exc,
+            )
             continue
         if s >= min_score:
             scored.append({**cand, "score": round(s, 4)})

--- a/src/dct_mcp_server/tools/core/meta_tools.py
+++ b/src/dct_mcp_server/tools/core/meta_tools.py
@@ -24,7 +24,7 @@ Runtime Registration Pattern (GitHub MCP Server style):
 import logging
 import re
 from functools import lru_cache
-from typing import Dict, Any, List, Optional, Callable, Tuple
+from typing import Dict, Any, List, Optional, Tuple
 
 from mcp.server.fastmcp import Context
 from dct_mcp_server.config import (
@@ -32,7 +32,6 @@ from dct_mcp_server.config import (
     load_toolset_metadata,
     load_all_toolsets_metadata,
     get_tools_for_toolset,
-    get_modules_for_toolset,
     load_toolset_grouped_apis,
 )
 from dct_mcp_server.core.decorators import log_tool_execution
@@ -56,7 +55,9 @@ logger = logging.getLogger(__name__)
 _app = None  # FastMCP app instance
 _dct_client = None  # DCT API client instance
 _tool_inventory: Dict[str, Dict[str, Any]] = {}  # Pre-loaded tool modules per toolset
-_current_toolset: Optional[str] = None  # Currently active toolset (None = meta-tools only)
+_current_toolset: Optional[str] = (
+    None  # Currently active toolset (None = meta-tools only)
+)
 _registered_tool_names: List[str] = []  # Names of currently registered domain tools
 
 
@@ -94,7 +95,9 @@ def initialize_tool_inventory(app, dct_client):
             "loaded": False,
         }
 
-    logger.info(f"Tool inventory initialized with {len(_tool_inventory)} toolsets (dynamic generation)")
+    logger.info(
+        f"Tool inventory initialized with {len(_tool_inventory)} toolsets (dynamic generation)"
+    )
 
 
 @log_tool_execution
@@ -122,12 +125,16 @@ def list_available_toolsets() -> Dict[str, Any]:
 
         toolsets_list = []
         for name, metadata in sorted(toolsets_metadata.items()):
-            toolsets_list.append({
-                "name": name,
-                "description": metadata.get("description", "No description available"),
-                "tool_count": metadata.get("tool_count", 0),
-                "primary_use_case": metadata.get("primary_use_case", "General use"),
-            })
+            toolsets_list.append(
+                {
+                    "name": name,
+                    "description": metadata.get(
+                        "description", "No description available"
+                    ),
+                    "tool_count": metadata.get("tool_count", 0),
+                    "primary_use_case": metadata.get("primary_use_case", "General use"),
+                }
+            )
 
         return {
             "toolsets": toolsets_list,
@@ -250,7 +257,9 @@ async def enable_toolset(toolset_name: str, ctx: Context) -> Dict[str, Any]:
             await ctx.session.send_tool_list_changed()
             logger.info("Sent tools/list_changed notification to client")
         except Exception as notify_err:
-            logger.warning(f"Could not send tools/list_changed notification: {notify_err}")
+            logger.warning(
+                f"Could not send tools/list_changed notification: {notify_err}"
+            )
 
         metadata = load_toolset_metadata(toolset_name)
 
@@ -259,7 +268,8 @@ async def enable_toolset(toolset_name: str, ctx: Context) -> Dict[str, Any]:
             "status": "enabled",
             "description": metadata.get("description", "No description"),
             "tools_registered": tools_registered,
-            "total_available_tools": tools_registered + 8,  # domain tools + 8 meta-tools
+            "total_available_tools": tools_registered
+            + 8,  # domain tools + 8 meta-tools
             "previous_toolset": previous_toolset,
             "message": f"Toolset '{toolset_name}' is now active with {tools_registered} domain tools. No restart required.",
         }
@@ -304,7 +314,9 @@ async def disable_toolset(ctx: Context) -> Dict[str, Any]:
             await ctx.session.send_tool_list_changed()
             logger.info("Sent tools/list_changed notification to client")
         except Exception as notify_err:
-            logger.warning(f"Could not send tools/list_changed notification: {notify_err}")
+            logger.warning(
+                f"Could not send tools/list_changed notification: {notify_err}"
+            )
 
         return {
             "status": "disabled",
@@ -327,23 +339,25 @@ def _register_toolset_tools(toolset_name: str) -> int:
         return 0
 
     before_tools = set()
-    if hasattr(_app, '_tool_manager') and _app._tool_manager:
+    if hasattr(_app, "_tool_manager") and _app._tool_manager:
         before_tools = set(_app._tool_manager._tools.keys())
-    elif hasattr(_app, 'local_provider') and _app.local_provider:
+    elif hasattr(_app, "local_provider") and _app.local_provider:
         before_tools = set(_app.local_provider._tools.keys())
 
     register_toolset_tools(_app, toolset_name, _dct_client)
 
     after_tools = set()
-    if hasattr(_app, '_tool_manager') and _app._tool_manager:
+    if hasattr(_app, "_tool_manager") and _app._tool_manager:
         after_tools = set(_app._tool_manager._tools.keys())
-    elif hasattr(_app, 'local_provider') and _app.local_provider:
+    elif hasattr(_app, "local_provider") and _app.local_provider:
         after_tools = set(_app.local_provider._tools.keys())
 
     new_tools = after_tools - before_tools
     _registered_tool_names.extend(new_tools)
 
-    logger.info(f"Toolset '{toolset_name}' enabled with {len(new_tools)} dynamically generated tools")
+    logger.info(
+        f"Toolset '{toolset_name}' enabled with {len(new_tools)} dynamically generated tools"
+    )
     return len(new_tools)
 
 
@@ -358,12 +372,12 @@ def _disable_current_toolset_internal():
 
     for tool_name in _registered_tool_names:
         try:
-            if hasattr(_app, '_tool_manager') and _app._tool_manager:
+            if hasattr(_app, "_tool_manager") and _app._tool_manager:
                 if tool_name in _app._tool_manager._tools:
                     del _app._tool_manager._tools[tool_name]
                     logger.debug(f"Removed tool: {tool_name}")
-            elif hasattr(_app, 'local_provider') and _app.local_provider:
-                if hasattr(_app.local_provider, 'remove_tool'):
+            elif hasattr(_app, "local_provider") and _app.local_provider:
+                if hasattr(_app.local_provider, "remove_tool"):
                     _app.local_provider.remove_tool(tool_name)
                     logger.debug(f"Removed tool: {tool_name}")
                 elif tool_name in _app.local_provider._tools:
@@ -429,11 +443,7 @@ def _get_confirmation_guidance(level: str) -> str:
 
 @log_tool_execution
 async def execute_action(
-    toolset_name: str,
-    tool_name: str,
-    action: str,
-    confirmed: bool = False,
-    **kwargs
+    toolset_name: str, tool_name: str, action: str, confirmed: bool = False, **kwargs
 ) -> Dict[str, Any]:
     """
     Execute any DCT API action directly — no enable_toolset or tool list refresh needed.
@@ -497,7 +507,9 @@ async def execute_action(
             return {
                 "status": "confirmation_required",
                 "confirmation_level": confirmation["level"],
-                "confirmation_message": confirmation.get("message", "Please confirm this operation."),
+                "confirmation_message": confirmation.get(
+                    "message", "Please confirm this operation."
+                ),
                 "action": action,
                 "tool": tool_name,
                 "toolset": toolset_name,
@@ -511,10 +523,12 @@ async def execute_action(
         # Substitute path parameters from kwargs
         final_path = path
         remaining = dict(kwargs)
-        for match in re.finditer(r'\{(\w+)\}', path):
+        for match in re.finditer(r"\{(\w+)\}", path):
             param_name = match.group(1)
             if param_name in remaining:
-                final_path = final_path.replace(f"{{{param_name}}}", str(remaining.pop(param_name)))
+                final_path = final_path.replace(
+                    f"{{{param_name}}}", str(remaining.pop(param_name))
+                )
 
         # Handle filter_expression for search actions
         json_body = None
@@ -633,8 +647,12 @@ def find_endpoint(
     try:
         index = get_discovery_index(spec)
         ranked = rank_candidates(
-            index["corpus"], query, method_types,
-            float(min_score), capped_limit, index["hot_keywords"],
+            index["corpus"],
+            query,
+            method_types,
+            float(min_score),
+            capped_limit,
+            index["hot_keywords"],
         )
     except Exception as e:
         logger.error(f"find_endpoint ranking failed: {e}", exc_info=True)
@@ -653,17 +671,19 @@ def find_endpoint(
 
         suggested_toolset = toolset_index.get((method, path))
 
-        enriched.append({
-            "score": cand["score"],
-            "method": method,
-            "path": path,
-            "operation_id": cand.get("operation_id", ""),
-            "summary": cand.get("summary", ""),
-            "tags": cand.get("tags", []),
-            "requires_confirmation": level != "none",
-            "confirmation_level": level,
-            "suggested_toolset": suggested_toolset,
-        })
+        enriched.append(
+            {
+                "score": cand["score"],
+                "method": method,
+                "path": path,
+                "operation_id": cand.get("operation_id", ""),
+                "summary": cand.get("summary", ""),
+                "tags": cand.get("tags", []),
+                "requires_confirmation": level != "none",
+                "confirmation_level": level,
+                "suggested_toolset": suggested_toolset,
+            }
+        )
 
     logger.info(
         f"find_endpoint query='{query}' method_types={method_types} "

--- a/src/dct_mcp_server/tools/core/spec_cache.py
+++ b/src/dct_mcp_server/tools/core/spec_cache.py
@@ -50,6 +50,7 @@ _CACHE_META_FILENAME = ".cache-meta.json"
 # Public API
 # --------------------------------------------------------------------------- #
 
+
 def load_and_cache_spec() -> dict[str, Any]:
     """
     Download, validate, and cache the DCT OpenAPI spec.
@@ -84,7 +85,9 @@ def load_and_cache_spec() -> dict[str, Any]:
     if _should_use_cache(cache_path, max_age_hours):
         spec = _load_from_disk(cache_path)
         if spec is not None:
-            logger.info("Using cached OpenAPI spec from %s (within max age)", cache_path)
+            logger.info(
+                "Using cached OpenAPI spec from %s (within max age)", cache_path
+            )
             _cached_spec = spec
             return _cached_spec
 
@@ -123,6 +126,7 @@ def clear_spec_cache() -> None:
 # --------------------------------------------------------------------------- #
 # Private helpers
 # --------------------------------------------------------------------------- #
+
 
 def _should_use_cache(cache_path: Path, max_age_hours: int) -> bool:
     """Return True if the cache file exists and is younger than max_age_hours."""
@@ -181,7 +185,9 @@ def _load_from_disk(cache_path: Path) -> dict | None:
             spec = yaml.safe_load(f)
         if _validate_spec(spec):
             return spec
-        logger.warning("Cached spec at %s failed validation — will re-download", cache_path)
+        logger.warning(
+            "Cached spec at %s failed validation — will re-download", cache_path
+        )
         return None
     except Exception as exc:
         logger.warning("Could not load cached spec from %s: %s", cache_path, exc)
@@ -231,9 +237,7 @@ def _download_spec(
                     spec_url,
                 )
                 return None
-            logger.info(
-                "OpenAPI spec downloaded: %d paths", len(spec.get("paths", {}))
-            )
+            logger.info("OpenAPI spec downloaded: %d paths", len(spec.get("paths", {})))
             return spec
         except requests.HTTPError as exc:
             status = exc.response.status_code if exc.response is not None else "?"

--- a/src/dct_mcp_server/tools/core/tool_factory.py
+++ b/src/dct_mcp_server/tools/core/tool_factory.py
@@ -12,9 +12,6 @@ Architecture:
 """
 
 import logging
-import asyncio
-import tempfile
-import os
 import re
 from typing import Dict, Any, List, Optional, Callable, Tuple
 
@@ -24,7 +21,6 @@ import yaml
 import requests
 
 from dct_mcp_server.config import (
-    load_toolset_apis,
     load_toolset_grouped_apis,
 )
 from dct_mcp_server.config.config import get_dct_config
@@ -41,22 +37,32 @@ _dct_client = None  # DCT API client reference
 # The Delphix Engine silently ignores unknown keys, so we normalize camelCase
 # variants (which the LLM/user often produces) to the spec's snake_case form
 # and reject anything we can't map. See DLPXECO-13799.
-_VALID_HOOK_TYPES = frozenset({
-    "pre_refresh", "post_refresh",
-    "pre_self_refresh", "post_self_refresh",
-    "pre_rollback", "post_rollback",
-    "configure_clone",
-    "pre_snapshot", "post_snapshot",
-    "pre_start", "post_start",
-    "pre_stop", "post_stop",
-})
+_VALID_HOOK_TYPES = frozenset(
+    {
+        "pre_refresh",
+        "post_refresh",
+        "pre_self_refresh",
+        "post_self_refresh",
+        "pre_rollback",
+        "post_rollback",
+        "configure_clone",
+        "pre_snapshot",
+        "post_snapshot",
+        "pre_start",
+        "post_start",
+        "pre_stop",
+        "post_stop",
+    }
+)
 
 
 def _camel_to_snake(name: str) -> str:
     return re.sub(r"(?<!^)(?=[A-Z])", "_", name).lower()
 
 
-def _normalize_hooks_in_body(json_body: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+def _normalize_hooks_in_body(
+    json_body: Optional[Dict[str, Any]],
+) -> Optional[Dict[str, Any]]:
     """Rewrite camelCase hook keys (e.g. configureClone) to snake_case in place.
 
     Returns an error dict if a hook key is neither a known snake_case nor a
@@ -99,21 +105,24 @@ def _normalize_hooks_in_body(json_body: Optional[Dict[str, Any]]) -> Optional[Di
 # OPENAPI SPEC CACHING
 # =============================================================================
 
-def _download_openapi_spec(base_url: str, api_key: str = None, verify_ssl: bool = False) -> Dict[str, Any]:
+
+def _download_openapi_spec(
+    base_url: str, api_key: str = None, verify_ssl: bool = False
+) -> Dict[str, Any]:
     """Download OpenAPI spec from DCT server."""
     spec_url = f"{base_url.rstrip('/')}/dct/static/api-external.yaml"
-    
+
     headers = {
         "Accept": "application/x-yaml, text/yaml, application/json",
-        "User-Agent": "dct-mcp-server/1.0"
+        "User-Agent": "dct-mcp-server/1.0",
     }
     if api_key:
         headers["Authorization"] = f"apk {api_key}"
-    
+
     logger.info(f"Downloading OpenAPI spec from {spec_url}...")
     response = requests.get(spec_url, timeout=30, verify=verify_ssl, headers=headers)
     response.raise_for_status()
-    
+
     spec = yaml.safe_load(response.text)
     logger.info(f"OpenAPI spec loaded: {len(spec.get('paths', {}))} endpoints")
     return spec
@@ -121,10 +130,12 @@ def _download_openapi_spec(base_url: str, api_key: str = None, verify_ssl: bool 
 
 def _load_bundled_spec() -> Optional[Dict[str, Any]]:
     """Load bundled OpenAPI spec from docs directory as fallback."""
-    bundled_path = Path(__file__).parent.parent.parent.parent / "docs" / "api-external.yaml"
+    bundled_path = (
+        Path(__file__).parent.parent.parent.parent / "docs" / "api-external.yaml"
+    )
     if bundled_path.exists():
         logger.info(f"Loading bundled OpenAPI spec from {bundled_path}")
-        with open(bundled_path, 'r') as f:
+        with open(bundled_path, "r") as f:
             return yaml.safe_load(f)
     return None
 
@@ -132,38 +143,38 @@ def _load_bundled_spec() -> Optional[Dict[str, Any]]:
 def initialize_openapi_cache(dct_client=None) -> bool:
     """
     Initialize the OpenAPI spec cache at server startup.
-    
+
     Args:
         dct_client: DCT API client (optional, used for config)
-        
+
     Returns:
         True if spec was cached successfully
     """
     global _openapi_spec, _dct_client
     _dct_client = dct_client
-    
+
     if _openapi_spec is not None:
         logger.debug("OpenAPI spec already cached")
         return True
-    
+
     try:
         dct_config = get_dct_config()
         base_url = dct_config.get("base_url")
         api_key = dct_config.get("api_key")
         verify_ssl = dct_config.get("verify_ssl", False)
-        
+
         if base_url:
             _openapi_spec = _download_openapi_spec(base_url, api_key, verify_ssl)
             return True
     except Exception as e:
         logger.warning(f"Failed to download OpenAPI spec: {e}")
-    
+
     # Fallback to bundled spec
     _openapi_spec = _load_bundled_spec()
     if _openapi_spec:
         logger.info("Using bundled OpenAPI spec as fallback")
         return True
-    
+
     logger.warning("No OpenAPI spec available - tools will have basic docstrings")
     return False
 
@@ -183,12 +194,13 @@ def clear_spec_cache():
 # HELPER FUNCTIONS
 # =============================================================================
 
+
 def _resolve_ref(ref: str, spec: Dict[str, Any]) -> Dict[str, Any]:
     """Resolve a JSON $ref pointer in the OpenAPI spec."""
-    if not ref.startswith('#/'):
+    if not ref.startswith("#/"):
         raise ValueError(f"Unsupported ref format: {ref}")
-    
-    path = ref.lstrip('#/').split('/')
+
+    path = ref.lstrip("#/").split("/")
     node = spec
     for part in path:
         node = node[part]
@@ -199,7 +211,7 @@ def _get_python_type(schema_type: str) -> str:
     """Convert OpenAPI type to Python type hint."""
     type_map = {
         "integer": "int",
-        "string": "str", 
+        "string": "str",
         "boolean": "bool",
         "number": "float",
         "array": "list",
@@ -208,29 +220,28 @@ def _get_python_type(schema_type: str) -> str:
     return type_map.get(schema_type, "Any")
 
 
-
-
 # =============================================================================
 # DYNAMIC TOOL GENERATION
 # =============================================================================
+
 
 def _create_tool_function(
     api_path: str,
     method: str,
     action: str,
     operation: Dict[str, Any],
-    spec: Dict[str, Any]
+    spec: Dict[str, Any],
 ) -> Tuple[Callable, str]:
     """
     Create a tool function dynamically from OpenAPI operation.
-    
+
     Args:
         api_path: API endpoint path (e.g., "/vdbs/search")
         method: HTTP method (GET, POST, etc.)
         action: Action name from toolset config
         operation: OpenAPI operation object
         spec: Full OpenAPI spec for resolving refs
-        
+
     Returns:
         Tuple of (function, function_name)
     """
@@ -238,67 +249,75 @@ def _create_tool_function(
     summary = operation.get("summary", f"Execute {action}")
     description = operation.get("description", "")
     is_filterable = operation.get("x-filterable", False)
-    
+
     # Build parameter info
     params_info = []
     for param in operation.get("parameters", []):
         if "$ref" in param:
             param = _resolve_ref(param["$ref"], spec)
-        
+
         param_name = param.get("name", "unknown")
         param_schema = param.get("schema", {})
         param_type = _get_python_type(param_schema.get("type", "string"))
         param_required = param.get("required", False)
         param_desc = param.get("description", "No description")
-        
-        params_info.append({
-            "name": param_name,
-            "type": param_type,
-            "required": param_required,
-            "description": param_desc,
-        })
-    
+
+        params_info.append(
+            {
+                "name": param_name,
+                "type": param_type,
+                "required": param_required,
+                "description": param_desc,
+            }
+        )
+
     # Build docstring
     docstring_parts = [summary]
     if description:
         docstring_parts.append(f"\n{description}")
-    
+
     docstring_parts.append("\nArgs:")
     for p in params_info:
         req_str = "required" if p["required"] else "optional"
-        docstring_parts.append(f"    {p['name']} ({p['type']}): {p['description']} ({req_str})")
-    
+        docstring_parts.append(
+            f"    {p['name']} ({p['type']}): {p['description']} ({req_str})"
+        )
+
     if is_filterable:
-        docstring_parts.append("    filter_expression (str): Filter expression for search (optional)")
-    
+        docstring_parts.append(
+            "    filter_expression (str): Filter expression for search (optional)"
+        )
+
     docstring = "\n".join(docstring_parts)
-    
+
     # Check confirmation requirements
     confirmation = resolve_confirmation(method, api_path)
     needs_confirmation = confirmation["level"] != "none"
-    
+
     # Create the actual function
     async def tool_function(**kwargs):
         """Dynamic tool function - actual implementation."""
         if _dct_client is None:
             return {"error": "DCT client not initialized"}
-        
+
         # Check if confirmation is needed for destructive operations
         if needs_confirmation and not kwargs.pop("confirmed", False):
             return {
                 "status": "confirmation_required",
                 "confirmation_level": confirmation["level"],
-                "confirmation_message": confirmation.get("message", "Please confirm this operation."),
+                "confirmation_message": confirmation.get(
+                    "message", "Please confirm this operation."
+                ),
                 "operation": operation_id,
                 "api_path": api_path,
-                "instructions": "STOP: You MUST display the confirmation_message to the user and wait for their EXPLICIT approval before re-calling with confirmed=True. Do NOT proceed without user consent."
+                "instructions": "STOP: You MUST display the confirmation_message to the user and wait for their EXPLICIT approval before re-calling with confirmed=True. Do NOT proceed without user consent.",
             }
-        
+
         # Build request parameters
         query_params = {}
         path_params = {}
         json_body = None
-        
+
         for p in params_info:
             value = kwargs.get(p["name"])
             if value is not None:
@@ -307,22 +326,19 @@ def _create_tool_function(
                     path_params[p["name"]] = value
                 else:
                     query_params[p["name"]] = value
-        
+
         # Handle filter expression for search endpoints
         filter_expr = kwargs.get("filter_expression")
         if is_filterable and filter_expr:
             json_body = {"filter_expression": filter_expr}
-        
+
         # Substitute path parameters
         final_path = api_path
         for param_name, param_value in path_params.items():
             final_path = final_path.replace(f"{{{param_name}}}", str(param_value))
-        
+
         return await _dct_client.make_request(
-            method,
-            final_path,
-            params=query_params,
-            json=json_body
+            method, final_path, params=query_params, json=json_body
         )
 
     # Set function metadata
@@ -336,41 +352,41 @@ def _create_tool_function(
 
 
 def _create_grouped_tool_function(
-    tool_name: str, 
-    description: str, 
-    apis: List[Dict[str, str]], 
-    spec: Optional[Dict[str, Any]]
+    tool_name: str,
+    description: str,
+    apis: List[Dict[str, str]],
+    spec: Optional[Dict[str, Any]],
 ) -> Tuple[Callable, str]:
     """
     Create a grouped tool function that handles multiple actions via an 'action' parameter.
-    
+
     Args:
         tool_name: Name of the tool (e.g., "vdb_tool")
         description: Tool description
         apis: List of API definitions [{method, path, action}, ...]
         spec: OpenAPI spec for documentation
-        
+
     Returns:
         Tuple of (function, function_name)
     """
     # Build action registry
     action_registry: Dict[str, Dict[str, Any]] = {}
     action_descriptions = []
-    
+
     for api in apis:
         action_name = api["action"]
         method = api["method"]
         path = api["path"]
-        
+
         # Get operation details from spec if available
         operation = None
         if spec:
             path_item = spec.get("paths", {}).get(path, {})
             operation = path_item.get(method.lower(), {})
-        
+
         summary = operation.get("summary", action_name) if operation else action_name
         confirmation = resolve_confirmation(method, path)
-        
+
         action_registry[action_name] = {
             "method": method,
             "path": path,
@@ -379,21 +395,21 @@ def _create_grouped_tool_function(
             "operation": operation,
         }
         action_descriptions.append(f"  - {action_name}: {summary}")
-    
+
     # Sort actions for consistent documentation
     action_descriptions.sort()
     available_actions = sorted(action_registry.keys())
-    
+
     # Build docstring
     docstring = f"""{description}
 
-Available actions: {', '.join(available_actions)}
+Available actions: {", ".join(available_actions)}
 
 Action details:
 {chr(10).join(action_descriptions)}
 
 Args:
-    action (str, required): The action to perform. One of: {', '.join(available_actions)}
+    action (str, required): The action to perform. One of: {", ".join(available_actions)}
     **kwargs: Action-specific parameters (e.g., vdbId, filter_expression, etc.)
     
 Common parameters:
@@ -404,50 +420,54 @@ Common parameters:
 Returns:
     API response as dict
 """
-    
+
     async def grouped_tool(action: str, **kwargs):
         """Grouped tool implementation."""
         if _dct_client is None:
             return {"error": "DCT client not initialized"}
-        
+
         if action not in action_registry:
             return {
                 "error": f"Unknown action: {action}",
                 "available_actions": available_actions,
-                "hint": f"Use one of: {', '.join(available_actions)}"
+                "hint": f"Use one of: {', '.join(available_actions)}",
             }
-        
+
         action_info = action_registry[action]
         method = action_info["method"]
         path = action_info["path"]
         confirmation = action_info["confirmation"]
-        
+
         # Check confirmation for destructive operations
         needs_confirmation = confirmation["level"] != "none"
         if needs_confirmation and not kwargs.pop("confirmed", False):
             return {
                 "status": "confirmation_required",
                 "confirmation_level": confirmation["level"],
-                "confirmation_message": confirmation.get("message", "Please confirm this operation."),
+                "confirmation_message": confirmation.get(
+                    "message", "Please confirm this operation."
+                ),
                 "action": action,
                 "tool": tool_name,
                 "api_path": path,
-                "instructions": "STOP: You MUST display the confirmation_message to the user and wait for their EXPLICIT approval before re-calling with confirmed=True. Do NOT proceed without user consent."
+                "instructions": "STOP: You MUST display the confirmation_message to the user and wait for their EXPLICIT approval before re-calling with confirmed=True. Do NOT proceed without user consent.",
             }
-        
+
         # Build request - extract path params from kwargs
         final_path = path
-        for match in re.finditer(r'\{(\w+)\}', path):
+        for match in re.finditer(r"\{(\w+)\}", path):
             param_name = match.group(1)
             if param_name in kwargs:
-                final_path = final_path.replace(f"{{{param_name}}}", str(kwargs.pop(param_name)))
-        
+                final_path = final_path.replace(
+                    f"{{{param_name}}}", str(kwargs.pop(param_name))
+                )
+
         # Handle filter_expression for search actions
         json_body = None
         filter_expr = kwargs.pop("filter_expression", None)
         if filter_expr and "search" in action.lower():
             json_body = {"filter_expression": filter_expr}
-        
+
         # Handle explicit body parameter
         body = kwargs.pop("body", None)
         if body:
@@ -472,12 +492,12 @@ Returns:
             method,
             final_path,
             params=query_params if query_params else None,
-            json=json_body
+            json=json_body,
         )
-    
+
     grouped_tool.__name__ = tool_name
     grouped_tool.__doc__ = docstring
-    
+
     decorated_func = log_tool_execution(grouped_tool)
     return decorated_func, tool_name
 
@@ -485,13 +505,13 @@ Returns:
 def generate_tools_for_toolset(toolset_name: str) -> List[Tuple[Callable, str]]:
     """
     Generate GROUPED tool functions for a toolset.
-    
+
     Each logical tool (e.g., vdb_tool, dsource_tool) becomes a single tool
     with an 'action' parameter to select the specific operation.
-    
+
     Args:
         toolset_name: Name of the toolset to generate tools for
-        
+
     Returns:
         List of (function, function_name) tuples
     """
@@ -500,26 +520,28 @@ def generate_tools_for_toolset(toolset_name: str) -> List[Tuple[Callable, str]]:
         logger.warning("OpenAPI spec not cached - initializing...")
         initialize_openapi_cache(_dct_client)
         spec = get_cached_spec()
-    
+
     # Load APIs grouped by tool from toolset file headers
     grouped_apis = load_toolset_grouped_apis(toolset_name)
     tools = []
-    
-    logger.info(f"Generating GROUPED tools for toolset '{toolset_name}' ({len(grouped_apis)} tools)...")
-    
+
+    logger.info(
+        f"Generating GROUPED tools for toolset '{toolset_name}' ({len(grouped_apis)} tools)..."
+    )
+
     for tool_name, tool_data in grouped_apis.items():
         description = tool_data.get("description", f"{tool_name} operations")
         apis = tool_data.get("apis", [])
-        
+
         if not apis:
             logger.warning(f"  Skipping {tool_name} - no APIs defined")
             continue
-        
+
         # Create grouped tool function
         func, name = _create_grouped_tool_function(tool_name, description, apis, spec)
         tools.append((func, name))
         logger.info(f"  Generated: {tool_name} ({len(apis)} actions)")
-    
+
     logger.info(f"Generated {len(tools)} grouped tools for toolset '{toolset_name}'")
     return tools
 
@@ -528,24 +550,25 @@ def generate_tools_for_toolset(toolset_name: str) -> List[Tuple[Callable, str]]:
 # TOOL REGISTRATION
 # =============================================================================
 
+
 def register_toolset_tools(app, toolset_name: str, dct_client=None) -> int:
     """
     Generate and register all tools for a toolset.
-    
+
     Args:
         app: FastMCP application instance
         toolset_name: Name of the toolset
         dct_client: DCT API client
-        
+
     Returns:
         Number of tools registered
     """
     global _dct_client
     if dct_client:
         _dct_client = dct_client
-    
+
     tools = generate_tools_for_toolset(toolset_name)
-    
+
     registered = 0
     for func, name in tools:
         try:
@@ -553,6 +576,8 @@ def register_toolset_tools(app, toolset_name: str, dct_client=None) -> int:
             registered += 1
         except Exception as e:
             logger.error(f"Failed to register tool {name}: {e}")
-    
-    logger.info(f"Registered {registered}/{len(tools)} tools for toolset '{toolset_name}'")
+
+    logger.info(
+        f"Registered {registered}/{len(tools)} tools for toolset '{toolset_name}'"
+    )
     return registered

--- a/src/dct_mcp_server/tools/dataset_endpoints_tool.py
+++ b/src/dct_mcp_server/tools/dataset_endpoints_tool.py
@@ -1,7 +1,6 @@
-from mcp.server.fastmcp import FastMCP
-from typing import Dict,Any,Optional
+from typing import Dict, Any, Optional
 from dct_mcp_server.core.decorators import log_tool_execution
-from dct_mcp_server.config import get_confirmation_for_operation, requires_confirmation
+from dct_mcp_server.config import get_confirmation_for_operation
 import asyncio
 import logging
 import threading
@@ -29,7 +28,16 @@ logger = logging.getLogger(__name__)
 #       }
 # =============================================================================
 
-def check_confirmation(method: str, api_path: str, action: str, tool_name: str, confirmed: bool = False, request_params: Optional[Dict[str, Any]] = None, request_body: Optional[Dict[str, Any]] = None) -> Optional[Dict[str, Any]]:
+
+def check_confirmation(
+    method: str,
+    api_path: str,
+    action: str,
+    tool_name: str,
+    confirmed: bool = False,
+    request_params: Optional[Dict[str, Any]] = None,
+    request_body: Optional[Dict[str, Any]] = None,
+) -> Optional[Dict[str, Any]]:
     """Check if operation requires confirmation. Returns confirmation response or None if confirmed/not needed."""
     confirmation = get_confirmation_for_operation(method, api_path)
     if confirmation["level"] != "none" and not confirmed:
@@ -41,7 +49,11 @@ def check_confirmation(method: str, api_path: str, action: str, tool_name: str, 
             review.update(request_params)
         if request_body:
             review.update(request_body)
-        is_review_critical = action.startswith("provision_") or action.startswith("dsource_link_") or action == "dsource_create_snapshot"
+        is_review_critical = (
+            action.startswith("provision_")
+            or action.startswith("dsource_link_")
+            or action == "dsource_create_snapshot"
+        )
         instructions = (
             "STOP: You MUST display the confirmation_message to the user and wait for their EXPLICIT "
             "approval before re-calling with confirmed=True. Do NOT proceed without user consent."
@@ -56,7 +68,9 @@ def check_confirmation(method: str, api_path: str, action: str, tool_name: str, 
         return {
             "status": "confirmation_required",
             "confirmation_level": confirmation["level"],
-            "confirmation_message": confirmation.get("message", "Please confirm this operation."),
+            "confirmation_message": confirmation.get(
+                "message", "Please confirm this operation."
+            ),
             "action": action,
             "tool": tool_name,
             "api_path": api_path,
@@ -66,8 +80,10 @@ def check_confirmation(method: str, api_path: str, action: str, tool_name: str, 
         }
     return None
 
+
 def async_to_sync(async_func):
     """Utility decorator to convert async functions to sync with proper event loop handling."""
+
     @wraps(async_func)
     def wrapper(*args, **kwargs):
         try:
@@ -76,12 +92,14 @@ def async_to_sync(async_func):
                 # Create a task and run it synchronously
                 result = None
                 exception = None
+
                 def run_in_thread():
                     nonlocal result, exception
                     try:
                         result = asyncio.run(async_func(*args, **kwargs))
                     except Exception as e:
                         exception = e
+
                 thread = threading.Thread(target=run_in_thread)
                 thread.start()
                 thread.join()
@@ -92,18 +110,28 @@ def async_to_sync(async_func):
                 return loop.run_until_complete(async_func(*args, **kwargs))
         except RuntimeError:
             return asyncio.run(async_func(*args, **kwargs))
+
     return wrapper
 
-def make_api_request(method: str, endpoint: str, params: dict = None, json_body: dict = None):
+
+def make_api_request(
+    method: str, endpoint: str, params: dict = None, json_body: dict = None
+):
     """Utility function to make API requests with consistent parameter handling."""
+
     @async_to_sync
     async def _make_request():
-        return await client.make_request(method, endpoint, params=params or {}, json=json_body)
+        return await client.make_request(
+            method, endpoint, params=params or {}, json=json_body
+        )
+
     return _make_request()
+
 
 def build_params(**kwargs):
     """Build parameters dictionary excluding None and empty string values."""
-    return {k: v for k, v in kwargs.items() if v is not None and v != ''}
+    return {k: v for k, v in kwargs.items() if v is not None and v != ""}
+
 
 @log_tool_execution
 def data_tool(
@@ -423,3405 +451,6701 @@ def data_tool(
     confirmed: Optional[bool] = None,
 ) -> Dict[str, Any]:
     """
-    Unified tool for DATA operations.
-    
-    This tool supports 122 actions: list_vdbs, search_vdbs, get_vdb, update_vdb, provision_by_timestamp, provision_by_timestamp_defaults, provision_by_snapshot, provision_by_snapshot_defaults, provision_from_bookmark, provision_from_bookmark_defaults, provision_by_location, provision_by_location_defaults, provision_empty_vdb, delete_vdb, start_vdb, stop_vdb, enable_vdb, disable_vdb, refresh_vdb_by_timestamp, refresh_vdb_by_snapshot, refresh_vdb_from_bookmark, refresh_vdb_by_location, undo_vdb_refresh, rollback_vdb_by_timestamp, rollback_vdb_by_snapshot, rollback_vdb_from_bookmark, switch_vdb_timeflow, lock_vdb, unlock_vdb, migrate_vdb, get_migrate_compatible_repositories, upgrade_vdb, upgrade_oracle_vdb, get_upgrade_compatible_repositories, list_vdb_snapshots, snapshot_vdb, list_vdb_bookmarks, search_vdb_bookmarks, get_vdb_deletion_dependencies, verify_vdb_jdbc_connection, get_vdb_tags, add_vdb_tags, export_vdb_in_place, export_vdb_asm_in_place, export_vdb_by_snapshot, export_vdb_by_timestamp, export_vdb_by_location, export_vdb_from_bookmark, export_vdb_to_asm_by_snapshot, export_vdb_to_asm_by_timestamp, export_vdb_to_asm_by_location, export_vdb_to_asm_from_bookmark, export_cleanup, export_finalize, list_vdb_groups, search_vdb_groups, get_vdb_group, create_vdb_group, update_vdb_group, delete_vdb_group, provision_vdb_group_from_bookmark, refresh_vdb_group, refresh_vdb_group_from_bookmark, refresh_vdb_group_by_snapshot, refresh_vdb_group_by_timestamp, rollback_vdb_group, lock_vdb_group, unlock_vdb_group, start_vdb_group, stop_vdb_group, enable_vdb_group, disable_vdb_group, get_vdb_group_latest_snapshots, get_vdb_group_timestamp_summary, list_vdb_group_bookmarks, search_vdb_group_bookmarks, get_vdb_group_tags, add_vdb_group_tags, list_dsources, search_dsources, get_dsource, delete_dsource, enable_dsource, disable_dsource, list_dsource_snapshots, dsource_create_snapshot, upgrade_dsource, get_dsource_upgrade_compatible_repositories, get_dsource_deletion_dependencies, get_dsource_tags, add_dsource_tags, delete_dsource_tags, dsource_link_oracle, dsource_link_oracle_defaults, dsource_link_oracle_staging_push, dsource_link_oracle_staging_push_defaults, update_oracle_dsource, attach_oracle_dsource, detach_oracle_dsource, upgrade_oracle_dsource, dsource_link_ase, dsource_link_ase_defaults, update_ase_dsource, dsource_link_appdata, dsource_link_appdata_defaults, update_appdata_dsource, dsource_link_mssql, dsource_link_mssql_defaults, dsource_link_mssql_staging_push, dsource_link_mssql_staging_push_defaults, attach_mssql_staging_push_dsource, update_mssql_dsource, attach_mssql_dsource, detach_mssql_dsource, export_dsource_by_snapshot, export_dsource_by_timestamp, export_dsource_by_location, export_dsource_from_bookmark, export_dsource_to_asm_by_snapshot, export_dsource_to_asm_by_timestamp, export_dsource_to_asm_by_location, export_dsource_to_asm_from_bookmark
-    
-    IMPORTANT — Delphix domain terminology:
-  • "dSource" is often used as a VERB meaning "create/link a dSource" (i.e. ingest a source database). When a user says "dSource database X", they want to LINK a new dSource for database X, NOT look up an existing dSource named X. Use the appropriate dsource_link_* action (dsource_link_oracle, dsource_link_mssql, dsource_link_ase, dsource_link_appdata) depending on the database type.
-  • "provision" or "spin up" a VDB or "create a golden image of a VDB" means creating a virtual database from a dSource or bookmark  — use provision_by_timestamp, provision_by_snapshot, etc.
-  • "refresh" a VDB means updating it with newer data from its parent — use refresh_vdb_by_timestamp, refresh_vdb_by_snapshot, etc.
-    
-    ======================================================================
-    ACTION REFERENCE
-    ======================================================================
-    
-    ACTION: list_vdbs
-    ----------------------------------------
-    Summary: List all vdbs.
-    Method: GET
-    Endpoint: /vdbs
-    Required Parameters: limit, cursor, sort, permission
-    
-    Example:
-        >>> data_tool(action='list_vdbs', limit=..., cursor=..., sort=..., permission=...)
-    
-    ACTION: search_vdbs
-    ----------------------------------------
-    Summary: Search for VDBs.
-    Method: POST
-    Endpoint: /vdbs/search
-    Required Parameters: limit, cursor, sort, permission
-    Key Parameters (provide as applicable): filter_expression
-    
-    Filterable Fields:
-        - id: The VDB object entity ID.
-        - database_type: The database type of this VDB.
-        - name: The logical name of this VDB.
-        - description: The container description of this VDB.
-        - database_name: The name of the database on the target environment or in ...
-        - namespace_id: The namespace id of this VDB.
-        - namespace_name: The namespace name of this VDB.
-        - is_replica: Is this a replicated object.
-        - is_locked: Is this VDB locked.
-        - locked_by: The ID of the account that locked this VDB.
-        - locked_by_name: The name of the account that locked this VDB.
-        - database_version: The database version of this VDB.
-        - jdbc_connection_string: The JDBC connection URL for this VDB.
-        - size: The total size of this VDB, in bytes.
-        - storage_size: The actual space used by this VDB, in bytes.
-        - unvirtualized_space: The disk space, in bytes, that it would take to store the...
-        - engine_id: A reference to the Engine that this VDB belongs to.
-        - status: The runtime status of the VDB. 'Unknown' if all attempts ...
-        - masked: The VDB is masked or not.
-        - content_type: The content type of the vdb.
-        - parent_timeflow_timestamp: The timestamp for parent timeflow.
-        - parent_timeflow_timezone: The timezone for parent timeflow.
-        - environment_id: A reference to the Environment that hosts this VDB.
-        - ip_address: The IP address of the VDB's host.
-        - fqdn: The FQDN of the VDB's host.
-        - parent_id: A reference to the parent dataset of this VDB.
-        - parent_dsource_id: A reference to the parent dSource of this VDB.
-        - root_parent_id: A reference to the root parent dataset of this VDB which ...
-        - group_name: The name of the group containing this VDB.
-        - engine_name: Name of the Engine where this VDB is hosted
-        - cdb_id: A reference to the CDB or VCDB associated with this VDB.
-        - tags: 
-        - creation_date: The date this VDB was created.
-        - hooks: 
-        - appdata_source_params: The JSON payload conforming to the DraftV4 schema based o...
-        - template_id: A reference to the Database Template.
-        - template_name: Name of the Database Template.
-        - config_params: Database configuration parameter overrides.
-        - environment_user_ref: The environment user reference.
-        - additional_mount_points: Specifies additional locations on which to mount a subdir...
-        - appdata_config_params: The parameters specified by the source config schema in t...
-        - mount_point: Mount point for the VDB (Oracle, ASE, AppData).
-        - current_timeflow_id: A reference to the currently active timeflow for this VDB.
-        - previous_timeflow_id: A reference to the previous timeflow for this VDB.
-        - last_refreshed_date: The date this VDB was last refreshed.
-        - vdb_restart: Indicates whether the Engine should automatically restart...
-        - is_appdata: Indicates whether this VDB has an AppData database.
-        - exported_data_directory: ZFS exported data directory path.
-        - vcdb_exported_data_directory: ZFS exported data directory path of the virtual CDB conta...
-        - toolkit_id: The ID of the toolkit associated with this VDB.
-        - plugin_version: The version of the plugin associated with this VDB.
-        - primary_object_id: The ID of the parent object from which replication was done.
-        - primary_engine_id: The ID of the parent engine from which replication was done.
-        - primary_engine_name: The name of the parent engine from which replication was ...
-        - replicas: The list of replicas replicated from this object.
-        - invoke_datapatch: Indicates whether datapatch should be invoked.
-        - enabled: True if VDB is enabled false if VDB is disabled.
-        - node_listeners: The list of node listeners for this VDB.
-        - instance_name: The instance name name of this single instance VDB.
-        - instance_number: The instance number of this single instance VDB.
-        - instances: 
-        - oracle_services: 
-        - repository_id: The repository id of this VDB.
-        - containerization_state: 
-        - parent_tde_keystore_path: Path to a copy of the parent's Oracle transparent data en...
-        - target_vcdb_tde_keystore_path: Path to the keystore of the target vCDB.
-        - tde_key_identifier: ID of the key created by Delphix, as recorded in v$encryp...
-        - parent_pdb_tde_keystore_path: Path to a copy of the parent PDB's Oracle transparent dat...
-        - target_pdb_tde_keystore_path: Path of the virtual PDB's Oracle transparent data encrypt...
-        - recovery_model: Recovery model of the vdb database.
-        - cdc_on_provision: Whether to enable CDC on provision for MSSql.
-        - data_connection_id: The ID of the associated DataConnection.
-        - mssql_ag_backup_location: Shared backup location to be used for VDB provision on AG...
-        - mssql_ag_backup_based: Indicates whether to do fast operations for VDB on AG whi...
-        - mssql_ag_replicas: Indicates the mssql replica sources constitutes in MSSQL ...
-        - database_unique_name: The unique name of the database.
-        - db_username: The user name of the database.
-        - new_db_id: Indicates whether Delphix will generate a new DBID during...
-        - redo_log_groups: Number of Online Redo Log Groups.
-        - redo_log_size_in_mb: Online Redo Log size in MB.
-        - custom_env_vars: 
-        - active_instances: 
-        - nfs_version: The NFS version that was last used to mount this source."
-        - nfs_version_reason: 
-        - nfs_encryption_enabled: Flag indicating whether the data transfer is encrypted or...
-        - cache_priority: When set to a value other than NORMAL (valid only for obj...
-        - mssql_incremental_export_backup_frequency_minutes: Frequency in minutes for incremental export backups for V...
-        - recycle_bin: Indicates whether the VDB is in recycle bin or not.
-        - recycle_days: Number of days to retain VDB in the recycle bin before it...
-        - recycle_bin_date: The date this VDB was moved to recycle bin.
-        - recycle_bin_account_id: The ID of the account that moved this VDB to recycle bin.
-    
-    Filter Syntax:
-        Operators: EQ, NE, GT, GE, LT, LE, CONTAINS, IN, NOT_IN
-        Combine: AND, OR
-        Example: "name CONTAINS 'prod' AND status EQ 'RUNNING'"
-    
-    Example:
-        >>> data_tool(action='search_vdbs', limit=..., cursor=..., sort=..., permission=..., filter_expression="name CONTAINS 'test'")
-    
-    ACTION: get_vdb
-    ----------------------------------------
-    Summary: Get a VDB by ID.
-    Method: GET
-    Endpoint: /vdbs/{vdbId}
-    Required Parameters: vdb_id
-    
-    Example:
-        >>> data_tool(action='get_vdb', vdb_id='example-vdb-123')
-    
-    ACTION: update_vdb
-    ----------------------------------------
-    Summary: Update values of a VDB
-    Method: PATCH
-    Endpoint: /vdbs/{vdbId}
-    Required Parameters: vdb_id
-    Key Parameters (provide as applicable): name, description, db_username, db_password, validate_db_credentials, auto_restart, environment_user_id, template_id, listener_ids, new_dbid, cdc_on_provision, pre_script, post_script, hooks, custom_env_vars, custom_env_files, oracle_rac_custom_env_files, oracle_rac_custom_env_vars, parent_tde_keystore_path, parent_tde_keystore_password, tde_key_identifier, target_vcdb_tde_keystore_path, cdb_tde_keystore_password, parent_pdb_tde_keystore_path, parent_pdb_tde_keystore_password, target_pdb_tde_keystore_password, appdata_source_params, additional_mount_points, appdata_config_params, config_params, mount_point, oracle_services, instances, invoke_datapatch, mssql_ag_backup_location, mssql_ag_backup_based, cache_priority, mssql_incremental_export_backup_frequency_minutes, database_name
-    
-    Example:
-        >>> data_tool(action='update_vdb', vdb_id='example-vdb-123', name=..., description=..., db_username=..., db_password=..., validate_db_credentials=..., auto_restart=..., environment_user_id='example-environment_user-123', template_id='example-template-123', listener_ids=..., new_dbid=..., cdc_on_provision=..., pre_script=..., post_script=..., hooks=..., custom_env_vars=..., custom_env_files=..., oracle_rac_custom_env_files=..., oracle_rac_custom_env_vars=..., parent_tde_keystore_path=..., parent_tde_keystore_password=..., tde_key_identifier=..., target_vcdb_tde_keystore_path=..., cdb_tde_keystore_password=..., parent_pdb_tde_keystore_path=..., parent_pdb_tde_keystore_password=..., target_pdb_tde_keystore_password=..., appdata_source_params=..., additional_mount_points=..., appdata_config_params=..., config_params=..., mount_point=..., oracle_services=..., instances=..., invoke_datapatch=..., mssql_ag_backup_location=..., mssql_ag_backup_based=..., cache_priority=..., mssql_incremental_export_backup_frequency_minutes=..., database_name=...)
-    
-    ACTION: provision_by_timestamp
-    ----------------------------------------
-    Summary: Provision a new VDB by timestamp.
-    Method: POST
-    Endpoint: /vdbs/provision_by_timestamp
-    Required Parameters: source_data_id
-    Key Parameters (provide as applicable): timestamp, timestamp_in_database_timezone, timeflow_id, engine_id, make_current_account_owner
-    
-    Example:
-        >>> data_tool(action='provision_by_timestamp', timestamp=..., timestamp_in_database_timezone=..., timeflow_id='example-timeflow-123', engine_id='example-engine-123', source_data_id='example-source_data-123', make_current_account_owner=...)
-    
-        IMPORTANT — AppData VDB only: If provisioning an AppData VDB (i.e., you need to populate 'appdata_source_params' or 'appdata_config_params'), call toolkit_tool(action='search') first and filter by the engine_id of the target environment, and use environment_user_id. Use the matching toolkit's 'virtual_source_definition.parameters' schema for 'appdata_source_params', and 'source_config_definition.parameters' for 'appdata_config_params'. For Oracle, MSSQL, PostgreSQL, or other non-AppData types, skip this step.
-    
-    ACTION: provision_by_timestamp_defaults
-    ----------------------------------------
-    Summary: Get default provision parameters for provisioning a new VDB by timestamp.
-    Method: POST
-    Endpoint: /vdbs/provision_by_timestamp/defaults
-    Required Parameters: source_data_id
-    Key Parameters (provide as applicable): timestamp, timestamp_in_database_timezone, timeflow_id, engine_id
-    
-    Example:
-        >>> data_tool(action='provision_by_timestamp_defaults', timestamp=..., timestamp_in_database_timezone=..., timeflow_id='example-timeflow-123', engine_id='example-engine-123', source_data_id='example-source_data-123')
-    
-    ACTION: provision_by_snapshot
-    ----------------------------------------
-    Summary: Provision a new VDB by snapshot.
-    Method: POST
-    Endpoint: /vdbs/provision_by_snapshot
-    Key Parameters (provide as applicable): engine_id, source_data_id, make_current_account_owner, snapshot_id
-    
-    Example:
-        >>> data_tool(action='provision_by_snapshot', engine_id='example-engine-123', source_data_id='example-source_data-123', make_current_account_owner=..., snapshot_id='example-snapshot-123')
-    
-        IMPORTANT — AppData VDB only: If provisioning an AppData VDB (i.e., you need to populate 'appdata_source_params' or 'appdata_config_params'), call toolkit_tool(action='search') first and filter by the engine_id of the target environment, and use environment_user_id. Use the matching toolkit's 'virtual_source_definition.parameters' schema for 'appdata_source_params', and 'source_config_definition.parameters' for 'appdata_config_params'. For Oracle, MSSQL, PostgreSQL, or other non-AppData types, skip this step.
-    
-    ACTION: provision_by_snapshot_defaults
-    ----------------------------------------
-    Summary: Get default provision parameters for provisioning a new VDB by snapshot.
-    Method: POST
-    Endpoint: /vdbs/provision_by_snapshot/defaults
-    Key Parameters (provide as applicable): engine_id, source_data_id, snapshot_id
-    
-    Example:
-        >>> data_tool(action='provision_by_snapshot_defaults', engine_id='example-engine-123', source_data_id='example-source_data-123', snapshot_id='example-snapshot-123')
-    
-    ACTION: provision_from_bookmark
-    ----------------------------------------
-    Summary: Provision a new VDB from a bookmark with a single VDB.
-    Method: POST
-    Endpoint: /vdbs/provision_from_bookmark
-    Required Parameters: bookmark_id
-    Key Parameters (provide as applicable): make_current_account_owner
-    
-    Example:
-        >>> data_tool(action='provision_from_bookmark', make_current_account_owner=..., bookmark_id='example-bookmark-123')
-    
-        IMPORTANT — AppData VDB only: If provisioning an AppData VDB (i.e., you need to populate 'appdata_source_params' or 'appdata_config_params'), call toolkit_tool(action='search') first and filter by the engine_id of the target environment, and use environment_user_id. Use the matching toolkit's 'virtual_source_definition.parameters' schema for 'appdata_source_params', and 'source_config_definition.parameters' for 'appdata_config_params'. For Oracle, MSSQL, PostgreSQL, or other non-AppData types, skip this step.
-    
-    ACTION: provision_from_bookmark_defaults
-    ----------------------------------------
-    Summary: Get default provision parameters for provisioning a new VDB from a bookmark.
-    Method: POST
-    Endpoint: /vdbs/provision_from_bookmark/defaults
-    Required Parameters: bookmark_id
-    
-    Example:
-        >>> data_tool(action='provision_from_bookmark_defaults', bookmark_id='example-bookmark-123')
-    
-    ACTION: provision_by_location
-    ----------------------------------------
-    Summary: Provision a new VDB by location.
-    Method: POST
-    Endpoint: /vdbs/provision_by_location
-    Key Parameters (provide as applicable): timeflow_id, engine_id, source_data_id, make_current_account_owner, location
-    
-    Example:
-        >>> data_tool(action='provision_by_location', timeflow_id='example-timeflow-123', engine_id='example-engine-123', source_data_id='example-source_data-123', make_current_account_owner=..., location=...)
-    
-        IMPORTANT — AppData VDB only: If provisioning an AppData VDB (i.e., you need to populate 'appdata_source_params' or 'appdata_config_params'), call toolkit_tool(action='search') first and filter by the engine_id of the target environment, and use environment_user_id. Use the matching toolkit's 'virtual_source_definition.parameters' schema for 'appdata_source_params', and 'source_config_definition.parameters' for 'appdata_config_params'. For Oracle, MSSQL, PostgreSQL, or other non-AppData types, skip this step.
-    
-    ACTION: provision_by_location_defaults
-    ----------------------------------------
-    Summary: Get default provision parameters for provisioning a new VDB by location.
-    Method: POST
-    Endpoint: /vdbs/provision_by_location/defaults
-    Key Parameters (provide as applicable): timeflow_id, engine_id, source_data_id, location
-    
-    Example:
-        >>> data_tool(action='provision_by_location_defaults', timeflow_id='example-timeflow-123', engine_id='example-engine-123', source_data_id='example-source_data-123', location=...)
-    
-    ACTION: provision_empty_vdb
-    ----------------------------------------
-    Summary: Provision an empty VDB.
-    Method: POST
-    Endpoint: /vdbs/empty_vdb
-    Key Parameters (provide as applicable): repository_id, engine_id
-    
-    Example:
-        >>> data_tool(action='provision_empty_vdb', repository_id='example-repository-123', engine_id='example-engine-123')
-    
-        IMPORTANT — AppData VDB only: If provisioning an AppData VDB (i.e., you need to populate 'appdata_source_params' or 'appdata_config_params'), call toolkit_tool(action='search') first and filter by the engine_id of the target environment, and use environment_user_id. Use the matching toolkit's 'virtual_source_definition.parameters' schema for 'appdata_source_params', and 'source_config_definition.parameters' for 'appdata_config_params'. For Oracle, MSSQL, PostgreSQL, or other non-AppData types, skip this step.
-    
-    ACTION: delete_vdb
-    ----------------------------------------
-    Summary: Delete a VDB.
-    Method: POST
-    Endpoint: /vdbs/{vdbId}/delete
-    Required Parameters: vdb_id
-    Key Parameters (provide as applicable): force, delete_all_dependent_vdbs
-    
-    Example:
-        >>> data_tool(action='delete_vdb', vdb_id='example-vdb-123', force=..., delete_all_dependent_vdbs=...)
-    
-    ACTION: start_vdb
-    ----------------------------------------
-    Summary: Start a VDB.
-    Method: POST
-    Endpoint: /vdbs/{vdbId}/start
-    Required Parameters: vdb_id
-    Key Parameters (provide as applicable): instances
-    
-    Example:
-        >>> data_tool(action='start_vdb', vdb_id='example-vdb-123', instances=...)
-    
-    ACTION: stop_vdb
-    ----------------------------------------
-    Summary: Stop a VDB.
-    Method: POST
-    Endpoint: /vdbs/{vdbId}/stop
-    Required Parameters: vdb_id
-    Key Parameters (provide as applicable): instances, abort
-    
-    Example:
-        >>> data_tool(action='stop_vdb', vdb_id='example-vdb-123', instances=..., abort=...)
-    
-    ACTION: enable_vdb
-    ----------------------------------------
-    Summary: Enable a VDB.
-    Method: POST
-    Endpoint: /vdbs/{vdbId}/enable
-    Required Parameters: vdb_id
-    Key Parameters (provide as applicable): container_mode, attempt_start, ownership_spec
-    
-    Example:
-        >>> data_tool(action='enable_vdb', vdb_id='example-vdb-123', container_mode=..., attempt_start=..., ownership_spec=...)
-    
-    ACTION: disable_vdb
-    ----------------------------------------
-    Summary: Disable a VDB.
-    Method: POST
-    Endpoint: /vdbs/{vdbId}/disable
-    Required Parameters: vdb_id
-    Key Parameters (provide as applicable): container_mode, attempt_cleanup
-    
-    Example:
-        >>> data_tool(action='disable_vdb', vdb_id='example-vdb-123', container_mode=..., attempt_cleanup=...)
-    
-    ACTION: refresh_vdb_by_timestamp
-    ----------------------------------------
-    Summary: Refresh a VDB by timestamp.
-    Method: POST
-    Endpoint: /vdbs/{vdbId}/refresh_by_timestamp
-    Required Parameters: vdb_id
-    Key Parameters (provide as applicable): timestamp, timestamp_in_database_timezone, timeflow_id, dataset_id
-    
-    Example:
-        >>> data_tool(action='refresh_vdb_by_timestamp', vdb_id='example-vdb-123', timestamp=..., timestamp_in_database_timezone=..., timeflow_id='example-timeflow-123', dataset_id='example-dataset-123')
-    
-    ACTION: refresh_vdb_by_snapshot
-    ----------------------------------------
-    Summary: Refresh a VDB by snapshot.
-    Method: POST
-    Endpoint: /vdbs/{vdbId}/refresh_by_snapshot
-    Required Parameters: vdb_id
-    Key Parameters (provide as applicable): snapshot_id
-    
-    Example:
-        >>> data_tool(action='refresh_vdb_by_snapshot', vdb_id='example-vdb-123', snapshot_id='example-snapshot-123')
-    
-    ACTION: refresh_vdb_from_bookmark
-    ----------------------------------------
-    Summary: Refresh a VDB from bookmark with a single VDB.
-    Method: POST
-    Endpoint: /vdbs/{vdbId}/refresh_from_bookmark
-    Required Parameters: vdb_id, bookmark_id
-    
-    Example:
-        >>> data_tool(action='refresh_vdb_from_bookmark', vdb_id='example-vdb-123', bookmark_id='example-bookmark-123')
-    
-    ACTION: refresh_vdb_by_location
-    ----------------------------------------
-    Summary: Refresh a VDB by location.
-    Method: POST
-    Endpoint: /vdbs/{vdbId}/refresh_by_location
-    Required Parameters: vdb_id
-    Key Parameters (provide as applicable): timeflow_id, location, dataset_id
-    
-    Example:
-        >>> data_tool(action='refresh_vdb_by_location', vdb_id='example-vdb-123', timeflow_id='example-timeflow-123', location=..., dataset_id='example-dataset-123')
-    
-    ACTION: undo_vdb_refresh
-    ----------------------------------------
-    Summary: Undo the last refresh operation.
-    Method: POST
-    Endpoint: /vdbs/{vdbId}/undo_refresh
-    Required Parameters: vdb_id
-    
-    Example:
-        >>> data_tool(action='undo_vdb_refresh', vdb_id='example-vdb-123')
-    
-    ACTION: rollback_vdb_by_timestamp
-    ----------------------------------------
-    Summary: Rollback a VDB by timestamp.
-    Method: POST
-    Endpoint: /vdbs/{vdbId}/rollback_by_timestamp
-    Required Parameters: vdb_id
-    Key Parameters (provide as applicable): timestamp, timestamp_in_database_timezone, timeflow_id
-    
-    Example:
-        >>> data_tool(action='rollback_vdb_by_timestamp', vdb_id='example-vdb-123', timestamp=..., timestamp_in_database_timezone=..., timeflow_id='example-timeflow-123')
-    
-    ACTION: rollback_vdb_by_snapshot
-    ----------------------------------------
-    Summary: Rollback a VDB by snapshot.
-    Method: POST
-    Endpoint: /vdbs/{vdbId}/rollback_by_snapshot
-    Required Parameters: vdb_id
-    Key Parameters (provide as applicable): snapshot_id
-    
-    Example:
-        >>> data_tool(action='rollback_vdb_by_snapshot', vdb_id='example-vdb-123', snapshot_id='example-snapshot-123')
-    
-    ACTION: rollback_vdb_from_bookmark
-    ----------------------------------------
-    Summary: Rollback a VDB from a bookmark with only the same VDB.
-    Method: POST
-    Endpoint: /vdbs/{vdbId}/rollback_from_bookmark
-    Required Parameters: vdb_id, bookmark_id
-    
-    Example:
-        >>> data_tool(action='rollback_vdb_from_bookmark', vdb_id='example-vdb-123', bookmark_id='example-bookmark-123')
-    
-    ACTION: switch_vdb_timeflow
-    ----------------------------------------
-    Summary: Switches the current timeflow of a VDB.
-    Method: POST
-    Endpoint: /vdbs/{vdbId}/switch_timeflow
-    Required Parameters: vdb_id
-    Key Parameters (provide as applicable): timeflow_id
-    
-    Example:
-        >>> data_tool(action='switch_vdb_timeflow', vdb_id='example-vdb-123', timeflow_id='example-timeflow-123')
-    
-    ACTION: lock_vdb
-    ----------------------------------------
-    Summary: Lock a VDB.
-    Method: POST
-    Endpoint: /vdbs/{vdbId}/lock
-    Required Parameters: vdb_id
-    Key Parameters (provide as applicable): account_id
-    
-    Example:
-        >>> data_tool(action='lock_vdb', vdb_id='example-vdb-123', account_id='example-account-123')
-    
-    ACTION: unlock_vdb
-    ----------------------------------------
-    Summary: Unlock a VDB.
-    Method: POST
-    Endpoint: /vdbs/{vdbId}/unlock
-    Required Parameters: vdb_id
-    
-    Example:
-        >>> data_tool(action='unlock_vdb', vdb_id='example-vdb-123')
-    
-    ACTION: migrate_vdb
-    ----------------------------------------
-    Summary: Migrate a VDB.
-    Method: POST
-    Endpoint: /vdbs/{vdbId}/migrate
-    Required Parameters: vdb_id
-    Key Parameters (provide as applicable): cdb_id, cluster_node_ids, cluster_node_instances, environment_id, repository_id, environment_user_ref
-    
-    Example:
-        >>> data_tool(action='migrate_vdb', vdb_id='example-vdb-123', cdb_id='example-cdb-123', cluster_node_ids=..., cluster_node_instances=..., environment_id='example-environment-123', repository_id='example-repository-123', environment_user_ref=...)
-    
-    ACTION: get_migrate_compatible_repositories
-    ----------------------------------------
-    Summary: Returns a list of compatible repositories for vdb migration.
-    Method: GET
-    Endpoint: /vdbs/{vdbId}/migrate_compatible_repositories
-    Required Parameters: vdb_id
-    
-    Example:
-        >>> data_tool(action='get_migrate_compatible_repositories', vdb_id='example-vdb-123')
-    
-    ACTION: upgrade_vdb
-    ----------------------------------------
-    Summary: Upgrade VDB
-    Method: POST
-    Endpoint: /vdbs/{vdbId}/upgrade
-    Required Parameters: vdb_id, repository_id
-    Key Parameters (provide as applicable): environment_user_id, ppt_repository
-    
-    Example:
-        >>> data_tool(action='upgrade_vdb', vdb_id='example-vdb-123', environment_user_id='example-environment_user-123', repository_id='example-repository-123', ppt_repository=...)
-    
-    ACTION: upgrade_oracle_vdb
-    ----------------------------------------
-    Summary: Upgrade Oracle VDB
-    Method: POST
-    Endpoint: /vdbs/oracle/{vdbId}/upgrade
-    Required Parameters: vdb_id, environment_user_id, repository_id
-    
-    Example:
-        >>> data_tool(action='upgrade_oracle_vdb', vdb_id='example-vdb-123', environment_user_id='example-environment_user-123', repository_id='example-repository-123')
-    
-    ACTION: get_upgrade_compatible_repositories
-    ----------------------------------------
-    Summary: Returns a list of compatible repositories for vdb upgrade.
-    Method: GET
-    Endpoint: /vdbs/{vdbId}/upgrade_compatible_repositories
-    Required Parameters: vdb_id
-    
-    Example:
-        >>> data_tool(action='get_upgrade_compatible_repositories', vdb_id='example-vdb-123')
-    
-    ACTION: list_vdb_snapshots
-    ----------------------------------------
-    Summary: List Snapshots for a VDB.
-    Method: GET
-    Endpoint: /vdbs/{vdbId}/snapshots
-    Required Parameters: limit, cursor, vdb_id
-    
-    Example:
-        >>> data_tool(action='list_vdb_snapshots', limit=..., cursor=..., vdb_id='example-vdb-123')
-    
-    ACTION: snapshot_vdb
-    ----------------------------------------
-    Summary: Snapshot a VDB.
-    Method: POST
-    Endpoint: /vdbs/{vdbId}/snapshots
-    Required Parameters: vdb_id
-    
-    Example:
-        >>> data_tool(action='snapshot_vdb', vdb_id='example-vdb-123')
-    
-    ACTION: list_vdb_bookmarks
-    ----------------------------------------
-    Summary: List Bookmarks compatible with this VDB.
-    Method: GET
-    Endpoint: /vdbs/{vdbId}/bookmarks
-    Required Parameters: limit, cursor, sort, vdb_id
-    
-    Example:
-        >>> data_tool(action='list_vdb_bookmarks', limit=..., cursor=..., sort=..., vdb_id='example-vdb-123')
-    
-    ACTION: search_vdb_bookmarks
-    ----------------------------------------
-    Summary: Search Bookmarks compatible with this VDB.
-    Method: POST
-    Endpoint: /vdbs/{vdbId}/bookmarks/search
-    Required Parameters: limit, cursor, sort, vdb_id
-    Key Parameters (provide as applicable): filter_expression
-    
-    Filterable Fields:
-        - id: The Bookmark object entity ID.
-        - name: The user-defined name of this bookmark.
-        - creation_date: The date and time that this bookmark was created.
-        - data_timestamp: The timestamp for the data that the bookmark refers to.
-        - timeflow_id: The timeflow for the snapshot that the bookmark was creat...
-        - location: The location for the data that the bookmark refers to.
-        - vdb_ids: The list of VDB IDs associated with this bookmark.
-        - dsource_ids: The list of dSource IDs associated with this bookmark.
-        - vdb_group_id: The ID of the VDB group on which bookmark is created.
-        - vdb_group_name: The name of the VDB group on which bookmark is created.
-        - vdbs: The list of VDB IDs and VDB names associated with this bo...
-        - dsources: The list of dSource IDs and dSource names associated with...
-        - paas_databases: The list of PaaS Database IDs and PaaS Database names ass...
-        - paas_instances: The list of PaaS Instance IDs and PaaS Instance names ass...
-        - retention: The retention policy for this bookmark, in days. A value ...
-        - expiration: The expiration for this bookmark. When unset, indicates t...
-        - status: A message with details about operation progress or state ...
-        - replicated_dataset: Whether this bookmark is created from a replicated datase...
-        - bookmark_source: Source of the bookmark, default is DCT. In case of self-s...
-        - bookmark_status: Status of the bookmark. It can have INACTIVE value for en...
-        - ss_data_layout_id: Data-layout Id for engine-managed bookmarks.
-        - ss_bookmark_reference: Engine reference of the self-service bookmark.
-        - ss_bookmark_errors: List of errors if any, during bookmark creation in DCT fr...
-        - bookmark_type: Type of the bookmark, either PUBLIC or PRIVATE.
-        - namespace_id: The namespace id of this bookmark.
-        - namespace_name: The namespace name of this bookmark.
-        - is_replica: Is this a replicated bookmark.
-        - primary_object_id: Id of the parent bookmark from which this bookmark was re...
-        - primary_engine_id: The ID of the parent engine from which replication was done.
-        - primary_engine_name: The name of the parent engine from which replication was ...
-        - primary_bookmark_expiration: The expiration for the primary bookmark.
-        - replicas: The list of replicas replicated from this object.
-        - tags: The tags to be created for this Bookmark.
-    
-    Filter Syntax:
-        Operators: EQ, NE, GT, GE, LT, LE, CONTAINS, IN, NOT_IN
-        Combine: AND, OR
-        Example: "name CONTAINS 'prod' AND status EQ 'RUNNING'"
-    
-    Example:
-        >>> data_tool(action='search_vdb_bookmarks', limit=..., cursor=..., sort=..., filter_expression="name CONTAINS 'test'", vdb_id='example-vdb-123')
-    
-    ACTION: get_vdb_deletion_dependencies
-    ----------------------------------------
-    Summary: Get deletion dependencies of a VDB.
-    Method: GET
-    Endpoint: /vdbs/{vdbId}/deletion-dependencies
-    Required Parameters: vdb_id
-    
-    Example:
-        >>> data_tool(action='get_vdb_deletion_dependencies', vdb_id='example-vdb-123')
-    
-    ACTION: verify_vdb_jdbc_connection
-    ----------------------------------------
-    Summary: Verify JDBC connection string for VDB.
-    Method: POST
-    Endpoint: /vdbs/{vdbId}/jdbc-check
-    Required Parameters: vdb_id, database_username, database_password, jdbc_connection_string
-    
-    Example:
-        >>> data_tool(action='verify_vdb_jdbc_connection', vdb_id='example-vdb-123', database_username=..., database_password=..., jdbc_connection_string=...)
-    
-    ACTION: get_vdb_tags
-    ----------------------------------------
-    Summary: Get tags for a VDB.
-    Method: GET
-    Endpoint: /vdbs/{vdbId}/tags
-    Required Parameters: vdb_id
-    
-    Example:
-        >>> data_tool(action='get_vdb_tags', vdb_id='example-vdb-123')
-    
-    ACTION: add_vdb_tags
-    ----------------------------------------
-    Summary: Create tags for a VDB.
-    Method: POST
-    Endpoint: /vdbs/{vdbId}/tags
-    Required Parameters: vdb_id, tags
-    
-    Example:
-        >>> data_tool(action='add_vdb_tags', vdb_id='example-vdb-123', tags=...)
-    
-    ACTION: export_vdb_in_place
-    ----------------------------------------
-    Summary: Convert a virtual database to a physical database on physical file system.
-    Method: POST
-    Endpoint: /vdbs/{vdbId}/in-place-export
-    Required Parameters: vdb_id
-    Key Parameters (provide as applicable): rman_channels, rman_file_section_size_in_gb, db_unique_name, pdb_name, operations_post_v2_p
-    
-    Example:
-        >>> data_tool(action='export_vdb_in_place', vdb_id='example-vdb-123', rman_channels=..., rman_file_section_size_in_gb=..., db_unique_name=..., pdb_name=..., operations_post_v2_p=...)
-    
-    ACTION: export_vdb_asm_in_place
-    ----------------------------------------
-    Summary: Convert a virtual database to a physical database on Oracle ASM file system.
-    Method: POST
-    Endpoint: /vdbs/{vdbId}/asm-in-place-export
-    Required Parameters: vdb_id, default_data_diskgroup
-    Key Parameters (provide as applicable): rman_channels, rman_file_section_size_in_gb, db_unique_name, pdb_name, operations_post_v2_p, redo_diskgroup
-    
-    Example:
-        >>> data_tool(action='export_vdb_asm_in_place', vdb_id='example-vdb-123', rman_channels=..., rman_file_section_size_in_gb=..., db_unique_name=..., pdb_name=..., operations_post_v2_p=..., default_data_diskgroup=..., redo_diskgroup=...)
-    
-    ACTION: export_vdb_by_snapshot
-    ----------------------------------------
-    Summary: Export a vdb using snapshot to a physical file system
-    Method: POST
-    Endpoint: /vdbs/{vdbId}/export-by-snapshot
-    Required Parameters: vdb_id
-    Key Parameters (provide as applicable): snapshot_id, rman_channels, rman_file_section_size_in_gb
-    
-    Example:
-        >>> data_tool(action='export_vdb_by_snapshot', vdb_id='example-vdb-123', snapshot_id='example-snapshot-123', rman_channels=..., rman_file_section_size_in_gb=...)
-    
-    ACTION: export_vdb_by_timestamp
-    ----------------------------------------
-    Summary: Export a vdb using timestamp to a physical file system
-    Method: POST
-    Endpoint: /vdbs/{vdbId}/export-by-timestamp
-    Required Parameters: vdb_id, timestamp, timeflow_id
-    Key Parameters (provide as applicable): rman_channels, rman_file_section_size_in_gb
-    
-    Example:
-        >>> data_tool(action='export_vdb_by_timestamp', vdb_id='example-vdb-123', timestamp=..., timeflow_id='example-timeflow-123', rman_channels=..., rman_file_section_size_in_gb=...)
-    
-    ACTION: export_vdb_by_location
-    ----------------------------------------
-    Summary: Export a vdb using timeflow location to a physical file system
-    Method: POST
-    Endpoint: /vdbs/{vdbId}/export-by-location
-    Required Parameters: vdb_id, location
-    Key Parameters (provide as applicable): rman_channels, rman_file_section_size_in_gb
-    
-    Example:
-        >>> data_tool(action='export_vdb_by_location', vdb_id='example-vdb-123', location=..., rman_channels=..., rman_file_section_size_in_gb=...)
-    
-    ACTION: export_vdb_from_bookmark
-    ----------------------------------------
-    Summary: Export a vdb using bookmark to physical file system
-    Method: POST
-    Endpoint: /vdbs/{vdbId}/export-from-bookmark
-    Required Parameters: vdb_id, bookmark_id
-    Key Parameters (provide as applicable): rman_channels, rman_file_section_size_in_gb
-    
-    Example:
-        >>> data_tool(action='export_vdb_from_bookmark', vdb_id='example-vdb-123', bookmark_id='example-bookmark-123', rman_channels=..., rman_file_section_size_in_gb=...)
-    
-    ACTION: export_vdb_to_asm_by_snapshot
-    ----------------------------------------
-    Summary: Export a vdb using snapshot to an ASM file system
-    Method: POST
-    Endpoint: /vdbs/{vdbId}/asm-export-by-snapshot
-    Required Parameters: vdb_id, default_data_diskgroup
-    Key Parameters (provide as applicable): snapshot_id, rman_channels, rman_file_section_size_in_gb, redo_diskgroup
-    
-    Example:
-        >>> data_tool(action='export_vdb_to_asm_by_snapshot', vdb_id='example-vdb-123', snapshot_id='example-snapshot-123', rman_channels=..., rman_file_section_size_in_gb=..., default_data_diskgroup=..., redo_diskgroup=...)
-    
-    ACTION: export_vdb_to_asm_by_timestamp
-    ----------------------------------------
-    Summary: Export a vdb using timestamp to an ASM file system
-    Method: POST
-    Endpoint: /vdbs/{vdbId}/asm-export-by-timestamp
-    Required Parameters: vdb_id, timestamp, timeflow_id, default_data_diskgroup
-    Key Parameters (provide as applicable): rman_channels, rman_file_section_size_in_gb, redo_diskgroup
-    
-    Example:
-        >>> data_tool(action='export_vdb_to_asm_by_timestamp', vdb_id='example-vdb-123', timestamp=..., timeflow_id='example-timeflow-123', rman_channels=..., rman_file_section_size_in_gb=..., default_data_diskgroup=..., redo_diskgroup=...)
-    
-    ACTION: export_vdb_to_asm_by_location
-    ----------------------------------------
-    Summary: Export a vdb using SCN to an ASM file system
-    Method: POST
-    Endpoint: /vdbs/{vdbId}/asm-export-by-location
-    Required Parameters: vdb_id, location, default_data_diskgroup
-    Key Parameters (provide as applicable): rman_channels, rman_file_section_size_in_gb, redo_diskgroup
-    
-    Example:
-        >>> data_tool(action='export_vdb_to_asm_by_location', vdb_id='example-vdb-123', location=..., rman_channels=..., rman_file_section_size_in_gb=..., default_data_diskgroup=..., redo_diskgroup=...)
-    
-    ACTION: export_vdb_to_asm_from_bookmark
-    ----------------------------------------
-    Summary: Export a vdb using bookmark to an ASM file system
-    Method: POST
-    Endpoint: /vdbs/{vdbId}/asm-export-from-bookmark
-    Required Parameters: vdb_id, bookmark_id, default_data_diskgroup
-    Key Parameters (provide as applicable): rman_channels, rman_file_section_size_in_gb, redo_diskgroup
-    
-    Example:
-        >>> data_tool(action='export_vdb_to_asm_from_bookmark', vdb_id='example-vdb-123', bookmark_id='example-bookmark-123', rman_channels=..., rman_file_section_size_in_gb=..., default_data_diskgroup=..., redo_diskgroup=...)
-    
-    ACTION: export_cleanup
-    ----------------------------------------
-    Summary: Export cleanup for incremental V2P operation
-    Method: POST
-    Endpoint: /vdbs/{vdbId}/export_cleanup
-    Required Parameters: vdb_id
-    Key Parameters (provide as applicable): cleanup_target_physical_files, cleanup_target_container
-    
-    Example:
-        >>> data_tool(action='export_cleanup', vdb_id='example-vdb-123', cleanup_target_physical_files=..., cleanup_target_container=...)
-    
-    ACTION: export_finalize
-    ----------------------------------------
-    Summary: Finalize operation on incremental V2P export
-    Method: POST
-    Endpoint: /vdbs/{vdbId}/export_finalize
-    Required Parameters: vdb_id
-    Key Parameters (provide as applicable): force, max_allowed_backups_pending_restore
-    
-    Example:
-        >>> data_tool(action='export_finalize', vdb_id='example-vdb-123', force=..., max_allowed_backups_pending_restore=...)
-    
-    ACTION: list_vdb_groups
-    ----------------------------------------
-    Summary: List all VDBGroups.
-    Method: GET
-    Endpoint: /vdb-groups
-    Required Parameters: limit, cursor, sort
-    
-    Example:
-        >>> data_tool(action='list_vdb_groups', limit=..., cursor=..., sort=...)
-    
-    ACTION: search_vdb_groups
-    ----------------------------------------
-    Summary: Search for VDB Groups.
-    Method: POST
-    Endpoint: /vdb-groups/search
-    Required Parameters: limit, cursor, sort
-    Key Parameters (provide as applicable): filter_expression
-    
-    Filterable Fields:
-        - id: A unique identifier for the entity.
-        - name: A unique name for the entity.
-        - vdb_ids: The list of VDB IDs in this VDB Group.
-        - is_locked: Indicates whether the VDB Group is locked.
-        - locked_by: The Id of the account that locked the VDB Group.
-        - locked_by_name: The name of the account that locked the VDB Group.
-        - vdb_group_source: Source of the vdb group, default is DCT. In case of self-...
-        - ss_data_layout_id: Data-layout Id for engine-managed vdb groups.
-        - vdbs: Dictates order of operations on VDBs. Operations can be p...
-        - database_type: The database type of the VDB Group. If all VDBs in the gr...
-        - status: The status of the VDB Group. If all VDBs in the VDB Group...
-        - last_successful_refresh_to_bookmark_id: The bookmark ID to which the VDB Group was last successfu...
-        - last_successful_refresh_time: The time at which the VDB Group was last successfully ref...
-        - tags: 
-    
-    Filter Syntax:
-        Operators: EQ, NE, GT, GE, LT, LE, CONTAINS, IN, NOT_IN
-        Combine: AND, OR
-        Example: "name CONTAINS 'prod' AND status EQ 'RUNNING'"
-    
-    Example:
-        >>> data_tool(action='search_vdb_groups', limit=..., cursor=..., sort=..., filter_expression="name CONTAINS 'test'")
-    
-    ACTION: get_vdb_group
-    ----------------------------------------
-    Summary: Get a VDB Group by name.
-    Method: GET
-    Endpoint: /vdb-groups/{vdbGroupId}
-    Required Parameters: vdb_group_id
-    
-    Example:
-        >>> data_tool(action='get_vdb_group', vdb_group_id='example-vdb_group-123')
-    
-    ACTION: create_vdb_group
-    ----------------------------------------
-    Summary: Create a new VDB Group.
-    Method: POST
-    Endpoint: /vdb-groups
-    Required Parameters: name
-    Key Parameters (provide as applicable): tags, make_current_account_owner, vdb_ids, vdbs, refresh_immediately
-    
-    Example:
-        >>> data_tool(action='create_vdb_group', name=..., tags=..., make_current_account_owner=..., vdb_ids=..., vdbs=..., refresh_immediately=...)
-    
-    ACTION: update_vdb_group
-    ----------------------------------------
-    Summary: Update values of a VDB group.
-    Method: PATCH
-    Endpoint: /vdb-groups/{vdbGroupId}
-    Required Parameters: vdb_group_id
-    Key Parameters (provide as applicable): name, vdb_ids, vdbs, refresh_immediately
-    
-    Example:
-        >>> data_tool(action='update_vdb_group', name=..., vdb_group_id='example-vdb_group-123', vdb_ids=..., vdbs=..., refresh_immediately=...)
-    
-    ACTION: delete_vdb_group
-    ----------------------------------------
-    Summary: Delete a VDBGoup.
-    Method: DELETE
-    Endpoint: /vdb-groups/{vdbGroupId}
-    Required Parameters: vdb_group_id
-    
-    Example:
-        >>> data_tool(action='delete_vdb_group', vdb_group_id='example-vdb_group-123')
-    
-    ACTION: provision_vdb_group_from_bookmark
-    ----------------------------------------
-    Summary: Provision a new VDB Group from a Bookmark.
-    Method: POST
-    Endpoint: /vdb-groups/provision_from_bookmark
-    Required Parameters: name, bookmark_id, provision_parameters
-    Key Parameters (provide as applicable): tags, make_current_account_owner
-    
-    Example:
-        >>> data_tool(action='provision_vdb_group_from_bookmark', name=..., tags=..., make_current_account_owner=..., bookmark_id='example-bookmark-123', provision_parameters=...)
-    
-    ACTION: refresh_vdb_group
-    ----------------------------------------
-    Summary: Refresh a VDB Group from bookmark.
-    Method: POST
-    Endpoint: /vdb-groups/{vdbGroupId}/refresh
-    Required Parameters: bookmark_id, vdb_group_id
-    
-    Example:
-        >>> data_tool(action='refresh_vdb_group', bookmark_id='example-bookmark-123', vdb_group_id='example-vdb_group-123')
-    
-    ACTION: refresh_vdb_group_from_bookmark
-    ----------------------------------------
-    Summary: Refresh a VDB Group from bookmark.
-    Method: POST
-    Endpoint: /vdb-groups/{vdbGroupId}/refresh_from_bookmark
-    Required Parameters: bookmark_id, vdb_group_id
-    
-    Example:
-        >>> data_tool(action='refresh_vdb_group_from_bookmark', bookmark_id='example-bookmark-123', vdb_group_id='example-vdb_group-123')
-    
-    ACTION: refresh_vdb_group_by_snapshot
-    ----------------------------------------
-    Summary: Refresh a VDB Group by snapshot.
-    Method: POST
-    Endpoint: /vdb-groups/{vdbGroupId}/refresh_by_snapshot
-    Required Parameters: vdb_group_id
-    Key Parameters (provide as applicable): vdb_snapshot_mappings
-    
-    Example:
-        >>> data_tool(action='refresh_vdb_group_by_snapshot', vdb_group_id='example-vdb_group-123', vdb_snapshot_mappings=...)
-    
-    ACTION: refresh_vdb_group_by_timestamp
-    ----------------------------------------
-    Summary: Refresh a VDB Group by timestamp.
-    Method: POST
-    Endpoint: /vdb-groups/{vdbGroupId}/refresh_by_timestamp
-    Required Parameters: vdb_group_id
-    Key Parameters (provide as applicable): vdb_timestamp_mappings, is_refresh_to_nearest
-    
-    Example:
-        >>> data_tool(action='refresh_vdb_group_by_timestamp', vdb_group_id='example-vdb_group-123', vdb_timestamp_mappings=..., is_refresh_to_nearest=...)
-    
-    ACTION: rollback_vdb_group
-    ----------------------------------------
-    Summary: Rollback a VDB Group from a bookmark.
-    Method: POST
-    Endpoint: /vdb-groups/{vdbGroupId}/rollback
-    Required Parameters: bookmark_id, vdb_group_id
-    
-    Example:
-        >>> data_tool(action='rollback_vdb_group', bookmark_id='example-bookmark-123', vdb_group_id='example-vdb_group-123')
-    
-    ACTION: lock_vdb_group
-    ----------------------------------------
-    Summary: Lock a VDB Group.
-    Method: POST
-    Endpoint: /vdb-groups/{vdbGroupId}/lock
-    Required Parameters: vdb_group_id
-    Key Parameters (provide as applicable): account_id
-    
-    Example:
-        >>> data_tool(action='lock_vdb_group', account_id='example-account-123', vdb_group_id='example-vdb_group-123')
-    
-    ACTION: unlock_vdb_group
-    ----------------------------------------
-    Summary: Unlock a VDB Group.
-    Method: POST
-    Endpoint: /vdb-groups/{vdbGroupId}/unlock
-    Required Parameters: vdb_group_id
-    
-    Example:
-        >>> data_tool(action='unlock_vdb_group', vdb_group_id='example-vdb_group-123')
-    
-    ACTION: start_vdb_group
-    ----------------------------------------
-    Summary: Start a VDB Group.
-    Method: POST
-    Endpoint: /vdb-groups/{vdbGroupId}/start
-    Required Parameters: vdb_group_id
-    Key Parameters (provide as applicable): vdb_start_param_mappings
-    
-    Example:
-        >>> data_tool(action='start_vdb_group', vdb_group_id='example-vdb_group-123', vdb_start_param_mappings=...)
-    
-    ACTION: stop_vdb_group
-    ----------------------------------------
-    Summary: Stop a VDB Group.
-    Method: POST
-    Endpoint: /vdb-groups/{vdbGroupId}/stop
-    Required Parameters: vdb_group_id
-    Key Parameters (provide as applicable): vdb_stop_param_mappings
-    
-    Example:
-        >>> data_tool(action='stop_vdb_group', vdb_group_id='example-vdb_group-123', vdb_stop_param_mappings=...)
-    
-    ACTION: enable_vdb_group
-    ----------------------------------------
-    Summary: Enable a VDB Group.
-    Method: POST
-    Endpoint: /vdb-groups/{vdbGroupId}/enable
-    Required Parameters: vdb_group_id
-    Key Parameters (provide as applicable): vdb_enable_param_mappings
-    
-    Example:
-        >>> data_tool(action='enable_vdb_group', vdb_group_id='example-vdb_group-123', vdb_enable_param_mappings=...)
-    
-    ACTION: disable_vdb_group
-    ----------------------------------------
-    Summary: Disable a VDB Group.
-    Method: POST
-    Endpoint: /vdb-groups/{vdbGroupId}/disable
-    Required Parameters: vdb_group_id
-    Key Parameters (provide as applicable): vdb_disable_param_mappings
-    
-    Example:
-        >>> data_tool(action='disable_vdb_group', vdb_group_id='example-vdb_group-123', vdb_disable_param_mappings=...)
-    
-    ACTION: get_vdb_group_latest_snapshots
-    ----------------------------------------
-    Summary: Get latest snapshot of all the vdbs in VDB Group.
-    Method: GET
-    Endpoint: /vdb-groups/{vdbGroupId}/latest-snapshots
-    Required Parameters: vdb_group_id
-    
-    Example:
-        >>> data_tool(action='get_vdb_group_latest_snapshots', vdb_group_id='example-vdb_group-123')
-    
-    ACTION: get_vdb_group_timestamp_summary
-    ----------------------------------------
-    Summary: Get timestamp summary of all the vdbs in VDB Group.
-    Method: POST
-    Endpoint: /vdb-groups/{vdbGroupId}/timestamp-summary
-    Required Parameters: vdb_group_id
-    Key Parameters (provide as applicable): timestamp, vdb_ids, mode
-    
-    Example:
-        >>> data_tool(action='get_vdb_group_timestamp_summary', timestamp=..., vdb_group_id='example-vdb_group-123', vdb_ids=..., mode=...)
-    
-    ACTION: list_vdb_group_bookmarks
-    ----------------------------------------
-    Summary: List bookmarks compatible with this VDB Group.
-    Method: GET
-    Endpoint: /vdb-groups/{vdbGroupId}/bookmarks
-    Required Parameters: limit, cursor, sort, vdb_group_id
-    
-    Example:
-        >>> data_tool(action='list_vdb_group_bookmarks', limit=..., cursor=..., sort=..., vdb_group_id='example-vdb_group-123')
-    
-    ACTION: search_vdb_group_bookmarks
-    ----------------------------------------
-    Summary: Search for bookmarks compatible with this VDB Group.
-    Method: POST
-    Endpoint: /vdb-groups/{vdbGroupId}/bookmarks/search
-    Required Parameters: limit, cursor, sort, vdb_group_id
-    Key Parameters (provide as applicable): filter_expression
-    
-    Filterable Fields:
-        - id: The Bookmark object entity ID.
-        - name: The user-defined name of this bookmark.
-        - creation_date: The date and time that this bookmark was created.
-        - data_timestamp: The timestamp for the data that the bookmark refers to.
-        - timeflow_id: The timeflow for the snapshot that the bookmark was creat...
-        - location: The location for the data that the bookmark refers to.
-        - vdb_ids: The list of VDB IDs associated with this bookmark.
-        - dsource_ids: The list of dSource IDs associated with this bookmark.
-        - vdb_group_id: The ID of the VDB group on which bookmark is created.
-        - vdb_group_name: The name of the VDB group on which bookmark is created.
-        - vdbs: The list of VDB IDs and VDB names associated with this bo...
-        - dsources: The list of dSource IDs and dSource names associated with...
-        - paas_databases: The list of PaaS Database IDs and PaaS Database names ass...
-        - paas_instances: The list of PaaS Instance IDs and PaaS Instance names ass...
-        - retention: The retention policy for this bookmark, in days. A value ...
-        - expiration: The expiration for this bookmark. When unset, indicates t...
-        - status: A message with details about operation progress or state ...
-        - replicated_dataset: Whether this bookmark is created from a replicated datase...
-        - bookmark_source: Source of the bookmark, default is DCT. In case of self-s...
-        - bookmark_status: Status of the bookmark. It can have INACTIVE value for en...
-        - ss_data_layout_id: Data-layout Id for engine-managed bookmarks.
-        - ss_bookmark_reference: Engine reference of the self-service bookmark.
-        - ss_bookmark_errors: List of errors if any, during bookmark creation in DCT fr...
-        - bookmark_type: Type of the bookmark, either PUBLIC or PRIVATE.
-        - namespace_id: The namespace id of this bookmark.
-        - namespace_name: The namespace name of this bookmark.
-        - is_replica: Is this a replicated bookmark.
-        - primary_object_id: Id of the parent bookmark from which this bookmark was re...
-        - primary_engine_id: The ID of the parent engine from which replication was done.
-        - primary_engine_name: The name of the parent engine from which replication was ...
-        - primary_bookmark_expiration: The expiration for the primary bookmark.
-        - replicas: The list of replicas replicated from this object.
-        - tags: The tags to be created for this Bookmark.
-    
-    Filter Syntax:
-        Operators: EQ, NE, GT, GE, LT, LE, CONTAINS, IN, NOT_IN
-        Combine: AND, OR
-        Example: "name CONTAINS 'prod' AND status EQ 'RUNNING'"
-    
-    Example:
-        >>> data_tool(action='search_vdb_group_bookmarks', limit=..., cursor=..., sort=..., filter_expression="name CONTAINS 'test'", vdb_group_id='example-vdb_group-123')
-    
-    ACTION: get_vdb_group_tags
-    ----------------------------------------
-    Summary: Get tags for a VDB Group.
-    Method: GET
-    Endpoint: /vdb-groups/{vdbGroupId}/tags
-    Required Parameters: vdb_group_id
-    
-    Example:
-        >>> data_tool(action='get_vdb_group_tags', vdb_group_id='example-vdb_group-123')
-    
-    ACTION: add_vdb_group_tags
-    ----------------------------------------
-    Summary: Create tags for a VDB Group.
-    Method: POST
-    Endpoint: /vdb-groups/{vdbGroupId}/tags
-    Required Parameters: tags, vdb_group_id
-    
-    Example:
-        >>> data_tool(action='add_vdb_group_tags', tags=..., vdb_group_id='example-vdb_group-123')
-    
-    ACTION: list_dsources
-    ----------------------------------------
-    Summary: List all dSources.
-    Method: GET
-    Endpoint: /dsources
-    Required Parameters: limit, cursor, sort, permission
-    
-    Example:
-        >>> data_tool(action='list_dsources', limit=..., cursor=..., sort=..., permission=...)
-    
-    ACTION: search_dsources
-    ----------------------------------------
-    Summary: Search for dSources.
-    Method: POST
-    Endpoint: /dsources/search
-    Required Parameters: limit, cursor, sort, permission
-    Key Parameters (provide as applicable): filter_expression
-    
-    Filterable Fields:
-        - id: The dSource object entity ID.
-        - database_type: The database type of this dSource.
-        - name: The container name of this dSource.
-        - description: The container description of this dSource.
-        - namespace_id: The namespace id of this dSource.
-        - namespace_name: The namespace name of this dSource.
-        - is_replica: Is this a replicated object.
-        - database_version: The database version of this dSource.
-        - content_type: The content type of the dSource.
-        - data_uuid: A universal ID that uniquely identifies the dSource datab...
-        - storage_size: The actual space used by this dSource, in bytes.
-        - plugin_version: The version of the plugin associated with this source dat...
-        - creation_date: The date this dSource was created.
-        - group_name: The name of the group containing this dSource.
-        - enabled: A value indicating whether this dSource is enabled.
-        - is_detached: A value indicating whether this dSource is detached.
-        - engine_id: A reference to the Engine that this dSource belongs to.
-        - source_id: A reference to the Source associated with this dSource.
-        - staging_source_id: A reference to the Staging Source associated with this dS...
-        - status: The runtime status of the dSource. 'Unknown' if all attem...
-        - engine_name: Name of the Engine where this DSource is hosted
-        - cdb_id: A reference to the CDB associated with this dSource.
-        - current_timeflow_id: A reference to the currently active timeflow for this dSo...
-        - previous_timeflow_id: A reference to the previous timeflow for this dSource.
-        - is_appdata: Indicates whether this dSource has an AppData database.
-        - toolkit_id: The ID of the toolkit associated with this dSource(AppDat...
-        - unvirtualized_space: This is the sum of unvirtualized space from the dependant...
-        - dependant_vdbs: The number of VDBs that are dependant on this dSource. Th...
-        - appdata_source_params: The JSON payload conforming to the DraftV4 schema based o...
-        - appdata_config_params: The parameters specified by the source config schema in t...
-        - tags: 
-        - primary_object_id: The ID of the parent object from which replication was done.
-        - primary_engine_id: The ID of the parent engine from which replication was done.
-        - primary_engine_name: The name of the parent engine from which replication was ...
-        - replicas: The list of replicas replicated from this object.
-        - hooks: 
-        - sync_policy_id: The id of the snapshot policy associated with this dSource.
-        - retention_policy_id: The id of the retention policy associated with this dSource.
-        - replica_retention_policy_id: The id of the replica retention policy associated with th...
-        - quota_policy_id: The id of the quota policy associated with this dSource.
-        - logsync_enabled: True if LogSync is enabled for this dSource.
-        - logsync_mode: 
-        - logsync_interval: Interval between LogSync requests, in seconds.
-        - exported_data_directory: ZFS exported data directory path.
-        - template_id: A reference to the Non Virtual Database Template.
-        - allow_auto_staging_restart_on_host_reboot: Indicates whether Delphix should automatically restart th...
-        - physical_standby: Indicates whether this staging database is configured as ...
-        - validate_by_opening_db_in_read_only_mode: Indicates whether this staging database snapshot is valid...
-        - mssql_sync_strategy_managed_type: 
-        - validated_sync_mode: Specifies the backup types ValidatedSync will use to sync...
-        - shared_backup_locations: Shared source database backup locations.
-        - backup_policy: Specify which node of an availability group to run the co...
-        - compression_enabled: Specify whether the backups taken should be compressed or...
-        - staging_database_name: The name of the staging database
-        - db_state: User provided db state that is used to create staging pus...
-        - encryption_key: The encryption key to use when restoring encrypted backups.
-        - external_netbackup_config_master_name: The master server name of this NetBackup configuration.
-        - external_netbackup_config_source_client_name: The source's client server name of this NetBackup configu...
-        - external_netbackup_config_params: NetBackup configuration parameter overrides.
-        - external_netbackup_config_templates: Optional config template selection for NetBackup configur...
-        - external_commserve_host_name: The commserve host name of this Commvault configuration.
-        - external_commvault_config_source_client_name: The source client name of this Commvault configuration.
-        - external_commvault_config_staging_client_name: The staging client name of this Commvault configuration.
-        - external_commvault_config_params: Commvault configuration parameter overrides.
-        - external_commvault_config_templates: Optional config template selection for Commvault configur...
-        - mssql_user_type: Database user type for Database authentication.
-        - domain_user_credential_type: credential types.
-        - mssql_database_username: The database user name for database user type.
-        - mssql_user_environment_reference: The name or reference of the environment user for environ...
-        - mssql_user_domain_username: Domain User name for password credentials.
-        - mssql_user_domain_vault_username: Delphix display name for the vault user.
-        - mssql_user_domain_vault: The name or reference of the vault.
-        - mssql_user_domain_hashicorp_vault_engine: Vault engine name where the credential is stored.
-        - mssql_user_domain_hashicorp_vault_secret_path: Path in the vault engine where the credential is stored.
-        - mssql_user_domain_hashicorp_vault_username_key: Hashicorp vault key for the username in the key-value store.
-        - mssql_user_domain_hashicorp_vault_secret_key: Hashicorp vault key for the password in the key-value store.
-        - mssql_user_domain_azure_vault_name: Azure key vault name.
-        - mssql_user_domain_azure_vault_username_key: Azure vault key in the key-value store.
-        - mssql_user_domain_azure_vault_secret_key: Azure vault key in the key-value store.
-        - mssql_user_domain_cyberark_vault_query_string: Query to find a credential in the CyberArk vault.
-        - diagnose_no_logging_faults: If true, NOLOGGING operations on this container are treat...
-        - pre_provisioning_enabled: If true, pre-provisioning will be performed after every s...
-        - backup_level_enabled: Boolean value indicates whether LEVEL-based incremental b...
-        - rman_channels: Number of parallel channels to use.
-        - files_per_set: Number of data files to include in each RMAN backup set.
-        - check_logical: True if extended block checking should be used for this l...
-        - encrypted_linking_enabled: True if SnapSync data from the source should be retrieved...
-        - compressed_linking_enabled: True if SnapSync data from the source should be compresse...
-        - bandwidth_limit: Bandwidth limit (MB/s) for SnapSync and LogSync network t...
-        - number_of_connections: Total number of transport connections to use during SnapS...
-        - data_connection_id: The ID of the associated DataConnection.
-    
-    Filter Syntax:
-        Operators: EQ, NE, GT, GE, LT, LE, CONTAINS, IN, NOT_IN
-        Combine: AND, OR
-        Example: "name CONTAINS 'prod' AND status EQ 'RUNNING'"
-    
-    Example:
-        >>> data_tool(action='search_dsources', limit=..., cursor=..., sort=..., permission=..., filter_expression="name CONTAINS 'test'")
-    
-    ACTION: get_dsource
-    ----------------------------------------
-    Summary: Get a dSource by ID.
-    Method: GET
-    Endpoint: /dsources/{dsourceId}
-    Required Parameters: dsource_id
-    
-    Example:
-        >>> data_tool(action='get_dsource', dsource_id='example-dsource-123')
-    
-    ACTION: delete_dsource
-    ----------------------------------------
-    Summary: Delete the specified dSource.
-    Method: POST
-    Endpoint: /dsources/delete
-    Required Parameters: dsource_id
-    Key Parameters (provide as applicable): force, delete_all_dependent_vdbs, oracle_username, oracle_password
-    
-    Example:
-        >>> data_tool(action='delete_dsource', force=..., delete_all_dependent_vdbs=..., dsource_id='example-dsource-123', oracle_username=..., oracle_password=...)
-    
-    ACTION: enable_dsource
-    ----------------------------------------
-    Summary: Enable a dSource.
-    Method: POST
-    Endpoint: /dsources/{dsourceId}/enable
-    Required Parameters: dsource_id
-    Key Parameters (provide as applicable): attempt_start
-    
-    Example:
-        >>> data_tool(action='enable_dsource', attempt_start=..., dsource_id='example-dsource-123')
-    
-    ACTION: disable_dsource
-    ----------------------------------------
-    Summary: Disable a dSource.
-    Method: POST
-    Endpoint: /dsources/{dsourceId}/disable
-    Required Parameters: dsource_id
-    Key Parameters (provide as applicable): attempt_cleanup
-    
-    Example:
-        >>> data_tool(action='disable_dsource', attempt_cleanup=..., dsource_id='example-dsource-123')
-    
-    ACTION: list_dsource_snapshots
-    ----------------------------------------
-    Summary: List Snapshots for a dSource.
-    Method: GET
-    Endpoint: /dsources/{dsourceId}/snapshots
-    Required Parameters: limit, cursor, dsource_id
-    
-    Example:
-        >>> data_tool(action='list_dsource_snapshots', limit=..., cursor=..., dsource_id='example-dsource-123')
-    
-    ACTION: dsource_create_snapshot
-    ----------------------------------------
-    Summary: Snapshot a dSource.
-    Method: POST
-    Endpoint: /dsources/{dsourceId}/snapshots
-    Required Parameters: dsource_id
-    Key Parameters (provide as applicable): drop_and_recreate_devices, sync_strategy, ase_backup_files, mssql_backup_uuid, compression_enabled, availability_group_backup_policy, do_not_resume, double_sync, force_full_backup, skip_space_check, files_for_partial_full_backup, appdata_parameters, rman_rate_in__m_b
-    
-    Example:
-        >>> data_tool(action='dsource_create_snapshot', dsource_id='example-dsource-123', drop_and_recreate_devices=..., sync_strategy=..., ase_backup_files=..., mssql_backup_uuid=..., compression_enabled=..., availability_group_backup_policy=..., do_not_resume=..., double_sync=..., force_full_backup=..., skip_space_check=..., files_for_partial_full_backup=..., appdata_parameters=..., rman_rate_in__m_b=...)
-    
-    ACTION: upgrade_dsource
-    ----------------------------------------
-    Summary: Upgrade dSource
-    Method: POST
-    Endpoint: /dsources/{dsourceId}/upgrade
-    Required Parameters: repository_id, dsource_id
-    Key Parameters (provide as applicable): environment_user_id, ppt_repository
-    
-    Example:
-        >>> data_tool(action='upgrade_dsource', environment_user_id='example-environment_user-123', repository_id='example-repository-123', ppt_repository=..., dsource_id='example-dsource-123')
-    
-    ACTION: get_dsource_upgrade_compatible_repositories
-    ----------------------------------------
-    Summary: Returns a list of compatible repositories for dSource upgrade.
-    Method: GET
-    Endpoint: /dsources/{dsourceId}/upgrade_compatible_repositories
-    Required Parameters: dsource_id
-    
-    Example:
-        >>> data_tool(action='get_dsource_upgrade_compatible_repositories', dsource_id='example-dsource-123')
-    
-    ACTION: get_dsource_deletion_dependencies
-    ----------------------------------------
-    Summary: Get deletion dependencies for a dSource.
-    Method: GET
-    Endpoint: /dsources/{dsourceId}/deletion-dependencies
-    Required Parameters: dsource_id
-    
-    Example:
-        >>> data_tool(action='get_dsource_deletion_dependencies', dsource_id='example-dsource-123')
-    
-    ACTION: get_dsource_tags
-    ----------------------------------------
-    Summary: Get tags for a dSource.
-    Method: GET
-    Endpoint: /dsources/{dsourceId}/tags
-    Required Parameters: dsource_id
-    
-    Example:
-        >>> data_tool(action='get_dsource_tags', dsource_id='example-dsource-123')
-    
-    ACTION: add_dsource_tags
-    ----------------------------------------
-    Summary: Create tags for a dSource.
-    Method: POST
-    Endpoint: /dsources/{dsourceId}/tags
-    Required Parameters: tags, dsource_id
-    
-    Example:
-        >>> data_tool(action='add_dsource_tags', tags=..., dsource_id='example-dsource-123')
-    
-    ACTION: delete_dsource_tags
-    ----------------------------------------
-    Summary: Delete tags for a dSource.
-    Method: POST
-    Endpoint: /dsources/{dsourceId}/tags/delete
-    Required Parameters: dsource_id
-    Key Parameters (provide as applicable): tags, key, value
-    
-    Example:
-        >>> data_tool(action='delete_dsource_tags', tags=..., dsource_id='example-dsource-123', key=..., value=...)
-    
-    ACTION: dsource_link_oracle
-    ----------------------------------------
-    Summary: Link Oracle database as dSource.
-    Method: POST
-    Endpoint: /dsources/oracle
-    Key Parameters (provide as applicable): environment_user_id, rman_channels, do_not_resume, double_sync, force_full_backup, skip_space_check, rman_rate_in__m_b, external_file_path, backup_level_enabled, files_per_set, check_logical, encrypted_linking_enabled, compressed_linking_enabled, bandwidth_limit, number_of_connections, diagnose_no_logging_faults, pre_provisioning_enabled, link_now, files_for_full_backup, log_sync_mode, log_sync_interval, non_sys_username, non_sys_password, non_sys_vault_username, non_sys_vault, non_sys_hashicorp_vault_engine, non_sys_hashicorp_vault_secret_path, non_sys_hashicorp_vault_username_key, non_sys_hashicorp_vault_secret_key, non_sys_azure_vault_name, non_sys_azure_vault_username_key, non_sys_azure_vault_secret_key, non_sys_cyberark_vault_query_string, fallback_username, fallback_password, fallback_vault_username, fallback_vault, fallback_hashicorp_vault_engine, fallback_hashicorp_vault_secret_path, fallback_hashicorp_vault_username_key, fallback_hashicorp_vault_secret_key, fallback_azure_vault_name, fallback_azure_vault_username_key, fallback_azure_vault_secret_key, fallback_cyberark_vault_query_string, ops_pre_log_sync
-    
-    Example:
-        >>> data_tool(action='dsource_link_oracle', environment_user_id='example-environment_user-123', rman_channels=..., do_not_resume=..., double_sync=..., force_full_backup=..., skip_space_check=..., rman_rate_in__m_b=..., external_file_path=..., backup_level_enabled=..., files_per_set=..., check_logical=..., encrypted_linking_enabled=..., compressed_linking_enabled=..., bandwidth_limit=..., number_of_connections=..., diagnose_no_logging_faults=..., pre_provisioning_enabled=..., link_now=..., files_for_full_backup=..., log_sync_mode=..., log_sync_interval=..., non_sys_username=..., non_sys_password=..., non_sys_vault_username=..., non_sys_vault=..., non_sys_hashicorp_vault_engine=..., non_sys_hashicorp_vault_secret_path=..., non_sys_hashicorp_vault_username_key=..., non_sys_hashicorp_vault_secret_key=..., non_sys_azure_vault_name=..., non_sys_azure_vault_username_key=..., non_sys_azure_vault_secret_key=..., non_sys_cyberark_vault_query_string=..., fallback_username=..., fallback_password=..., fallback_vault_username=..., fallback_vault=..., fallback_hashicorp_vault_engine=..., fallback_hashicorp_vault_secret_path=..., fallback_hashicorp_vault_username_key=..., fallback_hashicorp_vault_secret_key=..., fallback_azure_vault_name=..., fallback_azure_vault_username_key=..., fallback_azure_vault_secret_key=..., fallback_cyberark_vault_query_string=..., ops_pre_log_sync=...)
-    
-    ACTION: dsource_link_oracle_defaults
-    ----------------------------------------
-    Summary: Get defaults for dSource linking.
-    Method: POST
-    Endpoint: /dsources/oracle/defaults
-    Required Parameters: source_id
-    
-    Example:
-        >>> data_tool(action='dsource_link_oracle_defaults', source_id='example-source-123')
-    
-    ACTION: dsource_link_oracle_staging_push
-    ----------------------------------------
-    Summary: Link an Oracle staging push database as dSource.
-    Method: POST
-    Endpoint: /dsources/oracle/staging-push
-    Key Parameters (provide as applicable): environment_user_id, template_id, database_name, tde_keystore_config_type, engine_id, mount_base, ops_pre_log_sync, container_type, repository, database_unique_name, sid, custom_env_variables_pairs, custom_env_variables_paths, auto_staging_restart, allow_auto_staging_restart_on_host_reboot, physical_standby, validate_snapshot_in_readonly, validate_by_opening_db_in_read_only_mode, staging_database_templates, staging_database_config_params, staging_container_database_reference
-    
-    Example:
-        >>> data_tool(action='dsource_link_oracle_staging_push', environment_user_id='example-environment_user-123', template_id='example-template-123', database_name=..., tde_keystore_config_type=..., engine_id='example-engine-123', mount_base=..., ops_pre_log_sync=..., container_type=..., repository=..., database_unique_name=..., sid=..., custom_env_variables_pairs=..., custom_env_variables_paths=..., auto_staging_restart=..., allow_auto_staging_restart_on_host_reboot=..., physical_standby=..., validate_snapshot_in_readonly=..., validate_by_opening_db_in_read_only_mode=..., staging_database_templates=..., staging_database_config_params=..., staging_container_database_reference=...)
-    
-    ACTION: dsource_link_oracle_staging_push_defaults
-    ----------------------------------------
-    Summary: Get defaults for a Oracle staging push dSource linking.
-    Method: POST
-    Endpoint: /dsources/oracle/staging-push/defaults
-    Required Parameters: environment_id
-    Key Parameters (provide as applicable): container_type
-    
-    Example:
-        >>> data_tool(action='dsource_link_oracle_staging_push_defaults', environment_id='example-environment-123', container_type=...)
-    
-    ACTION: update_oracle_dsource
-    ----------------------------------------
-    Summary: Update values of an Oracle dSource
-    Method: PATCH
-    Endpoint: /dsources/oracle/{dsourceId}
-    Required Parameters: dsource_id
-    Key Parameters (provide as applicable): name, description, db_username, db_password, validate_db_credentials, environment_user_id, template_id, hooks, rman_channels, external_file_path, backup_level_enabled, files_per_set, check_logical, encrypted_linking_enabled, compressed_linking_enabled, bandwidth_limit, number_of_connections, diagnose_no_logging_faults, pre_provisioning_enabled, non_sys_username, non_sys_password, repository, custom_env_variables_pairs, custom_env_variables_paths, allow_auto_staging_restart_on_host_reboot, physical_standby, validate_by_opening_db_in_read_only_mode, staging_database_config_params, rac_max_instance_lag, logsync_enabled, logsync_mode, logsync_interval
-    
-    Example:
-        >>> data_tool(action='update_oracle_dsource', name=..., description=..., db_username=..., db_password=..., validate_db_credentials=..., environment_user_id='example-environment_user-123', template_id='example-template-123', hooks=..., rman_channels=..., dsource_id='example-dsource-123', external_file_path=..., backup_level_enabled=..., files_per_set=..., check_logical=..., encrypted_linking_enabled=..., compressed_linking_enabled=..., bandwidth_limit=..., number_of_connections=..., diagnose_no_logging_faults=..., pre_provisioning_enabled=..., non_sys_username=..., non_sys_password=..., repository=..., custom_env_variables_pairs=..., custom_env_variables_paths=..., allow_auto_staging_restart_on_host_reboot=..., physical_standby=..., validate_by_opening_db_in_read_only_mode=..., staging_database_config_params=..., rac_max_instance_lag=..., logsync_enabled=..., logsync_mode=..., logsync_interval=...)
-    
-    ACTION: attach_oracle_dsource
-    ----------------------------------------
-    Summary: Attach an Oracle dSource to an Oracle database.
-    Method: POST
-    Endpoint: /dsources/oracle/{dsourceId}/attachSource
-    Required Parameters: dsource_id, source_id
-    
-    Example:
-        >>> data_tool(action='attach_oracle_dsource', dsource_id='example-dsource-123', source_id='example-source-123')
-    
-    ACTION: detach_oracle_dsource
-    ----------------------------------------
-    Summary: Detaches an Oracle source from an Oracle database.
-    Method: POST
-    Endpoint: /dsources/oracle/{dsourceId}/detachSource
-    Required Parameters: dsource_id
-    
-    Example:
-        >>> data_tool(action='detach_oracle_dsource', dsource_id='example-dsource-123')
-    
-    ACTION: upgrade_oracle_dsource
-    ----------------------------------------
-    Summary: Upgrade the requested Oracle dSource installation and user.
-    Method: POST
-    Endpoint: /dsources/oracle/{dsourceId}/upgrade
-    Required Parameters: environment_user_id, repository_id, dsource_id
-    
-    Example:
-        >>> data_tool(action='upgrade_oracle_dsource', environment_user_id='example-environment_user-123', repository_id='example-repository-123', dsource_id='example-dsource-123')
-    
-    ACTION: dsource_link_ase
-    ----------------------------------------
-    Summary: Link an ASE database as dSource.
-    Method: POST
-    Endpoint: /dsources/ase
-    Key Parameters (provide as applicable): db_password, mount_base, drop_and_recreate_devices, sync_strategy, ase_backup_files, external_file_path, load_backup_path, backup_server_name, backup_host_user, backup_host, dump_credentials, source_host_user, db_user, db_vault_username, db_vault, db_hashicorp_vault_engine, db_hashicorp_vault_secret_path, db_hashicorp_vault_username_key, db_hashicorp_vault_secret_key, db_azure_vault_name, db_azure_vault_username_key, db_azure_vault_secret_key, db_cyberark_vault_query_string, staging_repository, staging_host_user, validated_sync_mode, dump_history_file_enabled, pre_validated_sync, post_validated_sync
-    
-    Example:
-        >>> data_tool(action='dsource_link_ase', db_password=..., mount_base=..., drop_and_recreate_devices=..., sync_strategy=..., ase_backup_files=..., external_file_path=..., load_backup_path=..., backup_server_name=..., backup_host_user=..., backup_host=..., dump_credentials=..., source_host_user=..., db_user=..., db_vault_username=..., db_vault=..., db_hashicorp_vault_engine=..., db_hashicorp_vault_secret_path=..., db_hashicorp_vault_username_key=..., db_hashicorp_vault_secret_key=..., db_azure_vault_name=..., db_azure_vault_username_key=..., db_azure_vault_secret_key=..., db_cyberark_vault_query_string=..., staging_repository=..., staging_host_user=..., validated_sync_mode=..., dump_history_file_enabled=..., pre_validated_sync=..., post_validated_sync=...)
-    
-    ACTION: dsource_link_ase_defaults
-    ----------------------------------------
-    Summary: Get defaults for an ASE dSource linking.
-    Method: POST
-    Endpoint: /dsources/ase/defaults
-    Required Parameters: source_id
-    
-    Example:
-        >>> data_tool(action='dsource_link_ase_defaults', source_id='example-source-123')
-    
-    ACTION: update_ase_dsource
-    ----------------------------------------
-    Summary: Update values of an ASE dSource
-    Method: PATCH
-    Endpoint: /dsources/ase/{dsourceId}
-    Required Parameters: dsource_id
-    Key Parameters (provide as applicable): name, description, hooks, retention_policy_id, sync_policy_id
-    
-    Example:
-        >>> data_tool(action='update_ase_dsource', name=..., description=..., hooks=..., retention_policy_id='example-retention_policy-123', dsource_id='example-dsource-123', sync_policy_id='example-sync_policy-123')
-    
-    ACTION: dsource_link_appdata
-    ----------------------------------------
-    Summary: Link an AppData database as dSource.
-    Method: POST
-    Endpoint: /dsources/appdata
-    Key Parameters (provide as applicable): environment_user, link_type, staging_mount_base, staging_environment, staging_environment_user, excludes, follow_symlinks, parameters, sync_parameters
-    
-    Example:
-        >>> data_tool(action='dsource_link_appdata', environment_user=..., link_type=..., staging_mount_base=..., staging_environment=..., staging_environment_user=..., excludes=..., follow_symlinks=..., parameters=..., sync_parameters=...)
-    
-        IMPORTANT — AppData toolkit schema: Before populating toolkit-specific parameters, call toolkit_tool(action='search') to list available toolkits. Filter results by the engine_id of the environment you are operating on — use only toolkits whose engine_id matches.
-    Use the matching toolkit's 'linked_source_definition.parameters' schema to populate 'parameters', and 'snapshot_parameters_definition' for 'sync_parameters'.
-    
-    ACTION: dsource_link_appdata_defaults
-    ----------------------------------------
-    Summary: Get defaults for an AppData dSource linking.
-    Method: POST
-    Endpoint: /dsources/appdata/defaults
-    Required Parameters: source_id
-    
-    Example:
-        >>> data_tool(action='dsource_link_appdata_defaults', source_id='example-source-123')
-    
-        IMPORTANT — AppData toolkit schema: Before populating toolkit-specific parameters, call toolkit_tool(action='search') to list available toolkits. Filter results by the engine_id of the environment you are operating on — use only toolkits whose engine_id matches.
-    Use the matching toolkit's 'linked_source_definition.parameters' schema to populate 'parameters', and 'snapshot_parameters_definition' for 'sync_parameters'.
-    
-    ACTION: update_appdata_dsource
-    ----------------------------------------
-    Summary: Update values of an AppData dSource
-    Method: PATCH
-    Endpoint: /dsources/appdata/{dsourceId}
-    Required Parameters: dsource_id
-    Key Parameters (provide as applicable): name, description, hooks, retention_policy_id, sync_policy_id, ops_pre_sync, ops_post_sync, environment_user, staging_environment, staging_environment_user, parameters
-    
-    Example:
-        >>> data_tool(action='update_appdata_dsource', name=..., description=..., hooks=..., retention_policy_id='example-retention_policy-123', dsource_id='example-dsource-123', sync_policy_id='example-sync_policy-123', ops_pre_sync=..., ops_post_sync=..., environment_user=..., staging_environment=..., staging_environment_user=..., parameters=...)
-    
-        IMPORTANT — AppData toolkit schema: Before populating toolkit-specific parameters, call toolkit_tool(action='search') to list available toolkits. Filter results by the engine_id of the environment you are operating on — use only toolkits whose engine_id matches.
-    Use the matching toolkit's 'linked_source_definition.parameters' schema to populate 'parameters', and 'snapshot_parameters_definition' for 'sync_parameters'.
-    
-    ACTION: dsource_link_mssql
-    ----------------------------------------
-    Summary: Link a MSSql database as dSource.
-    Method: POST
-    Endpoint: /dsources/mssql
-    Key Parameters (provide as applicable): ppt_repository, sync_strategy, mssql_backup_uuid, compression_enabled, availability_group_backup_policy, source_host_user, encryption_key, ppt_host_user, staging_pre_script, staging_post_script, sync_strategy_managed_type, mssql_user_environment_reference, mssql_user_domain_username, mssql_user_domain_password, mssql_user_domain_vault_username, mssql_user_domain_vault, mssql_user_domain_hashicorp_vault_engine, mssql_user_domain_hashicorp_vault_secret_path, mssql_user_domain_hashicorp_vault_username_key, mssql_user_domain_hashicorp_vault_secret_key, mssql_user_domain_azure_vault_name, mssql_user_domain_azure_vault_username_key, mssql_user_domain_azure_vault_secret_key, mssql_user_domain_cyberark_vault_query_string, mssql_database_username, mssql_database_password, delphix_managed_backup_compression_enabled, delphix_managed_backup_policy, external_managed_validate_sync_mode, external_managed_shared_backup_locations, external_netbackup_config_master_name, external_netbackup_config_source_client_name, external_netbackup_config_params, external_netbackup_config_templates, external_commserve_host_name, external_commvault_config_source_client_name, external_commvault_config_staging_client_name, external_commvault_config_params, external_commvault_config_templates
-    
-    Example:
-        >>> data_tool(action='dsource_link_mssql', ppt_repository=..., sync_strategy=..., mssql_backup_uuid=..., compression_enabled=..., availability_group_backup_policy=..., source_host_user=..., encryption_key=..., ppt_host_user=..., staging_pre_script=..., staging_post_script=..., sync_strategy_managed_type=..., mssql_user_environment_reference=..., mssql_user_domain_username=..., mssql_user_domain_password=..., mssql_user_domain_vault_username=..., mssql_user_domain_vault=..., mssql_user_domain_hashicorp_vault_engine=..., mssql_user_domain_hashicorp_vault_secret_path=..., mssql_user_domain_hashicorp_vault_username_key=..., mssql_user_domain_hashicorp_vault_secret_key=..., mssql_user_domain_azure_vault_name=..., mssql_user_domain_azure_vault_username_key=..., mssql_user_domain_azure_vault_secret_key=..., mssql_user_domain_cyberark_vault_query_string=..., mssql_database_username=..., mssql_database_password=..., delphix_managed_backup_compression_enabled=..., delphix_managed_backup_policy=..., external_managed_validate_sync_mode=..., external_managed_shared_backup_locations=..., external_netbackup_config_master_name=..., external_netbackup_config_source_client_name=..., external_netbackup_config_params=..., external_netbackup_config_templates=..., external_commserve_host_name=..., external_commvault_config_source_client_name=..., external_commvault_config_staging_client_name=..., external_commvault_config_params=..., external_commvault_config_templates=...)
-    
-    ACTION: dsource_link_mssql_defaults
-    ----------------------------------------
-    Summary: Get defaults for a MSSql dSource linking.
-    Method: POST
-    Endpoint: /dsources/mssql/defaults
-    Required Parameters: source_id
-    
-    Example:
-        >>> data_tool(action='dsource_link_mssql_defaults', source_id='example-source-123')
-    
-    ACTION: dsource_link_mssql_staging_push
-    ----------------------------------------
-    Summary: Link a MSSql staging push database as dSource.
-    Method: POST
-    Endpoint: /dsources/mssql/staging-push
-    Key Parameters (provide as applicable): engine_id, ppt_repository, encryption_key, ppt_host_user, staging_pre_script, staging_post_script, staging_database_name, db_state
-    
-    Example:
-        >>> data_tool(action='dsource_link_mssql_staging_push', engine_id='example-engine-123', ppt_repository=..., encryption_key=..., ppt_host_user=..., staging_pre_script=..., staging_post_script=..., staging_database_name=..., db_state=...)
-    
-    ACTION: dsource_link_mssql_staging_push_defaults
-    ----------------------------------------
-    Summary: Get defaults for a MSSql staging push dSource linking.
-    Method: POST
-    Endpoint: /dsources/mssql/staging-push/defaults
-    Required Parameters: environment_id
-    
-    Example:
-        >>> data_tool(action='dsource_link_mssql_staging_push_defaults', environment_id='example-environment-123')
-    
-    ACTION: attach_mssql_staging_push_dsource
-    ----------------------------------------
-    Summary: Attaches a MSSql staging push database to a previously detached dsource.
-    Method: POST
-    Endpoint: /dsources/mssql/staging-push/{dsourceId}/attachSource
-    Required Parameters: ppt_repository, dsource_id, staging_database_name
-    Key Parameters (provide as applicable): ops_pre_sync, ops_post_sync, encryption_key, ppt_host_user, staging_pre_script, staging_post_script, db_state
-    
-    Example:
-        >>> data_tool(action='attach_mssql_staging_push_dsource', ppt_repository=..., dsource_id='example-dsource-123', ops_pre_sync=..., ops_post_sync=..., encryption_key=..., ppt_host_user=..., staging_pre_script=..., staging_post_script=..., staging_database_name=..., db_state=...)
-    
-    ACTION: update_mssql_dsource
-    ----------------------------------------
-    Summary: Update values of an MSSql dSource
-    Method: PATCH
-    Endpoint: /dsources/mssql/{dsourceId}
-    Required Parameters: dsource_id
-    Key Parameters (provide as applicable): name, hooks, retention_policy_id, ppt_repository, sync_policy_id, logsync_enabled, source_host_user, encryption_key, ppt_host_user, sync_strategy_managed_type, mssql_user_environment_reference, mssql_user_domain_username, mssql_user_domain_password, mssql_user_domain_vault_username, mssql_user_domain_vault, mssql_user_domain_hashicorp_vault_engine, mssql_user_domain_hashicorp_vault_secret_path, mssql_user_domain_hashicorp_vault_username_key, mssql_user_domain_hashicorp_vault_secret_key, mssql_user_domain_azure_vault_name, mssql_user_domain_azure_vault_username_key, mssql_user_domain_azure_vault_secret_key, mssql_user_domain_cyberark_vault_query_string, mssql_database_username, mssql_database_password, delphix_managed_backup_compression_enabled, delphix_managed_backup_policy, external_managed_validate_sync_mode, external_managed_shared_backup_locations, external_netbackup_config_master_name, external_netbackup_config_source_client_name, external_netbackup_config_params, external_netbackup_config_templates, external_commserve_host_name, external_commvault_config_source_client_name, external_commvault_config_staging_client_name, external_commvault_config_params, external_commvault_config_templates, disable_netbackup_config, disable_commvault_config
-    
-    Example:
-        >>> data_tool(action='update_mssql_dsource', name=..., hooks=..., retention_policy_id='example-retention_policy-123', ppt_repository=..., dsource_id='example-dsource-123', sync_policy_id='example-sync_policy-123', logsync_enabled=..., source_host_user=..., encryption_key=..., ppt_host_user=..., sync_strategy_managed_type=..., mssql_user_environment_reference=..., mssql_user_domain_username=..., mssql_user_domain_password=..., mssql_user_domain_vault_username=..., mssql_user_domain_vault=..., mssql_user_domain_hashicorp_vault_engine=..., mssql_user_domain_hashicorp_vault_secret_path=..., mssql_user_domain_hashicorp_vault_username_key=..., mssql_user_domain_hashicorp_vault_secret_key=..., mssql_user_domain_azure_vault_name=..., mssql_user_domain_azure_vault_username_key=..., mssql_user_domain_azure_vault_secret_key=..., mssql_user_domain_cyberark_vault_query_string=..., mssql_database_username=..., mssql_database_password=..., delphix_managed_backup_compression_enabled=..., delphix_managed_backup_policy=..., external_managed_validate_sync_mode=..., external_managed_shared_backup_locations=..., external_netbackup_config_master_name=..., external_netbackup_config_source_client_name=..., external_netbackup_config_params=..., external_netbackup_config_templates=..., external_commserve_host_name=..., external_commvault_config_source_client_name=..., external_commvault_config_staging_client_name=..., external_commvault_config_params=..., external_commvault_config_templates=..., disable_netbackup_config=..., disable_commvault_config=...)
-    
-    ACTION: attach_mssql_dsource
-    ----------------------------------------
-    Summary: Attaches a MSSql source to a previously detached dsource.
-    Method: POST
-    Endpoint: /dsources/mssql/{dsourceId}/attachSource
-    Required Parameters: ppt_repository, dsource_id, source_id
-    Key Parameters (provide as applicable): ops_pre_sync, ops_post_sync, source_host_user, encryption_key, ppt_host_user, staging_pre_script, staging_post_script, sync_strategy_managed_type, mssql_user_environment_reference, mssql_user_domain_username, mssql_user_domain_password, mssql_user_domain_vault_username, mssql_user_domain_vault, mssql_user_domain_hashicorp_vault_engine, mssql_user_domain_hashicorp_vault_secret_path, mssql_user_domain_hashicorp_vault_username_key, mssql_user_domain_hashicorp_vault_secret_key, mssql_user_domain_azure_vault_name, mssql_user_domain_azure_vault_username_key, mssql_user_domain_azure_vault_secret_key, mssql_user_domain_cyberark_vault_query_string, mssql_database_username, mssql_database_password, delphix_managed_backup_compression_enabled, delphix_managed_backup_policy, external_managed_validate_sync_mode, external_managed_shared_backup_locations, external_netbackup_config_master_name, external_netbackup_config_source_client_name, external_netbackup_config_params, external_netbackup_config_templates, external_commserve_host_name, external_commvault_config_source_client_name, external_commvault_config_staging_client_name, external_commvault_config_params, external_commvault_config_templates
-    
-    Example:
-        >>> data_tool(action='attach_mssql_dsource', ppt_repository=..., dsource_id='example-dsource-123', source_id='example-source-123', ops_pre_sync=..., ops_post_sync=..., source_host_user=..., encryption_key=..., ppt_host_user=..., staging_pre_script=..., staging_post_script=..., sync_strategy_managed_type=..., mssql_user_environment_reference=..., mssql_user_domain_username=..., mssql_user_domain_password=..., mssql_user_domain_vault_username=..., mssql_user_domain_vault=..., mssql_user_domain_hashicorp_vault_engine=..., mssql_user_domain_hashicorp_vault_secret_path=..., mssql_user_domain_hashicorp_vault_username_key=..., mssql_user_domain_hashicorp_vault_secret_key=..., mssql_user_domain_azure_vault_name=..., mssql_user_domain_azure_vault_username_key=..., mssql_user_domain_azure_vault_secret_key=..., mssql_user_domain_cyberark_vault_query_string=..., mssql_database_username=..., mssql_database_password=..., delphix_managed_backup_compression_enabled=..., delphix_managed_backup_policy=..., external_managed_validate_sync_mode=..., external_managed_shared_backup_locations=..., external_netbackup_config_master_name=..., external_netbackup_config_source_client_name=..., external_netbackup_config_params=..., external_netbackup_config_templates=..., external_commserve_host_name=..., external_commvault_config_source_client_name=..., external_commvault_config_staging_client_name=..., external_commvault_config_params=..., external_commvault_config_templates=...)
-    
-    ACTION: detach_mssql_dsource
-    ----------------------------------------
-    Summary: Detaches a linked source from a MSSql database.
-    Method: POST
-    Endpoint: /dsources/mssql/{dsourceId}/detachSource
-    Required Parameters: dsource_id
-    
-    Example:
-        >>> data_tool(action='detach_mssql_dsource', dsource_id='example-dsource-123')
-    
-    ACTION: export_dsource_by_snapshot
-    ----------------------------------------
-    Summary: Export a dSource using snapshot to a physical file system
-    Method: POST
-    Endpoint: /dsources/{dsourceId}/export-by-snapshot
-    Required Parameters: dsource_id
-    Key Parameters (provide as applicable): snapshot_id, rman_channels, rman_file_section_size_in_gb
-    
-    Example:
-        >>> data_tool(action='export_dsource_by_snapshot', snapshot_id='example-snapshot-123', rman_channels=..., rman_file_section_size_in_gb=..., dsource_id='example-dsource-123')
-    
-    ACTION: export_dsource_by_timestamp
-    ----------------------------------------
-    Summary: Export a dSource using timestamp to a physical file system.
-    Method: POST
-    Endpoint: /dsources/{dsourceId}/export-by-timestamp
-    Required Parameters: timestamp, timeflow_id, dsource_id
-    Key Parameters (provide as applicable): rman_channels, rman_file_section_size_in_gb
-    
-    Example:
-        >>> data_tool(action='export_dsource_by_timestamp', timestamp=..., timeflow_id='example-timeflow-123', rman_channels=..., rman_file_section_size_in_gb=..., dsource_id='example-dsource-123')
-    
-    ACTION: export_dsource_by_location
-    ----------------------------------------
-    Summary: Export a dSource using timeflow location to a physical file system.
-    Method: POST
-    Endpoint: /dsources/{dsourceId}/export-by-location
-    Required Parameters: location, dsource_id
-    Key Parameters (provide as applicable): rman_channels, rman_file_section_size_in_gb
-    
-    Example:
-        >>> data_tool(action='export_dsource_by_location', location=..., rman_channels=..., rman_file_section_size_in_gb=..., dsource_id='example-dsource-123')
-    
-    ACTION: export_dsource_from_bookmark
-    ----------------------------------------
-    Summary: Export a dSource using bookmark to physical file system
-    Method: POST
-    Endpoint: /dsources/{dsourceId}/export-from-bookmark
-    Required Parameters: bookmark_id, dsource_id
-    Key Parameters (provide as applicable): rman_channels, rman_file_section_size_in_gb
-    
-    Example:
-        >>> data_tool(action='export_dsource_from_bookmark', bookmark_id='example-bookmark-123', rman_channels=..., rman_file_section_size_in_gb=..., dsource_id='example-dsource-123')
-    
-    ACTION: export_dsource_to_asm_by_snapshot
-    ----------------------------------------
-    Summary: Export a dSource by a snapshot to an ASM file system
-    Method: POST
-    Endpoint: /dsources/{dsourceId}/asm-export-by-snapshot
-    Required Parameters: default_data_diskgroup, dsource_id
-    Key Parameters (provide as applicable): snapshot_id, rman_channels, rman_file_section_size_in_gb, redo_diskgroup
-    
-    Example:
-        >>> data_tool(action='export_dsource_to_asm_by_snapshot', snapshot_id='example-snapshot-123', rman_channels=..., rman_file_section_size_in_gb=..., default_data_diskgroup=..., redo_diskgroup=..., dsource_id='example-dsource-123')
-    
-    ACTION: export_dsource_to_asm_by_timestamp
-    ----------------------------------------
-    Summary: Export a dSource using timestamp to an ASM file system
-    Method: POST
-    Endpoint: /dsources/{dsourceId}/asm-export-by-timestamp
-    Required Parameters: timestamp, timeflow_id, default_data_diskgroup, dsource_id
-    Key Parameters (provide as applicable): rman_channels, rman_file_section_size_in_gb, redo_diskgroup
-    
-    Example:
-        >>> data_tool(action='export_dsource_to_asm_by_timestamp', timestamp=..., timeflow_id='example-timeflow-123', rman_channels=..., rman_file_section_size_in_gb=..., default_data_diskgroup=..., redo_diskgroup=..., dsource_id='example-dsource-123')
-    
-    ACTION: export_dsource_to_asm_by_location
-    ----------------------------------------
-    Summary: Export a dSource using SCN to an ASM file system
-    Method: POST
-    Endpoint: /dsources/{dsourceId}/asm-export-by-location
-    Required Parameters: location, default_data_diskgroup, dsource_id
-    Key Parameters (provide as applicable): rman_channels, rman_file_section_size_in_gb, redo_diskgroup
-    
-    Example:
-        >>> data_tool(action='export_dsource_to_asm_by_location', location=..., rman_channels=..., rman_file_section_size_in_gb=..., default_data_diskgroup=..., redo_diskgroup=..., dsource_id='example-dsource-123')
-    
-    ACTION: export_dsource_to_asm_from_bookmark
-    ----------------------------------------
-    Summary: Export a dSource using bookmark to an ASM file system
-    Method: POST
-    Endpoint: /dsources/{dsourceId}/asm-export-from-bookmark
-    Required Parameters: bookmark_id, default_data_diskgroup, dsource_id
-    Key Parameters (provide as applicable): rman_channels, rman_file_section_size_in_gb, redo_diskgroup
-    
-    Example:
-        >>> data_tool(action='export_dsource_to_asm_from_bookmark', bookmark_id='example-bookmark-123', rman_channels=..., rman_file_section_size_in_gb=..., default_data_diskgroup=..., redo_diskgroup=..., dsource_id='example-dsource-123')
-    
-    ======================================================================
-    PARAMETERS
-    ======================================================================
-    
-    Args:
-        action (str): The operation to perform. One of: list_vdbs, search_vdbs, get_vdb, update_vdb, provision_by_timestamp, provision_by_timestamp_defaults, provision_by_snapshot, provision_by_snapshot_defaults, provision_from_bookmark, provision_from_bookmark_defaults, provision_by_location, provision_by_location_defaults, provision_empty_vdb, delete_vdb, start_vdb, stop_vdb, enable_vdb, disable_vdb, refresh_vdb_by_timestamp, refresh_vdb_by_snapshot, refresh_vdb_from_bookmark, refresh_vdb_by_location, undo_vdb_refresh, rollback_vdb_by_timestamp, rollback_vdb_by_snapshot, rollback_vdb_from_bookmark, switch_vdb_timeflow, lock_vdb, unlock_vdb, migrate_vdb, get_migrate_compatible_repositories, upgrade_vdb, upgrade_oracle_vdb, get_upgrade_compatible_repositories, list_vdb_snapshots, snapshot_vdb, list_vdb_bookmarks, search_vdb_bookmarks, get_vdb_deletion_dependencies, verify_vdb_jdbc_connection, get_vdb_tags, add_vdb_tags, export_vdb_in_place, export_vdb_asm_in_place, export_vdb_by_snapshot, export_vdb_by_timestamp, export_vdb_by_location, export_vdb_from_bookmark, export_vdb_to_asm_by_snapshot, export_vdb_to_asm_by_timestamp, export_vdb_to_asm_by_location, export_vdb_to_asm_from_bookmark, export_cleanup, export_finalize, list_vdb_groups, search_vdb_groups, get_vdb_group, create_vdb_group, update_vdb_group, delete_vdb_group, provision_vdb_group_from_bookmark, refresh_vdb_group, refresh_vdb_group_from_bookmark, refresh_vdb_group_by_snapshot, refresh_vdb_group_by_timestamp, rollback_vdb_group, lock_vdb_group, unlock_vdb_group, start_vdb_group, stop_vdb_group, enable_vdb_group, disable_vdb_group, get_vdb_group_latest_snapshots, get_vdb_group_timestamp_summary, list_vdb_group_bookmarks, search_vdb_group_bookmarks, get_vdb_group_tags, add_vdb_group_tags, list_dsources, search_dsources, get_dsource, delete_dsource, enable_dsource, disable_dsource, list_dsource_snapshots, dsource_create_snapshot, upgrade_dsource, get_dsource_upgrade_compatible_repositories, get_dsource_deletion_dependencies, get_dsource_tags, add_dsource_tags, delete_dsource_tags, dsource_link_oracle, dsource_link_oracle_defaults, dsource_link_oracle_staging_push, dsource_link_oracle_staging_push_defaults, update_oracle_dsource, attach_oracle_dsource, detach_oracle_dsource, upgrade_oracle_dsource, dsource_link_ase, dsource_link_ase_defaults, update_ase_dsource, dsource_link_appdata, dsource_link_appdata_defaults, update_appdata_dsource, dsource_link_mssql, dsource_link_mssql_defaults, dsource_link_mssql_staging_push, dsource_link_mssql_staging_push_defaults, attach_mssql_staging_push_dsource, update_mssql_dsource, attach_mssql_dsource, detach_mssql_dsource, export_dsource_by_snapshot, export_dsource_by_timestamp, export_dsource_by_location, export_dsource_from_bookmark, export_dsource_to_asm_by_snapshot, export_dsource_to_asm_by_timestamp, export_dsource_to_asm_by_location, export_dsource_to_asm_from_bookmark
-    
-      -- General parameters (all database types) --
-        abort (bool): Whether to issue 'shutdown abort' to shutdown Oracle Virtual DB instances. (D...
-            [Optional for all actions]
-        account_id (int): Id of the account on whose behalf this request is being made. Only accounts h...
-            [Optional for all actions]
-        additional_mount_points (list): Specifies additional locations on which to mount a subdirectory of an AppData...
-            [Optional for all actions]
-        allow_auto_staging_restart_on_host_reboot (bool): Boolean value indicates whether this staging database should automatically be...
-            [Optional for all actions]
-        appdata_config_params (dict): The parameters specified by the source config schema in the toolkit (Pass as ...
-            [Optional for all actions]
-        appdata_parameters (dict): The list of parameters specified by the snapshotParametersDefinition schema i...
-            [Optional for all actions]
-        appdata_source_params (dict): The JSON payload conforming to the DraftV4 schema based on the type of applic...
-            [Optional for all actions]
-        archive_directory (str): The directory for archive files.
-            [Optional for all actions]
-        ase_backup_files (list): When using the `specific_backup` sync_strategy, determines the backup files. ...
-            [Optional for all actions]
-        attempt_cleanup (bool): Whether to attempt a cleanup of the VDB before the disable. (Default: True)
-            [Optional for all actions]
-        attempt_start (bool): Whether to attempt a startup of the VDB after the enable. (Default: True)
-            [Optional for all actions]
-        auto_restart (bool): Whether to enable VDB restart.
-            [Optional for all actions]
-        auto_select_repository (bool): Option to automatically select a compatible environment and repository. Mutua...
-            [Optional for all actions]
-        auto_staging_restart (bool): Boolean value indicates whether this staging database should automatically be...
-            [Optional for all actions]
-        availability_group_backup_policy (str): When using the `new_backup` sync_strategy for an MSSql Availability Group, de...
-            [Optional for all actions]
-        backup_frequency_minutes (int): The frequency with which the incremental backup will be taken in minutes. (De...
-            [Optional for all actions]
-        backup_host (str): Host environment where the backup server is located.
-            [Optional for all actions]
-        backup_host_user (str): OS user for the host where the backup server is located.
-            [Optional for all actions]
-        backup_level_enabled (bool): Boolean value indicates whether LEVEL-based incremental backups can be used o...
-            [Optional for all actions]
-        backup_server_name (str): Name of the backup server instance.
-            [Optional for all actions]
-        bandwidth_limit (int): Bandwidth limit (MB/s) for SnapSync and LogSync network traffic. A value of 0...
-            [Optional for all actions]
-        bookmark_id (str): The ID of the bookmark from which to execute the operation. The bookmark must...
-            [Required for: provision_from_bookmark, provision_from_bookmark_defaults, refresh_vdb_from_bookmark, rollback_vdb_from_bookmark, export_vdb_from_bookmark, export_vdb_to_asm_from_bookmark, provision_vdb_group_from_bookmark, refresh_vdb_group, refresh_vdb_group_from_bookmark, rollback_vdb_group, export_dsource_from_bookmark, export_dsource_to_asm_from_bookmark]
-        cache_priority (str): When set to a value other than NORMAL (valid only for object storage engines)...
-            [Optional for all actions]
-        cdb_tde_keystore_password (str): The password for the Transparent Data Encryption keystore associated with the...
-            [Optional for all actions]
-        cdc_on_provision (bool): Whether to enable CDC on provision for MSSql
-            [Optional for all actions]
-        check_logical (bool): True if extended block checking should be used for this linked database. (Def...
-            [Optional for all actions]
-        cleanup_target_container (bool): Flag indicating whether to delete the temporary virtual source created for ex...
-            [Optional for all actions]
-        cleanup_target_physical_files (bool): Flag indicating whether to delete the database files already copied to target...
-            [Optional for all actions]
-        compressed_linking_enabled (bool): True if SnapSync data from the source should be compressed over the network. ...
-            [Optional for all actions]
-        compression_enabled (bool): When using the `new_backup` sync_strategy, determines if compression must be ...
-            [Optional for all actions]
-        config_params (dict): Database configuration parameter overrides. (Pass as JSON object)
-            [Optional for all actions]
-        configure_clone (list): The commands to execute on the target environment when the VDB is created or ...
-            [Optional for all actions]
-        container_type (str): The container type of this database.If not provided the request would be cons...
-            [Optional for all actions]
-        crs_database_name (str): The Oracle Clusterware database name.
-            [Optional for all actions]
-        cursor (str): Cursor to fetch the next or previous page of results. The value of this prope...
-            [Required for: list_vdbs, search_vdbs, list_vdb_snapshots, list_vdb_bookmarks, search_vdb_bookmarks, list_vdb_groups, search_vdb_groups, list_vdb_group_bookmarks, search_vdb_group_bookmarks, list_dsources, search_dsources, list_dsource_snapshots]
-        custom_env_files (list): Environment files to be sourced when the Engine administers a VDB. This path ...
-            [Optional for all actions]
-        custom_env_variables_pairs (list): An array of name value pair of environment variables. (Pass as JSON array)
-            [Optional for all actions]
-        custom_env_variables_paths (list): An array of strings of whitespace-separated parameters to be passed to the so...
-            [Optional for all actions]
-        custom_env_vars (dict): Environment variable to be set when the engine administers a VDB. See the Eng...
-            [Optional for all actions]
-        data_directory (str): The directory for data files.
-            [Optional for all actions]
-        database_name (str): The name of the database in the target environment (update not applicable for...
-            [Optional for all actions]
-        database_password (str): oracle database password.
-            [Required for: verify_vdb_jdbc_connection]
-        database_unique_name (str): The unique name of the database.
-            [Optional for all actions]
-        database_username (str): oracle database username.
-            [Required for: verify_vdb_jdbc_connection]
-        dataset_id (str): ID of the dataset to refresh to, mutually exclusive with timeflow_id.
-            [Optional for all actions]
-        db_azure_vault_name (str): Azure key vault name.
-            [Optional for all actions]
-        db_azure_vault_secret_key (str): Azure vault key for the password in the key-value store.
-            [Optional for all actions]
-        db_azure_vault_username_key (str): Azure vault key for the username in the key-value store.
-            [Optional for all actions]
-        db_cyberark_vault_query_string (str): Query to find a credential in the CyberArk vault.
-            [Optional for all actions]
-        db_hashicorp_vault_engine (str): Vault engine name where the credential is stored.
-            [Optional for all actions]
-        db_hashicorp_vault_secret_key (str): Hashicorp vault key for the password in the key-value store.
-            [Optional for all actions]
-        db_hashicorp_vault_secret_path (str): Path in the vault engine where the credential is stored.
-            [Optional for all actions]
-        db_hashicorp_vault_username_key (str): Hashicorp vault key for the username in the key-value store.
-            [Optional for all actions]
-        db_password (str): The password of the database user (Oracle, ASE Only).
-            [Optional for all actions]
-        db_state (str): User provided db state that will be used to create staging push db. Default i...
-            [Optional for all actions]
-        db_unique_name (str): Unique name to be given to the database after it is converted to physical.
-            [Optional for all actions]
-        db_user (str): The user name for the source DB user.
-            [Optional for all actions]
-        db_username (str): The username of the database user (Oracle, ASE Only).
-            [Optional for all actions]
-        db_vault (str): The name or reference of the vault from which to read the database credentials.
-            [Optional for all actions]
-        db_vault_username (str): Delphix display name for the vault user.
-            [Optional for all actions]
-        default_data_diskgroup (str): Default diskgroup for datafiles.
-            [Required for: export_vdb_asm_in_place, export_vdb_to_asm_by_snapshot, export_vdb_to_asm_by_timestamp, export_vdb_to_asm_by_location, export_vdb_to_asm_from_bookmark, export_dsource_to_asm_by_snapshot, export_dsource_to_asm_by_timestamp, export_dsource_to_asm_by_location, export_dsource_to_asm_from_bookmark]
-        delete_all_dependent_vdbs (bool): Flag indicating whether to delete all dependent VDBs before deleting the VDB....
-            [Optional for all actions]
-        delphix_managed_backup_compression_enabled (bool): Specify whether the backups taken should be compressed or uncompressed when D...
-            [Optional for all actions]
-        delphix_managed_backup_policy (str): Specify which node of an availability group to run the copy-only full backup ...
-            [Optional for all actions]
-        description (str): The container description of this VDB.
-            [Optional for all actions]
-        diagnose_no_logging_faults (bool): If true, NOLOGGING operations on this container are treated as faults and can...
-            [Optional for all actions]
-        disable_commvault_config (bool): Disable Commvault configuration.
-            [Optional for all actions]
-        disable_netbackup_config (bool): Disable NetBackup configuration.
-            [Optional for all actions]
-        do_not_resume (bool): Indicates whether a fresh SnapSync must be started regardless if it was possi...
-            [Optional for all actions]
-        double_sync (bool): True if two SnapSyncs should be performed in immediate succession to reduce t...
-            [Optional for all actions]
-        drop_and_recreate_devices (bool): If this parameter is set to true, it will drop the older devices and create n...
-            [Optional for all actions]
-        dsource_id (str): The unique identifier for the dsource.
-            [Required for: get_dsource, delete_dsource, enable_dsource, disable_dsource, list_dsource_snapshots, dsource_create_snapshot, upgrade_dsource, get_dsource_upgrade_compatible_repositories, get_dsource_deletion_dependencies, get_dsource_tags, add_dsource_tags, delete_dsource_tags, update_oracle_dsource, attach_oracle_dsource, detach_oracle_dsource, upgrade_oracle_dsource, update_ase_dsource, update_appdata_dsource, attach_mssql_staging_push_dsource, update_mssql_dsource, attach_mssql_dsource, detach_mssql_dsource, export_dsource_by_snapshot, export_dsource_by_timestamp, export_dsource_by_location, export_dsource_from_bookmark, export_dsource_to_asm_by_snapshot, export_dsource_to_asm_by_timestamp, export_dsource_to_asm_by_location, export_dsource_to_asm_from_bookmark]
-        dump_credentials (str): The password credential for the source DB user.
-            [Optional for all actions]
-        dump_history_file_enabled (bool): Specifies if Dump History File is enabled for backup history detection. (Defa...
-            [Optional for all actions]
-        enable_cdc (bool): Indicates whether to enable Change Data Capture (CDC) or not on exported data...
-            [Optional for all actions]
-        encrypted_linking_enabled (bool): True if SnapSync data from the source should be retrieved through an encrypte...
-            [Optional for all actions]
-        encryption_key (str): The encryption key to use when restoring encrypted backups.
-            [Optional for all actions]
-        engine_id (str): The ID of the Engine onto which to provision. If the source ID unambiguously ...
-            [Optional for all actions]
-        environment_id (str): The ID of the target environment where to provision the VDB. If repository_id...
-            [Required for: dsource_link_oracle_staging_push_defaults, dsource_link_mssql_staging_push_defaults]
-        environment_user (str): Reference to the user that should be used in the host.
-            [Optional for all actions]
-        environment_user_id (str): The environment user ID to use to connect to the target environment.
-            [Required for: upgrade_oracle_vdb, upgrade_oracle_dsource]
-        environment_user_ref (str): Reference of the environment user.
-            [Optional for all actions]
-        excludes (list): List of subdirectories in the source to exclude when syncing data. These path...
-            [Optional for all actions]
-        external_commserve_host_name (str): The commserve host name of this Commvault configuration.
-            [Optional for all actions]
-        external_commvault_config_params (dict): Commvault configuration parameter overrides. (Pass as JSON object)
-            [Optional for all actions]
-        external_commvault_config_source_client_name (str): The source client name of this Commvault configuration.
-            [Optional for all actions]
-        external_commvault_config_staging_client_name (str): The staging client name of this Commvault configuration.
-            [Optional for all actions]
-        external_commvault_config_templates (str): Optional config template selection for Commvault configurations. If set, conf...
-            [Optional for all actions]
-        external_directory (str): The directory for external files.
-            [Optional for all actions]
-        external_file_path (str): External file path.
-            [Optional for all actions]
-        external_managed_shared_backup_locations (list): Shared source database backup locations. (Pass as JSON array)
-            [Optional for all actions]
-        external_managed_validate_sync_mode (str): Specifies the backup types ValidatedSync will use to synchronize the dSource ...
-            [Optional for all actions]
-        external_netbackup_config_master_name (str): The master server name of this NetBackup configuration.
-            [Optional for all actions]
-        external_netbackup_config_params (dict): NetBackup configuration parameter overrides. (Pass as JSON object)
-            [Optional for all actions]
-        external_netbackup_config_source_client_name (str): The source's client server name of this NetBackup configuration.
-            [Optional for all actions]
-        external_netbackup_config_templates (str): Optional config template selection for NetBackup configurations. If set, exte...
-            [Optional for all actions]
-        fallback_azure_vault_name (str): Azure key vault name.
-            [Optional for all actions]
-        fallback_azure_vault_secret_key (str): Azure vault key for the password in the key-value store.
-            [Optional for all actions]
-        fallback_azure_vault_username_key (str): Azure vault key for the username in the key-value store.
-            [Optional for all actions]
-        fallback_cyberark_vault_query_string (str): Query to find a credential in the CyberArk vault.
-            [Optional for all actions]
-        fallback_hashicorp_vault_engine (str): Vault engine name where the credential is stored.
-            [Optional for all actions]
-        fallback_hashicorp_vault_secret_key (str): Hashicorp vault key for the password in the key-value store.
-            [Optional for all actions]
-        fallback_hashicorp_vault_secret_path (str): Path in the vault engine where the credential is stored.
-            [Optional for all actions]
-        fallback_hashicorp_vault_username_key (str): Hashicorp vault key for the username in the key-value store.
-            [Optional for all actions]
-        fallback_password (str): Password for fallback username.
-            [Optional for all actions]
-        fallback_username (str): The database fallback username. Optional if bequeath connections are enabled ...
-            [Optional for all actions]
-        fallback_vault (str): The name or reference of the vault from which to read the database credentials.
-            [Optional for all actions]
-        fallback_vault_username (str): Delphix display name for the fallback vault user.
-            [Optional for all actions]
-        files_for_full_backup (list): List of datafiles to take a full backup of. This would be useful in situation...
-            [Optional for all actions]
-        files_for_partial_full_backup (list): List of datafiles to take a full backup of. This would be useful in situation...
-            [Optional for all actions]
-        files_per_set (int): Number of data files to include in each RMAN backup set. (Default: 5)
-            [Optional for all actions]
-        filter_expression (str): Request body parameter
-            [Optional for all actions]
-        follow_symlinks (list): List of symlinks in the source to follow when syncing data. These paths are r...
-            [Optional for all actions]
-        force (bool): Whether to continue the operation upon failures. (Default: False)
-            [Optional for all actions]
-        force_full_backup (bool): Whether or not to take another full backup of the source database. (Default: ...
-            [Optional for all actions]
-        group_id (str): Id of the dataset group where this dSource should belong to.
-            [Optional for all actions]
-        hooks (dict): VDB operation hooks. (Pass as JSON object)
-            [Optional for all actions]
-        instance_number (int): The number of the instance.
-            [Optional for all actions]
-        instances (list): The instances of this RAC database. (Pass as JSON array)
-            [Optional for all actions]
-        invoke_datapatch (bool): Indicates whether datapatch should be invoked.
-            [Optional for all actions]
-        is_incremental_v2p (bool): Whether to enable incremental V2P (Virtual to Physical) export. When enabled,...
-            [Optional for all actions]
-        is_refresh_to_nearest (bool): If true, and the provided timestamp is not found for the VDB mapping, the sys...
-            [Optional for all actions]
-        jdbc_connection_string (str): Oracle jdbc connection string to validate.
-            [Required for: verify_vdb_jdbc_connection]
-        key (str): Key of the tag
-            [Optional for all actions]
-        limit (int): Maximum number of objects to return per query. The value must be between 1 an...
-            [Required for: list_vdbs, search_vdbs, list_vdb_snapshots, list_vdb_bookmarks, search_vdb_bookmarks, list_vdb_groups, search_vdb_groups, list_vdb_group_bookmarks, search_vdb_group_bookmarks, list_dsources, search_dsources, list_dsource_snapshots]
-        link_now (bool): True if initial load should be done immediately. (Default: False)
-            [Optional for all actions]
-        link_type (str): The type of link to create. Default is AppDataDirect.
-* `AppDataDirect` - Rep...
-            [Optional for all actions]
-        listener_ids (list): The listener IDs for this provision operation (Oracle Only). (Pass as JSON ar...
-            [Optional for all actions]
-        load_backup_path (str): Source database backup location.
-            [Optional for all actions]
-        location (str): The location to provision from.
-            [Required for: export_vdb_by_location, export_vdb_to_asm_by_location, export_dsource_by_location, export_dsource_to_asm_by_location]
-        log_sync_enabled (bool): True if LogSync should run for this database. (Default: False)
-            [Optional for all actions]
-        log_sync_interval (int): Interval between LogSync requests, in seconds. (Default: 5)
-            [Optional for all actions]
-        log_sync_mode (str): LogSync operation mode for this database. Valid values: ARCHIVE_ONLY_MODE, AR...
-            [Optional for all actions]
-        logsync_enabled (bool): True if LogSync is enabled for this dSource.
-            [Optional for all actions]
-        logsync_interval (int): Interval between LogSync requests, in seconds.
-            [Optional for all actions]
-        logsync_mode (str): LogSync operation mode for this dSource. Valid values: ARCHIVE_ONLY_MODE, ARC...
-            [Optional for all actions]
-        make_current_account_owner (bool): Whether the account provisioning this VDB must be configured as owner of the ...
-            [Optional for all actions]
-        masked (bool): Indicates whether to mark this VDB as a masked VDB.
-            [Optional for all actions]
-        max_allowed_backups_pending_restore (int): The maximum number of pending backup restores at which export-finalize operat...
-            [Optional for all actions]
-        mirroring_state (str): Recovery model of the database (MSSql Only). Valid values: SUSPENDED, DISCONN...
-            [Optional for all actions]
-        mode (str): Refresh Mode either self or parent, if PARENT then VDB Group is refreshed fro...
-            [Optional for all actions]
-        mount_base (str): The base mount point to use for the NFS mounts for the temporary VDB.
-            [Optional for all actions]
-        mount_point (str): Mount point for the VDB (AppData only), can only be updated while the VDB is ...
-            [Optional for all actions]
-        mssql_ag_backup_based (bool): Indicates whether to do fast operations for VDB on AG which will use a health...
-            [Optional for all actions]
-        mssql_ag_backup_location (str): Shared backup location to be used for VDB provision on AG Cluster.
-            [Optional for all actions]
-        mssql_backup_uuid (str): When using the `specific_backup` sync_strategy, determines the Backup Set UUI...
-            [Optional for all actions]
-        mssql_database_password (str): Password for the database user.
-            [Optional for all actions]
-        mssql_database_username (str): The username for the source DB user.
-            [Optional for all actions]
-        mssql_incremental_export_backup_frequency_minutes (int): Frequency in minutes for incremental export backups for VDBs.
-            [Optional for all actions]
-        mssql_user_domain_azure_vault_name (str): Azure key vault name.
-            [Optional for all actions]
-        mssql_user_domain_azure_vault_secret_key (str): Azure vault key for the password in the key-value store.
-            [Optional for all actions]
-        mssql_user_domain_azure_vault_username_key (str): Azure vault key for the username in the key-value store.
-            [Optional for all actions]
-        mssql_user_domain_cyberark_vault_query_string (str): Query to find a credential in the CyberArk vault.
-            [Optional for all actions]
-        mssql_user_domain_hashicorp_vault_engine (str): Vault engine name where the credential is stored.
-            [Optional for all actions]
-        mssql_user_domain_hashicorp_vault_secret_key (str): Hashicorp vault key for the password in the key-value store.
-            [Optional for all actions]
-        mssql_user_domain_hashicorp_vault_secret_path (str): Path in the vault engine where the credential is stored.
-            [Optional for all actions]
-        mssql_user_domain_hashicorp_vault_username_key (str): Hashicorp vault key for the username in the key-value store.
-            [Optional for all actions]
-        mssql_user_domain_password (str): Password for the database user.
-            [Optional for all actions]
-        mssql_user_domain_username (str): The username for the source DB user.
-            [Optional for all actions]
-        mssql_user_domain_vault (str): The name or reference of the vault from which to read the database credentials.
-            [Optional for all actions]
-        mssql_user_domain_vault_username (str): Delphix display name for the vault user.
-            [Optional for all actions]
-        mssql_user_environment_reference (str): Reference to the source environment user to use for linking.
-            [Optional for all actions]
-        name (str): The unique name of the VDB within a group.
-            [Required for: create_vdb_group, provision_vdb_group_from_bookmark]
-        new_dbid (bool): Whether to enable new DBID for Oracle
-            [Optional for all actions]
-        non_sys_azure_vault_name (str): Azure key vault name (Single tenant only).
-            [Optional for all actions]
-        non_sys_azure_vault_secret_key (str): Azure vault key for the password in the key-value store (Single tenant only).
-            [Optional for all actions]
-        non_sys_azure_vault_username_key (str): Azure vault key for the username in the key-value store (Single tenant only).
-            [Optional for all actions]
-        non_sys_cyberark_vault_query_string (str): Query to find a credential in the CyberArk vault (Single tenant only).
-            [Optional for all actions]
-        non_sys_hashicorp_vault_engine (str): Vault engine name where the credential is stored (Single tenant only).
-            [Optional for all actions]
-        non_sys_hashicorp_vault_secret_key (str): Hashicorp vault key for the password in the key-value store (Single tenant on...
-            [Optional for all actions]
-        non_sys_hashicorp_vault_secret_path (str): Path in the vault engine where the credential is stored (Single tenant only).
-            [Optional for all actions]
-        non_sys_hashicorp_vault_username_key (str): Hashicorp vault key for the username in the key-value store (Single tenant on...
-            [Optional for all actions]
-        non_sys_password (str): Password for non sys user authentication (Single tenant only).
-            [Optional for all actions]
-        non_sys_username (str): Non-SYS database user to access this database. Only required for username-pas...
-            [Optional for all actions]
-        non_sys_vault (str): The name or reference of the vault from which to read the database credential...
-            [Optional for all actions]
-        non_sys_vault_username (str): Delphix display name for the non sys vault user(Single tenant only).
-            [Optional for all actions]
-        number_of_connections (int): Total number of transport connections to use during SnapSync. (Default: 1)
-            [Optional for all actions]
-        operations (list): Operations to perform after syncing a created dSource and before running the ...
-            [Optional for all actions]
-        operations_post_v2_p (bool): Indicates operations allowed on virtual source post V2P. (Default: False)
-            [Optional for all actions]
-        ops_post_sync (list): Operations to perform after syncing a created dSource. (Pass as JSON array)
-            [Optional for all actions]
-        ops_pre_log_sync (list): Operations to perform after syncing a created dSource and before running the ...
-            [Optional for all actions]
-        ops_pre_sync (list): Operations to perform before syncing the created dSource. These operations ca...
-            [Optional for all actions]
-        oracle_fallback_credentials (str): Password for fallback username.
-            [Optional for all actions]
-        oracle_fallback_user (str): The database fallback username. Optional if bequeath connections are enabled ...
-            [Optional for all actions]
-        oracle_password (str): Password for privileged user (Oracle only).
-            [Optional for all actions]
-        oracle_rac_custom_env_files (list): Environment files to be sourced when the Engine administers an Oracle RAC VDB...
-            [Optional for all actions]
-        oracle_rac_custom_env_vars (list): Environment variable to be set when the engine administers an Oracle RAC VDB....
-            [Optional for all actions]
-        oracle_services (list): List of jdbc connection strings which are used to connect with the database. ...
-            [Optional for all actions]
-        oracle_username (str): The name of the privileged user to run the delete operation as (Oracle only).
-            [Optional for all actions]
-        ownership_spec (str): The uid:gid string that NFS mounts should belong to.
-            [Optional for all actions]
-        parameters (dict): The JSON payload conforming to the DraftV4 schema based on the type of applic...
-            [Optional for all actions]
-        parent_pdb_tde_keystore_password (str): The password of the parent PDB keystore. (Oracle Multitenant Only)
-            [Optional for all actions]
-        parent_pdb_tde_keystore_path (str): Path to a copy of the parent PDB's Oracle transparent data encryption keystor...
-            [Optional for all actions]
-        parent_tde_keystore_password (str): The password of the keystore specified in parentTdeKeystorePath. (Oracle Mult...
-            [Optional for all actions]
-        parent_tde_keystore_path (str): Path to a copy of the parent's Oracle transparent data encryption keystore on...
-            [Optional for all actions]
-        pdb_name (str): The name to be given to the PDB after it is exported in-place.
-            [Optional for all actions]
-        permission (str): Restrict the objects, which are allowed.
-            [Required for: list_vdbs, search_vdbs, list_dsources, search_dsources]
-        physical_standby (bool): Boolean value indicates whether this staging database will be configured as a...
-            [Optional for all actions]
-        post_refresh (list): The commands to execute on the target environment after refreshing the VDB. (...
-            [Optional for all actions]
-        post_rollback (list): The commands to execute on the target environment after rewinding the VDB. (P...
-            [Optional for all actions]
-        post_script (str): Post script for MSSql.
-            [Optional for all actions]
-        post_self_refresh (list): The commands to execute on the target environment after refreshing the VDB wi...
-            [Optional for all actions]
-        post_snapshot (list): The commands to execute on the target environment after snapshotting a virtua...
-            [Optional for all actions]
-        post_start (list): The commands to execute on the target environment after starting a virtual so...
-            [Optional for all actions]
-        post_stop (list): The commands to execute on the target environment after stopping a virtual so...
-            [Optional for all actions]
-        post_validated_sync (list): Operations to perform on the staging source after performing a validated sync...
-            [Optional for all actions]
-        ppt_host_user (str): Reference of the host OS user on the PPT host to use for linking.
-            [Optional for all actions]
-        ppt_repository (str): The id of the SQL instance on the PPT environment that we want to use for pre...
-            [Required for: attach_mssql_staging_push_dsource, attach_mssql_dsource]
-        pre_provisioning_enabled (bool): If true, pre-provisioning will be performed after every sync. (Default: False)
-            [Optional for all actions]
-        pre_refresh (list): The commands to execute on the target environment before refreshing the VDB. ...
-            [Optional for all actions]
-        pre_rollback (list): The commands to execute on the target environment before rewinding the VDB. (...
-            [Optional for all actions]
-        pre_script (str): Pre script for MSSql.
-            [Optional for all actions]
-        pre_self_refresh (list): The commands to execute on the target environment before refreshing the VDB w...
-            [Optional for all actions]
-        pre_snapshot (list): The commands to execute on the target environment before snapshotting a virtu...
-            [Optional for all actions]
-        pre_start (list): The commands to execute on the target environment before starting a virtual s...
-            [Optional for all actions]
-        pre_stop (list): The commands to execute on the target environment before stopping a virtual s...
-            [Optional for all actions]
-        pre_validated_sync (list): Operations to perform on the staging source before performing a validated syn...
-            [Optional for all actions]
-        provision_parameters (dict): Provision parameters for each of the VDBs which will need to be provisioned. ...
-            [Required for: provision_vdb_group_from_bookmark]
-        rac_max_instance_lag (int): Maximum number of log sequences to allow a RAC instance to lag before conside...
-            [Optional for all actions]
-        recover_database (bool): If specified, then take the exported database through recovery procedures, if...
-            [Optional for all actions]
-        redo_diskgroup (str): Diskgroup for archive logs. Optional as it is not required for PDB databases.
-            [Optional for all actions]
-        refresh_immediately (bool): If true, VDB Group will be refreshed immediately after creation. (Default: Fa...
-            [Optional for all actions]
-        repository (str): The repository reference to link.
-            [Optional for all actions]
-        repository_id (str): The ID of the target repository where to provision the VDB. A repository typi...
-            [Required for: upgrade_vdb, upgrade_oracle_vdb, upgrade_dsource, upgrade_oracle_dsource]
-        retention_policy_id (str): The ID of the retention policy for the VDB.
-            [Optional for all actions]
-        rman_channels (int): Number of data streams to connect to the database. (Default: 8)
-            [Optional for all actions]
-        rman_channels_for_incremental_backup (int): Number of data streams to connect to the database for incremental backup. (De...
-            [Optional for all actions]
-        rman_file_section_size_in_gb (int): Number of GigaBytes in which RMAN will break large files to back them in para...
-            [Optional for all actions]
-        rman_file_section_size_in_gb_for_incremental_backup (int): Number of GigaBytes in which RMAN will break large files to back them up in p...
-            [Optional for all actions]
-        rman_files_per_set_for_incremental_backup (int): Number of data files to include in each RMAN backup set for incremental backu...
-            [Optional for all actions]
-        rman_rate_in__m_b (int): RMAN rate in megabytes to be used. This is the upper limit for bytes read so ...
-            [Optional for all actions]
-        script_directory (str): The directory for script files.
-            [Optional for all actions]
-        sid (str): The name (sid) of the instance.
-            [Optional for all actions]
-        skip_space_check (bool): Skip check that tests if there is enough space available to store the databas...
-            [Optional for all actions]
-        snapshot_id (str): The ID of the snapshot from which to execute the operation. If the snapshot_i...
-            [Optional for all actions]
-        snapshot_policy_id (str): The ID of the snapshot policy for the VDB.
-            [Optional for all actions]
-        sort (str): The field to sort results by. A property name with a prepended '-' signifies ...
-            [Required for: list_vdbs, search_vdbs, list_vdb_bookmarks, search_vdb_bookmarks, list_vdb_groups, search_vdb_groups, list_vdb_group_bookmarks, search_vdb_group_bookmarks, list_dsources, search_dsources]
-        source_data_id (str): The ID of the source object (dSource or VDB) to provision from. All other obj...
-            [Required for: provision_by_timestamp, provision_by_timestamp_defaults]
-        source_host_user (str): ID or user reference of the host OS user to use for linking.
-            [Optional for all actions]
-        source_id (str): Id of the source to link.
-            [Required for: dsource_link_oracle_defaults, attach_oracle_dsource, dsource_link_ase_defaults, dsource_link_appdata_defaults, dsource_link_mssql_defaults, attach_mssql_dsource]
-        staging_container_database_reference (str): Reference of the CDB source config.
-            [Optional for all actions]
-        staging_database_config_params (dict): Oracle database configuration parameter overrides. If both staging_database_t...
-            [Optional for all actions]
-        staging_database_name (str): The name of the database to create on the staging environment. This property ...
-            [Required for: attach_mssql_staging_push_dsource]
-        staging_database_templates (list): An array of name value pair of Oracle database configuration parameter overri...
-            [Optional for all actions]
-        staging_environment (str): The environment used as an intermediate stage to pull data into Delphix [AppD...
-            [Optional for all actions]
-        staging_environment_user (str): The environment user used to access the staging environment [AppDataStaged on...
-            [Optional for all actions]
-        staging_host_user (str): Information about the host OS user on the staging environment to use for link...
-            [Optional for all actions]
-        staging_mount_base (str): The base mount point for the NFS mount on the staging environment [AppDataSta...
-            [Optional for all actions]
-        staging_post_script (str): A user-provided PowerShell script or executable to run after restoring from a...
-            [Optional for all actions]
-        staging_pre_script (str): A user-provided PowerShell script or executable to run prior to restoring fro...
-            [Optional for all actions]
-        staging_repository (str): The SAP ASE instance on the staging environment that we want to use for valid...
-            [Optional for all actions]
-        sync_parameters (dict): The JSON payload conforming to the snapshot parameters definition in a LUA to...
-            [Optional for all actions]
-        sync_policy_id (str): The ID of the SnapSync policy for the dSource.
-            [Optional for all actions]
-        sync_strategy (str): Determines how the Delphix Engine will take a backup:
-* `latest_backup` - Use...
-            [Optional for all actions]
-        sync_strategy_managed_type (str): MSSQL specific parameters for source based sync strategy.:
-* `external` - MSS...
-            [Optional for all actions]
-        tags (list): The tags to be created for VDB. (Pass as JSON array)
-            [Required for: add_vdb_tags, add_vdb_group_tags, add_dsource_tags]
-        target_directory (str): The base directory to use for the exported database.
-            [Optional for all actions]
-        target_group_id (str): The ID of the group into which the VDB will be provisioned. This field must b...
-            [Optional for all actions]
-        target_pdb_tde_keystore_password (str): The password for the isolated mode TDE keystore of the target virtual PDB. (O...
-            [Optional for all actions]
-        target_vcdb_tde_keystore_path (str): Path to the keystore of the target vCDB. (Oracle Multitenant Only)
-            [Optional for all actions]
-        tde_exported_keyfile_secret (str): Secret to be used while exporting and importing vPDB encryption keys.
-            [Optional for all actions]
-        tde_key_identifier (str): ID of the key created by Delphix. (Oracle Multitenant Only)
-            [Optional for all actions]
-        tde_keystore_config_type (str): Oracle TDE keystore configuration type. Valid values: FILE, OKV, HSM, OKV|FIL...
-            [Optional for all actions]
-        tde_keystore_password (str): The password for the Transparent Data Encryption keystore associated with thi...
-            [Optional for all actions]
-        temp_directory (str): The directory for temporary files.
-            [Optional for all actions]
-        template_id (str): The ID of the target VDB Template (Oracle and MSSql Only).
-            [Optional for all actions]
-        timeflow_id (str): The Timeflow ID.
-            [Required for: export_vdb_by_timestamp, export_vdb_to_asm_by_timestamp, export_dsource_by_timestamp, export_dsource_to_asm_by_timestamp]
-        timestamp (str): The point in time from which to execute the operation. Mutually exclusive wit...
-            [Required for: export_vdb_by_timestamp, export_vdb_to_asm_by_timestamp, export_dsource_by_timestamp, export_dsource_to_asm_by_timestamp]
-        timestamp_in_database_timezone (str): The point in time from which to execute the operation, expressed as a date-ti...
-            [Optional for all actions]
-        use_absolute_path_for_data_files (bool): Whether to use absolute path for data files (Oracle only).
-            [Optional for all actions]
-        validate_by_opening_db_in_read_only_mode (bool): Boolean value indicates whether this staging database snapshot will be valida...
-            [Optional for all actions]
-        validate_db_credentials (bool): Whether db_username and db_password must be validated, if present, against th...
-            [Optional for all actions]
-        validate_snapshot_in_readonly (bool): Boolean value indicates whether this staging database snapshot will be valida...
-            [Optional for all actions]
-        validated_sync_mode (str): Information about the host OS user on the staging environment to use for link...
-            [Optional for all actions]
-        value (str): Value of the tag
-            [Optional for all actions]
-        vdb_disable_param_mappings (list): Request body parameter (Pass as JSON array)
-            [Optional for all actions]
-        vdb_enable_param_mappings (list): Request body parameter (Pass as JSON array)
-            [Optional for all actions]
-        vdb_group_id (str): The unique identifier for the vdbGroup.
-            [Required for: get_vdb_group, update_vdb_group, delete_vdb_group, refresh_vdb_group, refresh_vdb_group_from_bookmark, refresh_vdb_group_by_snapshot, refresh_vdb_group_by_timestamp, rollback_vdb_group, lock_vdb_group, unlock_vdb_group, start_vdb_group, stop_vdb_group, enable_vdb_group, disable_vdb_group, get_vdb_group_latest_snapshots, get_vdb_group_timestamp_summary, list_vdb_group_bookmarks, search_vdb_group_bookmarks, get_vdb_group_tags, add_vdb_group_tags]
-        vdb_id (str): The unique identifier for the vdb.
-            [Required for: get_vdb, update_vdb, delete_vdb, start_vdb, stop_vdb, enable_vdb, disable_vdb, refresh_vdb_by_timestamp, refresh_vdb_by_snapshot, refresh_vdb_from_bookmark, refresh_vdb_by_location, undo_vdb_refresh, rollback_vdb_by_timestamp, rollback_vdb_by_snapshot, rollback_vdb_from_bookmark, switch_vdb_timeflow, lock_vdb, unlock_vdb, migrate_vdb, get_migrate_compatible_repositories, upgrade_vdb, upgrade_oracle_vdb, get_upgrade_compatible_repositories, list_vdb_snapshots, snapshot_vdb, list_vdb_bookmarks, search_vdb_bookmarks, get_vdb_deletion_dependencies, verify_vdb_jdbc_connection, get_vdb_tags, add_vdb_tags, export_vdb_in_place, export_vdb_asm_in_place, export_vdb_by_snapshot, export_vdb_by_timestamp, export_vdb_by_location, export_vdb_from_bookmark, export_vdb_to_asm_by_snapshot, export_vdb_to_asm_by_timestamp, export_vdb_to_asm_by_location, export_vdb_to_asm_from_bookmark, export_cleanup, export_finalize]
-        vdb_ids (list): Request body parameter (Pass as JSON array)
-            [Optional for all actions]
-        vdb_restart (bool): Indicates whether the Engine should automatically restart this virtual source...
-            [Optional for all actions]
-        vdb_snapshot_mappings (list): List of the pair of VDB and snapshot to refresh from. If this is not set, all...
-            [Optional for all actions]
-        vdb_start_param_mappings (list): Request body parameter (Pass as JSON array)
-            [Optional for all actions]
-        vdb_stop_param_mappings (list): Request body parameter (Pass as JSON array)
-            [Optional for all actions]
-        vdb_timestamp_mappings (list): List of the pair of VDB and timestamp to refresh from. If this is not set, al...
-            [Optional for all actions]
-        vdbs (list): Dictates order of operations on VDBs. Operations can be performed in parallel...
-            [Optional for all actions]
-    
-      -- MSSql-specific parameters (SKIP if not provisioning mssql) --
-        mssql_failover_drive_letter (str): [MSSql only] Base drive letter location for mount points. (MSSql Only).
-            [Optional for all actions]
-        recovery_model (str): Recovery model of the database (MSSql Only). Valid values: FULL, SIMPLE, BULK...
-            [Optional for all actions]
-    
-      -- Oracle-specific parameters (SKIP if not provisioning oracle) --
-        archive_log (bool): [Oracle only] Option to create a VDB in archivelog mode (Oracle Only).
-            [Optional for all actions]
-        auxiliary_template_id (str): [Oracle only] The ID of the configuration template to apply to the auxiliary ...
-            [Optional for all actions]
-        cdb_id (str): [Oracle only] The ID of the container database (CDB) to provision an Oracle M...
-            [Optional for all actions]
-        cluster_node_ids (list): [Oracle only] The cluster node ids, name or addresses for this provision oper...
-            [Optional for all actions]
-        cluster_node_instances (list): [Oracle only] The cluster node instances details for this provision operation...
-            [Optional for all actions]
-        container_mode (bool): [Oracle only] Whether the virtual database will be provisioned for a containe...
-            [Optional for all actions]
-        file_mapping_rules (str): [Oracle only] Target VDB file mapping rules (Oracle Only). Rules must be line...
-            [Optional for all actions]
-        okv_client_id (str): [Oracle only] The id of the OKV client used by the target new vCDB for TDE ke...
-            [Optional for all actions]
-        online_log_groups (int): [Oracle only] Number of online log groups (Oracle Only).
-            [Optional for all actions]
-        online_log_size (int): [Oracle only] Online log size in MB (Oracle Only).
-            [Optional for all actions]
-        open_reset_logs (bool): [Oracle only] Whether to open the database after provision (Oracle Only).
-            [Optional for all actions]
-        oracle_instance_name (str): [Oracle only] Target VDB SID name (Oracle Only).
-            [Optional for all actions]
-        os_password (str): [Oracle only] The password of the privileged user to run the provision operat...
-            [Optional for all actions]
-        os_username (str): [Oracle only] The name of the privileged user to run the provision operation ...
-            [Optional for all actions]
-        tde_exported_key_file_secret (str): [Oracle only] Secret to be used while exporting and importing vPDB encryption...
-            [Optional for all actions]
-        unique_name (str): [Oracle only] Target VDB db_unique_name (Oracle Only).
-            [Optional for all actions]
-        vcdb_database_name (str): [Oracle only] When provisioning an Oracle Multitenant vCDB (when the cdb_id p...
-            [Optional for all actions]
-        vcdb_name (str): [Oracle only] When provisioning an Oracle Multitenant vCDB (when the cdb_id p...
-            [Optional for all actions]
-        vcdb_restart (bool): [Oracle only] Indicates whether the Engine should automatically restart this ...
-            [Optional for all actions]
-        vcdb_tde_key_identifier (str): [Oracle only] ID of the key created by Delphix. (Oracle Multitenant Only)
-            [Optional for all actions]
-    
-      -- Postgres-specific parameters (SKIP if not provisioning postgres) --
-        config_settings_stg (list): [Postgres only] Custom Database-Level config settings (postgres only). (Pass ...
-            [Optional for all actions]
-        postgres_port (int): [Postgres only] Port number for Postgres target database (postgres only).
-            [Optional for all actions]
-        privileged_os_user (str): [Postgres only] This privileged unix username will be used to create the VDB....
-            [Optional for all actions]
-    
-      -- ASE/Sybase-specific parameters (SKIP if not provisioning sybase) --
-        truncate_log_on_checkpoint (bool): [ASE/Sybase only] Whether to truncate log on checkpoint (ASE only).
-            [Optional for all actions]
-    
-    Returns:
-        Dict[str, Any]: The API response containing operation results
-    
-    Raises:
-        Returns error dict if required parameters are missing for the action
+        Unified tool for DATA operations.
+
+        This tool supports 122 actions: list_vdbs, search_vdbs, get_vdb, update_vdb, provision_by_timestamp, provision_by_timestamp_defaults, provision_by_snapshot, provision_by_snapshot_defaults, provision_from_bookmark, provision_from_bookmark_defaults, provision_by_location, provision_by_location_defaults, provision_empty_vdb, delete_vdb, start_vdb, stop_vdb, enable_vdb, disable_vdb, refresh_vdb_by_timestamp, refresh_vdb_by_snapshot, refresh_vdb_from_bookmark, refresh_vdb_by_location, undo_vdb_refresh, rollback_vdb_by_timestamp, rollback_vdb_by_snapshot, rollback_vdb_from_bookmark, switch_vdb_timeflow, lock_vdb, unlock_vdb, migrate_vdb, get_migrate_compatible_repositories, upgrade_vdb, upgrade_oracle_vdb, get_upgrade_compatible_repositories, list_vdb_snapshots, snapshot_vdb, list_vdb_bookmarks, search_vdb_bookmarks, get_vdb_deletion_dependencies, verify_vdb_jdbc_connection, get_vdb_tags, add_vdb_tags, export_vdb_in_place, export_vdb_asm_in_place, export_vdb_by_snapshot, export_vdb_by_timestamp, export_vdb_by_location, export_vdb_from_bookmark, export_vdb_to_asm_by_snapshot, export_vdb_to_asm_by_timestamp, export_vdb_to_asm_by_location, export_vdb_to_asm_from_bookmark, export_cleanup, export_finalize, list_vdb_groups, search_vdb_groups, get_vdb_group, create_vdb_group, update_vdb_group, delete_vdb_group, provision_vdb_group_from_bookmark, refresh_vdb_group, refresh_vdb_group_from_bookmark, refresh_vdb_group_by_snapshot, refresh_vdb_group_by_timestamp, rollback_vdb_group, lock_vdb_group, unlock_vdb_group, start_vdb_group, stop_vdb_group, enable_vdb_group, disable_vdb_group, get_vdb_group_latest_snapshots, get_vdb_group_timestamp_summary, list_vdb_group_bookmarks, search_vdb_group_bookmarks, get_vdb_group_tags, add_vdb_group_tags, list_dsources, search_dsources, get_dsource, delete_dsource, enable_dsource, disable_dsource, list_dsource_snapshots, dsource_create_snapshot, upgrade_dsource, get_dsource_upgrade_compatible_repositories, get_dsource_deletion_dependencies, get_dsource_tags, add_dsource_tags, delete_dsource_tags, dsource_link_oracle, dsource_link_oracle_defaults, dsource_link_oracle_staging_push, dsource_link_oracle_staging_push_defaults, update_oracle_dsource, attach_oracle_dsource, detach_oracle_dsource, upgrade_oracle_dsource, dsource_link_ase, dsource_link_ase_defaults, update_ase_dsource, dsource_link_appdata, dsource_link_appdata_defaults, update_appdata_dsource, dsource_link_mssql, dsource_link_mssql_defaults, dsource_link_mssql_staging_push, dsource_link_mssql_staging_push_defaults, attach_mssql_staging_push_dsource, update_mssql_dsource, attach_mssql_dsource, detach_mssql_dsource, export_dsource_by_snapshot, export_dsource_by_timestamp, export_dsource_by_location, export_dsource_from_bookmark, export_dsource_to_asm_by_snapshot, export_dsource_to_asm_by_timestamp, export_dsource_to_asm_by_location, export_dsource_to_asm_from_bookmark
+
+        IMPORTANT — Delphix domain terminology:
+      • "dSource" is often used as a VERB meaning "create/link a dSource" (i.e. ingest a source database). When a user says "dSource database X", they want to LINK a new dSource for database X, NOT look up an existing dSource named X. Use the appropriate dsource_link_* action (dsource_link_oracle, dsource_link_mssql, dsource_link_ase, dsource_link_appdata) depending on the database type.
+      • "provision" or "spin up" a VDB or "create a golden image of a VDB" means creating a virtual database from a dSource or bookmark  — use provision_by_timestamp, provision_by_snapshot, etc.
+      • "refresh" a VDB means updating it with newer data from its parent — use refresh_vdb_by_timestamp, refresh_vdb_by_snapshot, etc.
+
+        ======================================================================
+        ACTION REFERENCE
+        ======================================================================
+
+        ACTION: list_vdbs
+        ----------------------------------------
+        Summary: List all vdbs.
+        Method: GET
+        Endpoint: /vdbs
+        Required Parameters: limit, cursor, sort, permission
+
+        Example:
+            >>> data_tool(action='list_vdbs', limit=..., cursor=..., sort=..., permission=...)
+
+        ACTION: search_vdbs
+        ----------------------------------------
+        Summary: Search for VDBs.
+        Method: POST
+        Endpoint: /vdbs/search
+        Required Parameters: limit, cursor, sort, permission
+        Key Parameters (provide as applicable): filter_expression
+
+        Filterable Fields:
+            - id: The VDB object entity ID.
+            - database_type: The database type of this VDB.
+            - name: The logical name of this VDB.
+            - description: The container description of this VDB.
+            - database_name: The name of the database on the target environment or in ...
+            - namespace_id: The namespace id of this VDB.
+            - namespace_name: The namespace name of this VDB.
+            - is_replica: Is this a replicated object.
+            - is_locked: Is this VDB locked.
+            - locked_by: The ID of the account that locked this VDB.
+            - locked_by_name: The name of the account that locked this VDB.
+            - database_version: The database version of this VDB.
+            - jdbc_connection_string: The JDBC connection URL for this VDB.
+            - size: The total size of this VDB, in bytes.
+            - storage_size: The actual space used by this VDB, in bytes.
+            - unvirtualized_space: The disk space, in bytes, that it would take to store the...
+            - engine_id: A reference to the Engine that this VDB belongs to.
+            - status: The runtime status of the VDB. 'Unknown' if all attempts ...
+            - masked: The VDB is masked or not.
+            - content_type: The content type of the vdb.
+            - parent_timeflow_timestamp: The timestamp for parent timeflow.
+            - parent_timeflow_timezone: The timezone for parent timeflow.
+            - environment_id: A reference to the Environment that hosts this VDB.
+            - ip_address: The IP address of the VDB's host.
+            - fqdn: The FQDN of the VDB's host.
+            - parent_id: A reference to the parent dataset of this VDB.
+            - parent_dsource_id: A reference to the parent dSource of this VDB.
+            - root_parent_id: A reference to the root parent dataset of this VDB which ...
+            - group_name: The name of the group containing this VDB.
+            - engine_name: Name of the Engine where this VDB is hosted
+            - cdb_id: A reference to the CDB or VCDB associated with this VDB.
+            - tags:
+            - creation_date: The date this VDB was created.
+            - hooks:
+            - appdata_source_params: The JSON payload conforming to the DraftV4 schema based o...
+            - template_id: A reference to the Database Template.
+            - template_name: Name of the Database Template.
+            - config_params: Database configuration parameter overrides.
+            - environment_user_ref: The environment user reference.
+            - additional_mount_points: Specifies additional locations on which to mount a subdir...
+            - appdata_config_params: The parameters specified by the source config schema in t...
+            - mount_point: Mount point for the VDB (Oracle, ASE, AppData).
+            - current_timeflow_id: A reference to the currently active timeflow for this VDB.
+            - previous_timeflow_id: A reference to the previous timeflow for this VDB.
+            - last_refreshed_date: The date this VDB was last refreshed.
+            - vdb_restart: Indicates whether the Engine should automatically restart...
+            - is_appdata: Indicates whether this VDB has an AppData database.
+            - exported_data_directory: ZFS exported data directory path.
+            - vcdb_exported_data_directory: ZFS exported data directory path of the virtual CDB conta...
+            - toolkit_id: The ID of the toolkit associated with this VDB.
+            - plugin_version: The version of the plugin associated with this VDB.
+            - primary_object_id: The ID of the parent object from which replication was done.
+            - primary_engine_id: The ID of the parent engine from which replication was done.
+            - primary_engine_name: The name of the parent engine from which replication was ...
+            - replicas: The list of replicas replicated from this object.
+            - invoke_datapatch: Indicates whether datapatch should be invoked.
+            - enabled: True if VDB is enabled false if VDB is disabled.
+            - node_listeners: The list of node listeners for this VDB.
+            - instance_name: The instance name name of this single instance VDB.
+            - instance_number: The instance number of this single instance VDB.
+            - instances:
+            - oracle_services:
+            - repository_id: The repository id of this VDB.
+            - containerization_state:
+            - parent_tde_keystore_path: Path to a copy of the parent's Oracle transparent data en...
+            - target_vcdb_tde_keystore_path: Path to the keystore of the target vCDB.
+            - tde_key_identifier: ID of the key created by Delphix, as recorded in v$encryp...
+            - parent_pdb_tde_keystore_path: Path to a copy of the parent PDB's Oracle transparent dat...
+            - target_pdb_tde_keystore_path: Path of the virtual PDB's Oracle transparent data encrypt...
+            - recovery_model: Recovery model of the vdb database.
+            - cdc_on_provision: Whether to enable CDC on provision for MSSql.
+            - data_connection_id: The ID of the associated DataConnection.
+            - mssql_ag_backup_location: Shared backup location to be used for VDB provision on AG...
+            - mssql_ag_backup_based: Indicates whether to do fast operations for VDB on AG whi...
+            - mssql_ag_replicas: Indicates the mssql replica sources constitutes in MSSQL ...
+            - database_unique_name: The unique name of the database.
+            - db_username: The user name of the database.
+            - new_db_id: Indicates whether Delphix will generate a new DBID during...
+            - redo_log_groups: Number of Online Redo Log Groups.
+            - redo_log_size_in_mb: Online Redo Log size in MB.
+            - custom_env_vars:
+            - active_instances:
+            - nfs_version: The NFS version that was last used to mount this source."
+            - nfs_version_reason:
+            - nfs_encryption_enabled: Flag indicating whether the data transfer is encrypted or...
+            - cache_priority: When set to a value other than NORMAL (valid only for obj...
+            - mssql_incremental_export_backup_frequency_minutes: Frequency in minutes for incremental export backups for V...
+            - recycle_bin: Indicates whether the VDB is in recycle bin or not.
+            - recycle_days: Number of days to retain VDB in the recycle bin before it...
+            - recycle_bin_date: The date this VDB was moved to recycle bin.
+            - recycle_bin_account_id: The ID of the account that moved this VDB to recycle bin.
+
+        Filter Syntax:
+            Operators: EQ, NE, GT, GE, LT, LE, CONTAINS, IN, NOT_IN
+            Combine: AND, OR
+            Example: "name CONTAINS 'prod' AND status EQ 'RUNNING'"
+
+        Example:
+            >>> data_tool(action='search_vdbs', limit=..., cursor=..., sort=..., permission=..., filter_expression="name CONTAINS 'test'")
+
+        ACTION: get_vdb
+        ----------------------------------------
+        Summary: Get a VDB by ID.
+        Method: GET
+        Endpoint: /vdbs/{vdbId}
+        Required Parameters: vdb_id
+
+        Example:
+            >>> data_tool(action='get_vdb', vdb_id='example-vdb-123')
+
+        ACTION: update_vdb
+        ----------------------------------------
+        Summary: Update values of a VDB
+        Method: PATCH
+        Endpoint: /vdbs/{vdbId}
+        Required Parameters: vdb_id
+        Key Parameters (provide as applicable): name, description, db_username, db_password, validate_db_credentials, auto_restart, environment_user_id, template_id, listener_ids, new_dbid, cdc_on_provision, pre_script, post_script, hooks, custom_env_vars, custom_env_files, oracle_rac_custom_env_files, oracle_rac_custom_env_vars, parent_tde_keystore_path, parent_tde_keystore_password, tde_key_identifier, target_vcdb_tde_keystore_path, cdb_tde_keystore_password, parent_pdb_tde_keystore_path, parent_pdb_tde_keystore_password, target_pdb_tde_keystore_password, appdata_source_params, additional_mount_points, appdata_config_params, config_params, mount_point, oracle_services, instances, invoke_datapatch, mssql_ag_backup_location, mssql_ag_backup_based, cache_priority, mssql_incremental_export_backup_frequency_minutes, database_name
+
+        Example:
+            >>> data_tool(action='update_vdb', vdb_id='example-vdb-123', name=..., description=..., db_username=..., db_password=..., validate_db_credentials=..., auto_restart=..., environment_user_id='example-environment_user-123', template_id='example-template-123', listener_ids=..., new_dbid=..., cdc_on_provision=..., pre_script=..., post_script=..., hooks=..., custom_env_vars=..., custom_env_files=..., oracle_rac_custom_env_files=..., oracle_rac_custom_env_vars=..., parent_tde_keystore_path=..., parent_tde_keystore_password=..., tde_key_identifier=..., target_vcdb_tde_keystore_path=..., cdb_tde_keystore_password=..., parent_pdb_tde_keystore_path=..., parent_pdb_tde_keystore_password=..., target_pdb_tde_keystore_password=..., appdata_source_params=..., additional_mount_points=..., appdata_config_params=..., config_params=..., mount_point=..., oracle_services=..., instances=..., invoke_datapatch=..., mssql_ag_backup_location=..., mssql_ag_backup_based=..., cache_priority=..., mssql_incremental_export_backup_frequency_minutes=..., database_name=...)
+
+        ACTION: provision_by_timestamp
+        ----------------------------------------
+        Summary: Provision a new VDB by timestamp.
+        Method: POST
+        Endpoint: /vdbs/provision_by_timestamp
+        Required Parameters: source_data_id
+        Key Parameters (provide as applicable): timestamp, timestamp_in_database_timezone, timeflow_id, engine_id, make_current_account_owner
+
+        Example:
+            >>> data_tool(action='provision_by_timestamp', timestamp=..., timestamp_in_database_timezone=..., timeflow_id='example-timeflow-123', engine_id='example-engine-123', source_data_id='example-source_data-123', make_current_account_owner=...)
+
+            IMPORTANT — AppData VDB only: If provisioning an AppData VDB (i.e., you need to populate 'appdata_source_params' or 'appdata_config_params'), call toolkit_tool(action='search') first and filter by the engine_id of the target environment, and use environment_user_id. Use the matching toolkit's 'virtual_source_definition.parameters' schema for 'appdata_source_params', and 'source_config_definition.parameters' for 'appdata_config_params'. For Oracle, MSSQL, PostgreSQL, or other non-AppData types, skip this step.
+
+        ACTION: provision_by_timestamp_defaults
+        ----------------------------------------
+        Summary: Get default provision parameters for provisioning a new VDB by timestamp.
+        Method: POST
+        Endpoint: /vdbs/provision_by_timestamp/defaults
+        Required Parameters: source_data_id
+        Key Parameters (provide as applicable): timestamp, timestamp_in_database_timezone, timeflow_id, engine_id
+
+        Example:
+            >>> data_tool(action='provision_by_timestamp_defaults', timestamp=..., timestamp_in_database_timezone=..., timeflow_id='example-timeflow-123', engine_id='example-engine-123', source_data_id='example-source_data-123')
+
+        ACTION: provision_by_snapshot
+        ----------------------------------------
+        Summary: Provision a new VDB by snapshot.
+        Method: POST
+        Endpoint: /vdbs/provision_by_snapshot
+        Key Parameters (provide as applicable): engine_id, source_data_id, make_current_account_owner, snapshot_id
+
+        Example:
+            >>> data_tool(action='provision_by_snapshot', engine_id='example-engine-123', source_data_id='example-source_data-123', make_current_account_owner=..., snapshot_id='example-snapshot-123')
+
+            IMPORTANT — AppData VDB only: If provisioning an AppData VDB (i.e., you need to populate 'appdata_source_params' or 'appdata_config_params'), call toolkit_tool(action='search') first and filter by the engine_id of the target environment, and use environment_user_id. Use the matching toolkit's 'virtual_source_definition.parameters' schema for 'appdata_source_params', and 'source_config_definition.parameters' for 'appdata_config_params'. For Oracle, MSSQL, PostgreSQL, or other non-AppData types, skip this step.
+
+        ACTION: provision_by_snapshot_defaults
+        ----------------------------------------
+        Summary: Get default provision parameters for provisioning a new VDB by snapshot.
+        Method: POST
+        Endpoint: /vdbs/provision_by_snapshot/defaults
+        Key Parameters (provide as applicable): engine_id, source_data_id, snapshot_id
+
+        Example:
+            >>> data_tool(action='provision_by_snapshot_defaults', engine_id='example-engine-123', source_data_id='example-source_data-123', snapshot_id='example-snapshot-123')
+
+        ACTION: provision_from_bookmark
+        ----------------------------------------
+        Summary: Provision a new VDB from a bookmark with a single VDB.
+        Method: POST
+        Endpoint: /vdbs/provision_from_bookmark
+        Required Parameters: bookmark_id
+        Key Parameters (provide as applicable): make_current_account_owner
+
+        Example:
+            >>> data_tool(action='provision_from_bookmark', make_current_account_owner=..., bookmark_id='example-bookmark-123')
+
+            IMPORTANT — AppData VDB only: If provisioning an AppData VDB (i.e., you need to populate 'appdata_source_params' or 'appdata_config_params'), call toolkit_tool(action='search') first and filter by the engine_id of the target environment, and use environment_user_id. Use the matching toolkit's 'virtual_source_definition.parameters' schema for 'appdata_source_params', and 'source_config_definition.parameters' for 'appdata_config_params'. For Oracle, MSSQL, PostgreSQL, or other non-AppData types, skip this step.
+
+        ACTION: provision_from_bookmark_defaults
+        ----------------------------------------
+        Summary: Get default provision parameters for provisioning a new VDB from a bookmark.
+        Method: POST
+        Endpoint: /vdbs/provision_from_bookmark/defaults
+        Required Parameters: bookmark_id
+
+        Example:
+            >>> data_tool(action='provision_from_bookmark_defaults', bookmark_id='example-bookmark-123')
+
+        ACTION: provision_by_location
+        ----------------------------------------
+        Summary: Provision a new VDB by location.
+        Method: POST
+        Endpoint: /vdbs/provision_by_location
+        Key Parameters (provide as applicable): timeflow_id, engine_id, source_data_id, make_current_account_owner, location
+
+        Example:
+            >>> data_tool(action='provision_by_location', timeflow_id='example-timeflow-123', engine_id='example-engine-123', source_data_id='example-source_data-123', make_current_account_owner=..., location=...)
+
+            IMPORTANT — AppData VDB only: If provisioning an AppData VDB (i.e., you need to populate 'appdata_source_params' or 'appdata_config_params'), call toolkit_tool(action='search') first and filter by the engine_id of the target environment, and use environment_user_id. Use the matching toolkit's 'virtual_source_definition.parameters' schema for 'appdata_source_params', and 'source_config_definition.parameters' for 'appdata_config_params'. For Oracle, MSSQL, PostgreSQL, or other non-AppData types, skip this step.
+
+        ACTION: provision_by_location_defaults
+        ----------------------------------------
+        Summary: Get default provision parameters for provisioning a new VDB by location.
+        Method: POST
+        Endpoint: /vdbs/provision_by_location/defaults
+        Key Parameters (provide as applicable): timeflow_id, engine_id, source_data_id, location
+
+        Example:
+            >>> data_tool(action='provision_by_location_defaults', timeflow_id='example-timeflow-123', engine_id='example-engine-123', source_data_id='example-source_data-123', location=...)
+
+        ACTION: provision_empty_vdb
+        ----------------------------------------
+        Summary: Provision an empty VDB.
+        Method: POST
+        Endpoint: /vdbs/empty_vdb
+        Key Parameters (provide as applicable): repository_id, engine_id
+
+        Example:
+            >>> data_tool(action='provision_empty_vdb', repository_id='example-repository-123', engine_id='example-engine-123')
+
+            IMPORTANT — AppData VDB only: If provisioning an AppData VDB (i.e., you need to populate 'appdata_source_params' or 'appdata_config_params'), call toolkit_tool(action='search') first and filter by the engine_id of the target environment, and use environment_user_id. Use the matching toolkit's 'virtual_source_definition.parameters' schema for 'appdata_source_params', and 'source_config_definition.parameters' for 'appdata_config_params'. For Oracle, MSSQL, PostgreSQL, or other non-AppData types, skip this step.
+
+        ACTION: delete_vdb
+        ----------------------------------------
+        Summary: Delete a VDB.
+        Method: POST
+        Endpoint: /vdbs/{vdbId}/delete
+        Required Parameters: vdb_id
+        Key Parameters (provide as applicable): force, delete_all_dependent_vdbs
+
+        Example:
+            >>> data_tool(action='delete_vdb', vdb_id='example-vdb-123', force=..., delete_all_dependent_vdbs=...)
+
+        ACTION: start_vdb
+        ----------------------------------------
+        Summary: Start a VDB.
+        Method: POST
+        Endpoint: /vdbs/{vdbId}/start
+        Required Parameters: vdb_id
+        Key Parameters (provide as applicable): instances
+
+        Example:
+            >>> data_tool(action='start_vdb', vdb_id='example-vdb-123', instances=...)
+
+        ACTION: stop_vdb
+        ----------------------------------------
+        Summary: Stop a VDB.
+        Method: POST
+        Endpoint: /vdbs/{vdbId}/stop
+        Required Parameters: vdb_id
+        Key Parameters (provide as applicable): instances, abort
+
+        Example:
+            >>> data_tool(action='stop_vdb', vdb_id='example-vdb-123', instances=..., abort=...)
+
+        ACTION: enable_vdb
+        ----------------------------------------
+        Summary: Enable a VDB.
+        Method: POST
+        Endpoint: /vdbs/{vdbId}/enable
+        Required Parameters: vdb_id
+        Key Parameters (provide as applicable): container_mode, attempt_start, ownership_spec
+
+        Example:
+            >>> data_tool(action='enable_vdb', vdb_id='example-vdb-123', container_mode=..., attempt_start=..., ownership_spec=...)
+
+        ACTION: disable_vdb
+        ----------------------------------------
+        Summary: Disable a VDB.
+        Method: POST
+        Endpoint: /vdbs/{vdbId}/disable
+        Required Parameters: vdb_id
+        Key Parameters (provide as applicable): container_mode, attempt_cleanup
+
+        Example:
+            >>> data_tool(action='disable_vdb', vdb_id='example-vdb-123', container_mode=..., attempt_cleanup=...)
+
+        ACTION: refresh_vdb_by_timestamp
+        ----------------------------------------
+        Summary: Refresh a VDB by timestamp.
+        Method: POST
+        Endpoint: /vdbs/{vdbId}/refresh_by_timestamp
+        Required Parameters: vdb_id
+        Key Parameters (provide as applicable): timestamp, timestamp_in_database_timezone, timeflow_id, dataset_id
+
+        Example:
+            >>> data_tool(action='refresh_vdb_by_timestamp', vdb_id='example-vdb-123', timestamp=..., timestamp_in_database_timezone=..., timeflow_id='example-timeflow-123', dataset_id='example-dataset-123')
+
+        ACTION: refresh_vdb_by_snapshot
+        ----------------------------------------
+        Summary: Refresh a VDB by snapshot.
+        Method: POST
+        Endpoint: /vdbs/{vdbId}/refresh_by_snapshot
+        Required Parameters: vdb_id
+        Key Parameters (provide as applicable): snapshot_id
+
+        Example:
+            >>> data_tool(action='refresh_vdb_by_snapshot', vdb_id='example-vdb-123', snapshot_id='example-snapshot-123')
+
+        ACTION: refresh_vdb_from_bookmark
+        ----------------------------------------
+        Summary: Refresh a VDB from bookmark with a single VDB.
+        Method: POST
+        Endpoint: /vdbs/{vdbId}/refresh_from_bookmark
+        Required Parameters: vdb_id, bookmark_id
+
+        Example:
+            >>> data_tool(action='refresh_vdb_from_bookmark', vdb_id='example-vdb-123', bookmark_id='example-bookmark-123')
+
+        ACTION: refresh_vdb_by_location
+        ----------------------------------------
+        Summary: Refresh a VDB by location.
+        Method: POST
+        Endpoint: /vdbs/{vdbId}/refresh_by_location
+        Required Parameters: vdb_id
+        Key Parameters (provide as applicable): timeflow_id, location, dataset_id
+
+        Example:
+            >>> data_tool(action='refresh_vdb_by_location', vdb_id='example-vdb-123', timeflow_id='example-timeflow-123', location=..., dataset_id='example-dataset-123')
+
+        ACTION: undo_vdb_refresh
+        ----------------------------------------
+        Summary: Undo the last refresh operation.
+        Method: POST
+        Endpoint: /vdbs/{vdbId}/undo_refresh
+        Required Parameters: vdb_id
+
+        Example:
+            >>> data_tool(action='undo_vdb_refresh', vdb_id='example-vdb-123')
+
+        ACTION: rollback_vdb_by_timestamp
+        ----------------------------------------
+        Summary: Rollback a VDB by timestamp.
+        Method: POST
+        Endpoint: /vdbs/{vdbId}/rollback_by_timestamp
+        Required Parameters: vdb_id
+        Key Parameters (provide as applicable): timestamp, timestamp_in_database_timezone, timeflow_id
+
+        Example:
+            >>> data_tool(action='rollback_vdb_by_timestamp', vdb_id='example-vdb-123', timestamp=..., timestamp_in_database_timezone=..., timeflow_id='example-timeflow-123')
+
+        ACTION: rollback_vdb_by_snapshot
+        ----------------------------------------
+        Summary: Rollback a VDB by snapshot.
+        Method: POST
+        Endpoint: /vdbs/{vdbId}/rollback_by_snapshot
+        Required Parameters: vdb_id
+        Key Parameters (provide as applicable): snapshot_id
+
+        Example:
+            >>> data_tool(action='rollback_vdb_by_snapshot', vdb_id='example-vdb-123', snapshot_id='example-snapshot-123')
+
+        ACTION: rollback_vdb_from_bookmark
+        ----------------------------------------
+        Summary: Rollback a VDB from a bookmark with only the same VDB.
+        Method: POST
+        Endpoint: /vdbs/{vdbId}/rollback_from_bookmark
+        Required Parameters: vdb_id, bookmark_id
+
+        Example:
+            >>> data_tool(action='rollback_vdb_from_bookmark', vdb_id='example-vdb-123', bookmark_id='example-bookmark-123')
+
+        ACTION: switch_vdb_timeflow
+        ----------------------------------------
+        Summary: Switches the current timeflow of a VDB.
+        Method: POST
+        Endpoint: /vdbs/{vdbId}/switch_timeflow
+        Required Parameters: vdb_id
+        Key Parameters (provide as applicable): timeflow_id
+
+        Example:
+            >>> data_tool(action='switch_vdb_timeflow', vdb_id='example-vdb-123', timeflow_id='example-timeflow-123')
+
+        ACTION: lock_vdb
+        ----------------------------------------
+        Summary: Lock a VDB.
+        Method: POST
+        Endpoint: /vdbs/{vdbId}/lock
+        Required Parameters: vdb_id
+        Key Parameters (provide as applicable): account_id
+
+        Example:
+            >>> data_tool(action='lock_vdb', vdb_id='example-vdb-123', account_id='example-account-123')
+
+        ACTION: unlock_vdb
+        ----------------------------------------
+        Summary: Unlock a VDB.
+        Method: POST
+        Endpoint: /vdbs/{vdbId}/unlock
+        Required Parameters: vdb_id
+
+        Example:
+            >>> data_tool(action='unlock_vdb', vdb_id='example-vdb-123')
+
+        ACTION: migrate_vdb
+        ----------------------------------------
+        Summary: Migrate a VDB.
+        Method: POST
+        Endpoint: /vdbs/{vdbId}/migrate
+        Required Parameters: vdb_id
+        Key Parameters (provide as applicable): cdb_id, cluster_node_ids, cluster_node_instances, environment_id, repository_id, environment_user_ref
+
+        Example:
+            >>> data_tool(action='migrate_vdb', vdb_id='example-vdb-123', cdb_id='example-cdb-123', cluster_node_ids=..., cluster_node_instances=..., environment_id='example-environment-123', repository_id='example-repository-123', environment_user_ref=...)
+
+        ACTION: get_migrate_compatible_repositories
+        ----------------------------------------
+        Summary: Returns a list of compatible repositories for vdb migration.
+        Method: GET
+        Endpoint: /vdbs/{vdbId}/migrate_compatible_repositories
+        Required Parameters: vdb_id
+
+        Example:
+            >>> data_tool(action='get_migrate_compatible_repositories', vdb_id='example-vdb-123')
+
+        ACTION: upgrade_vdb
+        ----------------------------------------
+        Summary: Upgrade VDB
+        Method: POST
+        Endpoint: /vdbs/{vdbId}/upgrade
+        Required Parameters: vdb_id, repository_id
+        Key Parameters (provide as applicable): environment_user_id, ppt_repository
+
+        Example:
+            >>> data_tool(action='upgrade_vdb', vdb_id='example-vdb-123', environment_user_id='example-environment_user-123', repository_id='example-repository-123', ppt_repository=...)
+
+        ACTION: upgrade_oracle_vdb
+        ----------------------------------------
+        Summary: Upgrade Oracle VDB
+        Method: POST
+        Endpoint: /vdbs/oracle/{vdbId}/upgrade
+        Required Parameters: vdb_id, environment_user_id, repository_id
+
+        Example:
+            >>> data_tool(action='upgrade_oracle_vdb', vdb_id='example-vdb-123', environment_user_id='example-environment_user-123', repository_id='example-repository-123')
+
+        ACTION: get_upgrade_compatible_repositories
+        ----------------------------------------
+        Summary: Returns a list of compatible repositories for vdb upgrade.
+        Method: GET
+        Endpoint: /vdbs/{vdbId}/upgrade_compatible_repositories
+        Required Parameters: vdb_id
+
+        Example:
+            >>> data_tool(action='get_upgrade_compatible_repositories', vdb_id='example-vdb-123')
+
+        ACTION: list_vdb_snapshots
+        ----------------------------------------
+        Summary: List Snapshots for a VDB.
+        Method: GET
+        Endpoint: /vdbs/{vdbId}/snapshots
+        Required Parameters: limit, cursor, vdb_id
+
+        Example:
+            >>> data_tool(action='list_vdb_snapshots', limit=..., cursor=..., vdb_id='example-vdb-123')
+
+        ACTION: snapshot_vdb
+        ----------------------------------------
+        Summary: Snapshot a VDB.
+        Method: POST
+        Endpoint: /vdbs/{vdbId}/snapshots
+        Required Parameters: vdb_id
+
+        Example:
+            >>> data_tool(action='snapshot_vdb', vdb_id='example-vdb-123')
+
+        ACTION: list_vdb_bookmarks
+        ----------------------------------------
+        Summary: List Bookmarks compatible with this VDB.
+        Method: GET
+        Endpoint: /vdbs/{vdbId}/bookmarks
+        Required Parameters: limit, cursor, sort, vdb_id
+
+        Example:
+            >>> data_tool(action='list_vdb_bookmarks', limit=..., cursor=..., sort=..., vdb_id='example-vdb-123')
+
+        ACTION: search_vdb_bookmarks
+        ----------------------------------------
+        Summary: Search Bookmarks compatible with this VDB.
+        Method: POST
+        Endpoint: /vdbs/{vdbId}/bookmarks/search
+        Required Parameters: limit, cursor, sort, vdb_id
+        Key Parameters (provide as applicable): filter_expression
+
+        Filterable Fields:
+            - id: The Bookmark object entity ID.
+            - name: The user-defined name of this bookmark.
+            - creation_date: The date and time that this bookmark was created.
+            - data_timestamp: The timestamp for the data that the bookmark refers to.
+            - timeflow_id: The timeflow for the snapshot that the bookmark was creat...
+            - location: The location for the data that the bookmark refers to.
+            - vdb_ids: The list of VDB IDs associated with this bookmark.
+            - dsource_ids: The list of dSource IDs associated with this bookmark.
+            - vdb_group_id: The ID of the VDB group on which bookmark is created.
+            - vdb_group_name: The name of the VDB group on which bookmark is created.
+            - vdbs: The list of VDB IDs and VDB names associated with this bo...
+            - dsources: The list of dSource IDs and dSource names associated with...
+            - paas_databases: The list of PaaS Database IDs and PaaS Database names ass...
+            - paas_instances: The list of PaaS Instance IDs and PaaS Instance names ass...
+            - retention: The retention policy for this bookmark, in days. A value ...
+            - expiration: The expiration for this bookmark. When unset, indicates t...
+            - status: A message with details about operation progress or state ...
+            - replicated_dataset: Whether this bookmark is created from a replicated datase...
+            - bookmark_source: Source of the bookmark, default is DCT. In case of self-s...
+            - bookmark_status: Status of the bookmark. It can have INACTIVE value for en...
+            - ss_data_layout_id: Data-layout Id for engine-managed bookmarks.
+            - ss_bookmark_reference: Engine reference of the self-service bookmark.
+            - ss_bookmark_errors: List of errors if any, during bookmark creation in DCT fr...
+            - bookmark_type: Type of the bookmark, either PUBLIC or PRIVATE.
+            - namespace_id: The namespace id of this bookmark.
+            - namespace_name: The namespace name of this bookmark.
+            - is_replica: Is this a replicated bookmark.
+            - primary_object_id: Id of the parent bookmark from which this bookmark was re...
+            - primary_engine_id: The ID of the parent engine from which replication was done.
+            - primary_engine_name: The name of the parent engine from which replication was ...
+            - primary_bookmark_expiration: The expiration for the primary bookmark.
+            - replicas: The list of replicas replicated from this object.
+            - tags: The tags to be created for this Bookmark.
+
+        Filter Syntax:
+            Operators: EQ, NE, GT, GE, LT, LE, CONTAINS, IN, NOT_IN
+            Combine: AND, OR
+            Example: "name CONTAINS 'prod' AND status EQ 'RUNNING'"
+
+        Example:
+            >>> data_tool(action='search_vdb_bookmarks', limit=..., cursor=..., sort=..., filter_expression="name CONTAINS 'test'", vdb_id='example-vdb-123')
+
+        ACTION: get_vdb_deletion_dependencies
+        ----------------------------------------
+        Summary: Get deletion dependencies of a VDB.
+        Method: GET
+        Endpoint: /vdbs/{vdbId}/deletion-dependencies
+        Required Parameters: vdb_id
+
+        Example:
+            >>> data_tool(action='get_vdb_deletion_dependencies', vdb_id='example-vdb-123')
+
+        ACTION: verify_vdb_jdbc_connection
+        ----------------------------------------
+        Summary: Verify JDBC connection string for VDB.
+        Method: POST
+        Endpoint: /vdbs/{vdbId}/jdbc-check
+        Required Parameters: vdb_id, database_username, database_password, jdbc_connection_string
+
+        Example:
+            >>> data_tool(action='verify_vdb_jdbc_connection', vdb_id='example-vdb-123', database_username=..., database_password=..., jdbc_connection_string=...)
+
+        ACTION: get_vdb_tags
+        ----------------------------------------
+        Summary: Get tags for a VDB.
+        Method: GET
+        Endpoint: /vdbs/{vdbId}/tags
+        Required Parameters: vdb_id
+
+        Example:
+            >>> data_tool(action='get_vdb_tags', vdb_id='example-vdb-123')
+
+        ACTION: add_vdb_tags
+        ----------------------------------------
+        Summary: Create tags for a VDB.
+        Method: POST
+        Endpoint: /vdbs/{vdbId}/tags
+        Required Parameters: vdb_id, tags
+
+        Example:
+            >>> data_tool(action='add_vdb_tags', vdb_id='example-vdb-123', tags=...)
+
+        ACTION: export_vdb_in_place
+        ----------------------------------------
+        Summary: Convert a virtual database to a physical database on physical file system.
+        Method: POST
+        Endpoint: /vdbs/{vdbId}/in-place-export
+        Required Parameters: vdb_id
+        Key Parameters (provide as applicable): rman_channels, rman_file_section_size_in_gb, db_unique_name, pdb_name, operations_post_v2_p
+
+        Example:
+            >>> data_tool(action='export_vdb_in_place', vdb_id='example-vdb-123', rman_channels=..., rman_file_section_size_in_gb=..., db_unique_name=..., pdb_name=..., operations_post_v2_p=...)
+
+        ACTION: export_vdb_asm_in_place
+        ----------------------------------------
+        Summary: Convert a virtual database to a physical database on Oracle ASM file system.
+        Method: POST
+        Endpoint: /vdbs/{vdbId}/asm-in-place-export
+        Required Parameters: vdb_id, default_data_diskgroup
+        Key Parameters (provide as applicable): rman_channels, rman_file_section_size_in_gb, db_unique_name, pdb_name, operations_post_v2_p, redo_diskgroup
+
+        Example:
+            >>> data_tool(action='export_vdb_asm_in_place', vdb_id='example-vdb-123', rman_channels=..., rman_file_section_size_in_gb=..., db_unique_name=..., pdb_name=..., operations_post_v2_p=..., default_data_diskgroup=..., redo_diskgroup=...)
+
+        ACTION: export_vdb_by_snapshot
+        ----------------------------------------
+        Summary: Export a vdb using snapshot to a physical file system
+        Method: POST
+        Endpoint: /vdbs/{vdbId}/export-by-snapshot
+        Required Parameters: vdb_id
+        Key Parameters (provide as applicable): snapshot_id, rman_channels, rman_file_section_size_in_gb
+
+        Example:
+            >>> data_tool(action='export_vdb_by_snapshot', vdb_id='example-vdb-123', snapshot_id='example-snapshot-123', rman_channels=..., rman_file_section_size_in_gb=...)
+
+        ACTION: export_vdb_by_timestamp
+        ----------------------------------------
+        Summary: Export a vdb using timestamp to a physical file system
+        Method: POST
+        Endpoint: /vdbs/{vdbId}/export-by-timestamp
+        Required Parameters: vdb_id, timestamp, timeflow_id
+        Key Parameters (provide as applicable): rman_channels, rman_file_section_size_in_gb
+
+        Example:
+            >>> data_tool(action='export_vdb_by_timestamp', vdb_id='example-vdb-123', timestamp=..., timeflow_id='example-timeflow-123', rman_channels=..., rman_file_section_size_in_gb=...)
+
+        ACTION: export_vdb_by_location
+        ----------------------------------------
+        Summary: Export a vdb using timeflow location to a physical file system
+        Method: POST
+        Endpoint: /vdbs/{vdbId}/export-by-location
+        Required Parameters: vdb_id, location
+        Key Parameters (provide as applicable): rman_channels, rman_file_section_size_in_gb
+
+        Example:
+            >>> data_tool(action='export_vdb_by_location', vdb_id='example-vdb-123', location=..., rman_channels=..., rman_file_section_size_in_gb=...)
+
+        ACTION: export_vdb_from_bookmark
+        ----------------------------------------
+        Summary: Export a vdb using bookmark to physical file system
+        Method: POST
+        Endpoint: /vdbs/{vdbId}/export-from-bookmark
+        Required Parameters: vdb_id, bookmark_id
+        Key Parameters (provide as applicable): rman_channels, rman_file_section_size_in_gb
+
+        Example:
+            >>> data_tool(action='export_vdb_from_bookmark', vdb_id='example-vdb-123', bookmark_id='example-bookmark-123', rman_channels=..., rman_file_section_size_in_gb=...)
+
+        ACTION: export_vdb_to_asm_by_snapshot
+        ----------------------------------------
+        Summary: Export a vdb using snapshot to an ASM file system
+        Method: POST
+        Endpoint: /vdbs/{vdbId}/asm-export-by-snapshot
+        Required Parameters: vdb_id, default_data_diskgroup
+        Key Parameters (provide as applicable): snapshot_id, rman_channels, rman_file_section_size_in_gb, redo_diskgroup
+
+        Example:
+            >>> data_tool(action='export_vdb_to_asm_by_snapshot', vdb_id='example-vdb-123', snapshot_id='example-snapshot-123', rman_channels=..., rman_file_section_size_in_gb=..., default_data_diskgroup=..., redo_diskgroup=...)
+
+        ACTION: export_vdb_to_asm_by_timestamp
+        ----------------------------------------
+        Summary: Export a vdb using timestamp to an ASM file system
+        Method: POST
+        Endpoint: /vdbs/{vdbId}/asm-export-by-timestamp
+        Required Parameters: vdb_id, timestamp, timeflow_id, default_data_diskgroup
+        Key Parameters (provide as applicable): rman_channels, rman_file_section_size_in_gb, redo_diskgroup
+
+        Example:
+            >>> data_tool(action='export_vdb_to_asm_by_timestamp', vdb_id='example-vdb-123', timestamp=..., timeflow_id='example-timeflow-123', rman_channels=..., rman_file_section_size_in_gb=..., default_data_diskgroup=..., redo_diskgroup=...)
+
+        ACTION: export_vdb_to_asm_by_location
+        ----------------------------------------
+        Summary: Export a vdb using SCN to an ASM file system
+        Method: POST
+        Endpoint: /vdbs/{vdbId}/asm-export-by-location
+        Required Parameters: vdb_id, location, default_data_diskgroup
+        Key Parameters (provide as applicable): rman_channels, rman_file_section_size_in_gb, redo_diskgroup
+
+        Example:
+            >>> data_tool(action='export_vdb_to_asm_by_location', vdb_id='example-vdb-123', location=..., rman_channels=..., rman_file_section_size_in_gb=..., default_data_diskgroup=..., redo_diskgroup=...)
+
+        ACTION: export_vdb_to_asm_from_bookmark
+        ----------------------------------------
+        Summary: Export a vdb using bookmark to an ASM file system
+        Method: POST
+        Endpoint: /vdbs/{vdbId}/asm-export-from-bookmark
+        Required Parameters: vdb_id, bookmark_id, default_data_diskgroup
+        Key Parameters (provide as applicable): rman_channels, rman_file_section_size_in_gb, redo_diskgroup
+
+        Example:
+            >>> data_tool(action='export_vdb_to_asm_from_bookmark', vdb_id='example-vdb-123', bookmark_id='example-bookmark-123', rman_channels=..., rman_file_section_size_in_gb=..., default_data_diskgroup=..., redo_diskgroup=...)
+
+        ACTION: export_cleanup
+        ----------------------------------------
+        Summary: Export cleanup for incremental V2P operation
+        Method: POST
+        Endpoint: /vdbs/{vdbId}/export_cleanup
+        Required Parameters: vdb_id
+        Key Parameters (provide as applicable): cleanup_target_physical_files, cleanup_target_container
+
+        Example:
+            >>> data_tool(action='export_cleanup', vdb_id='example-vdb-123', cleanup_target_physical_files=..., cleanup_target_container=...)
+
+        ACTION: export_finalize
+        ----------------------------------------
+        Summary: Finalize operation on incremental V2P export
+        Method: POST
+        Endpoint: /vdbs/{vdbId}/export_finalize
+        Required Parameters: vdb_id
+        Key Parameters (provide as applicable): force, max_allowed_backups_pending_restore
+
+        Example:
+            >>> data_tool(action='export_finalize', vdb_id='example-vdb-123', force=..., max_allowed_backups_pending_restore=...)
+
+        ACTION: list_vdb_groups
+        ----------------------------------------
+        Summary: List all VDBGroups.
+        Method: GET
+        Endpoint: /vdb-groups
+        Required Parameters: limit, cursor, sort
+
+        Example:
+            >>> data_tool(action='list_vdb_groups', limit=..., cursor=..., sort=...)
+
+        ACTION: search_vdb_groups
+        ----------------------------------------
+        Summary: Search for VDB Groups.
+        Method: POST
+        Endpoint: /vdb-groups/search
+        Required Parameters: limit, cursor, sort
+        Key Parameters (provide as applicable): filter_expression
+
+        Filterable Fields:
+            - id: A unique identifier for the entity.
+            - name: A unique name for the entity.
+            - vdb_ids: The list of VDB IDs in this VDB Group.
+            - is_locked: Indicates whether the VDB Group is locked.
+            - locked_by: The Id of the account that locked the VDB Group.
+            - locked_by_name: The name of the account that locked the VDB Group.
+            - vdb_group_source: Source of the vdb group, default is DCT. In case of self-...
+            - ss_data_layout_id: Data-layout Id for engine-managed vdb groups.
+            - vdbs: Dictates order of operations on VDBs. Operations can be p...
+            - database_type: The database type of the VDB Group. If all VDBs in the gr...
+            - status: The status of the VDB Group. If all VDBs in the VDB Group...
+            - last_successful_refresh_to_bookmark_id: The bookmark ID to which the VDB Group was last successfu...
+            - last_successful_refresh_time: The time at which the VDB Group was last successfully ref...
+            - tags:
+
+        Filter Syntax:
+            Operators: EQ, NE, GT, GE, LT, LE, CONTAINS, IN, NOT_IN
+            Combine: AND, OR
+            Example: "name CONTAINS 'prod' AND status EQ 'RUNNING'"
+
+        Example:
+            >>> data_tool(action='search_vdb_groups', limit=..., cursor=..., sort=..., filter_expression="name CONTAINS 'test'")
+
+        ACTION: get_vdb_group
+        ----------------------------------------
+        Summary: Get a VDB Group by name.
+        Method: GET
+        Endpoint: /vdb-groups/{vdbGroupId}
+        Required Parameters: vdb_group_id
+
+        Example:
+            >>> data_tool(action='get_vdb_group', vdb_group_id='example-vdb_group-123')
+
+        ACTION: create_vdb_group
+        ----------------------------------------
+        Summary: Create a new VDB Group.
+        Method: POST
+        Endpoint: /vdb-groups
+        Required Parameters: name
+        Key Parameters (provide as applicable): tags, make_current_account_owner, vdb_ids, vdbs, refresh_immediately
+
+        Example:
+            >>> data_tool(action='create_vdb_group', name=..., tags=..., make_current_account_owner=..., vdb_ids=..., vdbs=..., refresh_immediately=...)
+
+        ACTION: update_vdb_group
+        ----------------------------------------
+        Summary: Update values of a VDB group.
+        Method: PATCH
+        Endpoint: /vdb-groups/{vdbGroupId}
+        Required Parameters: vdb_group_id
+        Key Parameters (provide as applicable): name, vdb_ids, vdbs, refresh_immediately
+
+        Example:
+            >>> data_tool(action='update_vdb_group', name=..., vdb_group_id='example-vdb_group-123', vdb_ids=..., vdbs=..., refresh_immediately=...)
+
+        ACTION: delete_vdb_group
+        ----------------------------------------
+        Summary: Delete a VDBGoup.
+        Method: DELETE
+        Endpoint: /vdb-groups/{vdbGroupId}
+        Required Parameters: vdb_group_id
+
+        Example:
+            >>> data_tool(action='delete_vdb_group', vdb_group_id='example-vdb_group-123')
+
+        ACTION: provision_vdb_group_from_bookmark
+        ----------------------------------------
+        Summary: Provision a new VDB Group from a Bookmark.
+        Method: POST
+        Endpoint: /vdb-groups/provision_from_bookmark
+        Required Parameters: name, bookmark_id, provision_parameters
+        Key Parameters (provide as applicable): tags, make_current_account_owner
+
+        Example:
+            >>> data_tool(action='provision_vdb_group_from_bookmark', name=..., tags=..., make_current_account_owner=..., bookmark_id='example-bookmark-123', provision_parameters=...)
+
+        ACTION: refresh_vdb_group
+        ----------------------------------------
+        Summary: Refresh a VDB Group from bookmark.
+        Method: POST
+        Endpoint: /vdb-groups/{vdbGroupId}/refresh
+        Required Parameters: bookmark_id, vdb_group_id
+
+        Example:
+            >>> data_tool(action='refresh_vdb_group', bookmark_id='example-bookmark-123', vdb_group_id='example-vdb_group-123')
+
+        ACTION: refresh_vdb_group_from_bookmark
+        ----------------------------------------
+        Summary: Refresh a VDB Group from bookmark.
+        Method: POST
+        Endpoint: /vdb-groups/{vdbGroupId}/refresh_from_bookmark
+        Required Parameters: bookmark_id, vdb_group_id
+
+        Example:
+            >>> data_tool(action='refresh_vdb_group_from_bookmark', bookmark_id='example-bookmark-123', vdb_group_id='example-vdb_group-123')
+
+        ACTION: refresh_vdb_group_by_snapshot
+        ----------------------------------------
+        Summary: Refresh a VDB Group by snapshot.
+        Method: POST
+        Endpoint: /vdb-groups/{vdbGroupId}/refresh_by_snapshot
+        Required Parameters: vdb_group_id
+        Key Parameters (provide as applicable): vdb_snapshot_mappings
+
+        Example:
+            >>> data_tool(action='refresh_vdb_group_by_snapshot', vdb_group_id='example-vdb_group-123', vdb_snapshot_mappings=...)
+
+        ACTION: refresh_vdb_group_by_timestamp
+        ----------------------------------------
+        Summary: Refresh a VDB Group by timestamp.
+        Method: POST
+        Endpoint: /vdb-groups/{vdbGroupId}/refresh_by_timestamp
+        Required Parameters: vdb_group_id
+        Key Parameters (provide as applicable): vdb_timestamp_mappings, is_refresh_to_nearest
+
+        Example:
+            >>> data_tool(action='refresh_vdb_group_by_timestamp', vdb_group_id='example-vdb_group-123', vdb_timestamp_mappings=..., is_refresh_to_nearest=...)
+
+        ACTION: rollback_vdb_group
+        ----------------------------------------
+        Summary: Rollback a VDB Group from a bookmark.
+        Method: POST
+        Endpoint: /vdb-groups/{vdbGroupId}/rollback
+        Required Parameters: bookmark_id, vdb_group_id
+
+        Example:
+            >>> data_tool(action='rollback_vdb_group', bookmark_id='example-bookmark-123', vdb_group_id='example-vdb_group-123')
+
+        ACTION: lock_vdb_group
+        ----------------------------------------
+        Summary: Lock a VDB Group.
+        Method: POST
+        Endpoint: /vdb-groups/{vdbGroupId}/lock
+        Required Parameters: vdb_group_id
+        Key Parameters (provide as applicable): account_id
+
+        Example:
+            >>> data_tool(action='lock_vdb_group', account_id='example-account-123', vdb_group_id='example-vdb_group-123')
+
+        ACTION: unlock_vdb_group
+        ----------------------------------------
+        Summary: Unlock a VDB Group.
+        Method: POST
+        Endpoint: /vdb-groups/{vdbGroupId}/unlock
+        Required Parameters: vdb_group_id
+
+        Example:
+            >>> data_tool(action='unlock_vdb_group', vdb_group_id='example-vdb_group-123')
+
+        ACTION: start_vdb_group
+        ----------------------------------------
+        Summary: Start a VDB Group.
+        Method: POST
+        Endpoint: /vdb-groups/{vdbGroupId}/start
+        Required Parameters: vdb_group_id
+        Key Parameters (provide as applicable): vdb_start_param_mappings
+
+        Example:
+            >>> data_tool(action='start_vdb_group', vdb_group_id='example-vdb_group-123', vdb_start_param_mappings=...)
+
+        ACTION: stop_vdb_group
+        ----------------------------------------
+        Summary: Stop a VDB Group.
+        Method: POST
+        Endpoint: /vdb-groups/{vdbGroupId}/stop
+        Required Parameters: vdb_group_id
+        Key Parameters (provide as applicable): vdb_stop_param_mappings
+
+        Example:
+            >>> data_tool(action='stop_vdb_group', vdb_group_id='example-vdb_group-123', vdb_stop_param_mappings=...)
+
+        ACTION: enable_vdb_group
+        ----------------------------------------
+        Summary: Enable a VDB Group.
+        Method: POST
+        Endpoint: /vdb-groups/{vdbGroupId}/enable
+        Required Parameters: vdb_group_id
+        Key Parameters (provide as applicable): vdb_enable_param_mappings
+
+        Example:
+            >>> data_tool(action='enable_vdb_group', vdb_group_id='example-vdb_group-123', vdb_enable_param_mappings=...)
+
+        ACTION: disable_vdb_group
+        ----------------------------------------
+        Summary: Disable a VDB Group.
+        Method: POST
+        Endpoint: /vdb-groups/{vdbGroupId}/disable
+        Required Parameters: vdb_group_id
+        Key Parameters (provide as applicable): vdb_disable_param_mappings
+
+        Example:
+            >>> data_tool(action='disable_vdb_group', vdb_group_id='example-vdb_group-123', vdb_disable_param_mappings=...)
+
+        ACTION: get_vdb_group_latest_snapshots
+        ----------------------------------------
+        Summary: Get latest snapshot of all the vdbs in VDB Group.
+        Method: GET
+        Endpoint: /vdb-groups/{vdbGroupId}/latest-snapshots
+        Required Parameters: vdb_group_id
+
+        Example:
+            >>> data_tool(action='get_vdb_group_latest_snapshots', vdb_group_id='example-vdb_group-123')
+
+        ACTION: get_vdb_group_timestamp_summary
+        ----------------------------------------
+        Summary: Get timestamp summary of all the vdbs in VDB Group.
+        Method: POST
+        Endpoint: /vdb-groups/{vdbGroupId}/timestamp-summary
+        Required Parameters: vdb_group_id
+        Key Parameters (provide as applicable): timestamp, vdb_ids, mode
+
+        Example:
+            >>> data_tool(action='get_vdb_group_timestamp_summary', timestamp=..., vdb_group_id='example-vdb_group-123', vdb_ids=..., mode=...)
+
+        ACTION: list_vdb_group_bookmarks
+        ----------------------------------------
+        Summary: List bookmarks compatible with this VDB Group.
+        Method: GET
+        Endpoint: /vdb-groups/{vdbGroupId}/bookmarks
+        Required Parameters: limit, cursor, sort, vdb_group_id
+
+        Example:
+            >>> data_tool(action='list_vdb_group_bookmarks', limit=..., cursor=..., sort=..., vdb_group_id='example-vdb_group-123')
+
+        ACTION: search_vdb_group_bookmarks
+        ----------------------------------------
+        Summary: Search for bookmarks compatible with this VDB Group.
+        Method: POST
+        Endpoint: /vdb-groups/{vdbGroupId}/bookmarks/search
+        Required Parameters: limit, cursor, sort, vdb_group_id
+        Key Parameters (provide as applicable): filter_expression
+
+        Filterable Fields:
+            - id: The Bookmark object entity ID.
+            - name: The user-defined name of this bookmark.
+            - creation_date: The date and time that this bookmark was created.
+            - data_timestamp: The timestamp for the data that the bookmark refers to.
+            - timeflow_id: The timeflow for the snapshot that the bookmark was creat...
+            - location: The location for the data that the bookmark refers to.
+            - vdb_ids: The list of VDB IDs associated with this bookmark.
+            - dsource_ids: The list of dSource IDs associated with this bookmark.
+            - vdb_group_id: The ID of the VDB group on which bookmark is created.
+            - vdb_group_name: The name of the VDB group on which bookmark is created.
+            - vdbs: The list of VDB IDs and VDB names associated with this bo...
+            - dsources: The list of dSource IDs and dSource names associated with...
+            - paas_databases: The list of PaaS Database IDs and PaaS Database names ass...
+            - paas_instances: The list of PaaS Instance IDs and PaaS Instance names ass...
+            - retention: The retention policy for this bookmark, in days. A value ...
+            - expiration: The expiration for this bookmark. When unset, indicates t...
+            - status: A message with details about operation progress or state ...
+            - replicated_dataset: Whether this bookmark is created from a replicated datase...
+            - bookmark_source: Source of the bookmark, default is DCT. In case of self-s...
+            - bookmark_status: Status of the bookmark. It can have INACTIVE value for en...
+            - ss_data_layout_id: Data-layout Id for engine-managed bookmarks.
+            - ss_bookmark_reference: Engine reference of the self-service bookmark.
+            - ss_bookmark_errors: List of errors if any, during bookmark creation in DCT fr...
+            - bookmark_type: Type of the bookmark, either PUBLIC or PRIVATE.
+            - namespace_id: The namespace id of this bookmark.
+            - namespace_name: The namespace name of this bookmark.
+            - is_replica: Is this a replicated bookmark.
+            - primary_object_id: Id of the parent bookmark from which this bookmark was re...
+            - primary_engine_id: The ID of the parent engine from which replication was done.
+            - primary_engine_name: The name of the parent engine from which replication was ...
+            - primary_bookmark_expiration: The expiration for the primary bookmark.
+            - replicas: The list of replicas replicated from this object.
+            - tags: The tags to be created for this Bookmark.
+
+        Filter Syntax:
+            Operators: EQ, NE, GT, GE, LT, LE, CONTAINS, IN, NOT_IN
+            Combine: AND, OR
+            Example: "name CONTAINS 'prod' AND status EQ 'RUNNING'"
+
+        Example:
+            >>> data_tool(action='search_vdb_group_bookmarks', limit=..., cursor=..., sort=..., filter_expression="name CONTAINS 'test'", vdb_group_id='example-vdb_group-123')
+
+        ACTION: get_vdb_group_tags
+        ----------------------------------------
+        Summary: Get tags for a VDB Group.
+        Method: GET
+        Endpoint: /vdb-groups/{vdbGroupId}/tags
+        Required Parameters: vdb_group_id
+
+        Example:
+            >>> data_tool(action='get_vdb_group_tags', vdb_group_id='example-vdb_group-123')
+
+        ACTION: add_vdb_group_tags
+        ----------------------------------------
+        Summary: Create tags for a VDB Group.
+        Method: POST
+        Endpoint: /vdb-groups/{vdbGroupId}/tags
+        Required Parameters: tags, vdb_group_id
+
+        Example:
+            >>> data_tool(action='add_vdb_group_tags', tags=..., vdb_group_id='example-vdb_group-123')
+
+        ACTION: list_dsources
+        ----------------------------------------
+        Summary: List all dSources.
+        Method: GET
+        Endpoint: /dsources
+        Required Parameters: limit, cursor, sort, permission
+
+        Example:
+            >>> data_tool(action='list_dsources', limit=..., cursor=..., sort=..., permission=...)
+
+        ACTION: search_dsources
+        ----------------------------------------
+        Summary: Search for dSources.
+        Method: POST
+        Endpoint: /dsources/search
+        Required Parameters: limit, cursor, sort, permission
+        Key Parameters (provide as applicable): filter_expression
+
+        Filterable Fields:
+            - id: The dSource object entity ID.
+            - database_type: The database type of this dSource.
+            - name: The container name of this dSource.
+            - description: The container description of this dSource.
+            - namespace_id: The namespace id of this dSource.
+            - namespace_name: The namespace name of this dSource.
+            - is_replica: Is this a replicated object.
+            - database_version: The database version of this dSource.
+            - content_type: The content type of the dSource.
+            - data_uuid: A universal ID that uniquely identifies the dSource datab...
+            - storage_size: The actual space used by this dSource, in bytes.
+            - plugin_version: The version of the plugin associated with this source dat...
+            - creation_date: The date this dSource was created.
+            - group_name: The name of the group containing this dSource.
+            - enabled: A value indicating whether this dSource is enabled.
+            - is_detached: A value indicating whether this dSource is detached.
+            - engine_id: A reference to the Engine that this dSource belongs to.
+            - source_id: A reference to the Source associated with this dSource.
+            - staging_source_id: A reference to the Staging Source associated with this dS...
+            - status: The runtime status of the dSource. 'Unknown' if all attem...
+            - engine_name: Name of the Engine where this DSource is hosted
+            - cdb_id: A reference to the CDB associated with this dSource.
+            - current_timeflow_id: A reference to the currently active timeflow for this dSo...
+            - previous_timeflow_id: A reference to the previous timeflow for this dSource.
+            - is_appdata: Indicates whether this dSource has an AppData database.
+            - toolkit_id: The ID of the toolkit associated with this dSource(AppDat...
+            - unvirtualized_space: This is the sum of unvirtualized space from the dependant...
+            - dependant_vdbs: The number of VDBs that are dependant on this dSource. Th...
+            - appdata_source_params: The JSON payload conforming to the DraftV4 schema based o...
+            - appdata_config_params: The parameters specified by the source config schema in t...
+            - tags:
+            - primary_object_id: The ID of the parent object from which replication was done.
+            - primary_engine_id: The ID of the parent engine from which replication was done.
+            - primary_engine_name: The name of the parent engine from which replication was ...
+            - replicas: The list of replicas replicated from this object.
+            - hooks:
+            - sync_policy_id: The id of the snapshot policy associated with this dSource.
+            - retention_policy_id: The id of the retention policy associated with this dSource.
+            - replica_retention_policy_id: The id of the replica retention policy associated with th...
+            - quota_policy_id: The id of the quota policy associated with this dSource.
+            - logsync_enabled: True if LogSync is enabled for this dSource.
+            - logsync_mode:
+            - logsync_interval: Interval between LogSync requests, in seconds.
+            - exported_data_directory: ZFS exported data directory path.
+            - template_id: A reference to the Non Virtual Database Template.
+            - allow_auto_staging_restart_on_host_reboot: Indicates whether Delphix should automatically restart th...
+            - physical_standby: Indicates whether this staging database is configured as ...
+            - validate_by_opening_db_in_read_only_mode: Indicates whether this staging database snapshot is valid...
+            - mssql_sync_strategy_managed_type:
+            - validated_sync_mode: Specifies the backup types ValidatedSync will use to sync...
+            - shared_backup_locations: Shared source database backup locations.
+            - backup_policy: Specify which node of an availability group to run the co...
+            - compression_enabled: Specify whether the backups taken should be compressed or...
+            - staging_database_name: The name of the staging database
+            - db_state: User provided db state that is used to create staging pus...
+            - encryption_key: The encryption key to use when restoring encrypted backups.
+            - external_netbackup_config_master_name: The master server name of this NetBackup configuration.
+            - external_netbackup_config_source_client_name: The source's client server name of this NetBackup configu...
+            - external_netbackup_config_params: NetBackup configuration parameter overrides.
+            - external_netbackup_config_templates: Optional config template selection for NetBackup configur...
+            - external_commserve_host_name: The commserve host name of this Commvault configuration.
+            - external_commvault_config_source_client_name: The source client name of this Commvault configuration.
+            - external_commvault_config_staging_client_name: The staging client name of this Commvault configuration.
+            - external_commvault_config_params: Commvault configuration parameter overrides.
+            - external_commvault_config_templates: Optional config template selection for Commvault configur...
+            - mssql_user_type: Database user type for Database authentication.
+            - domain_user_credential_type: credential types.
+            - mssql_database_username: The database user name for database user type.
+            - mssql_user_environment_reference: The name or reference of the environment user for environ...
+            - mssql_user_domain_username: Domain User name for password credentials.
+            - mssql_user_domain_vault_username: Delphix display name for the vault user.
+            - mssql_user_domain_vault: The name or reference of the vault.
+            - mssql_user_domain_hashicorp_vault_engine: Vault engine name where the credential is stored.
+            - mssql_user_domain_hashicorp_vault_secret_path: Path in the vault engine where the credential is stored.
+            - mssql_user_domain_hashicorp_vault_username_key: Hashicorp vault key for the username in the key-value store.
+            - mssql_user_domain_hashicorp_vault_secret_key: Hashicorp vault key for the password in the key-value store.
+            - mssql_user_domain_azure_vault_name: Azure key vault name.
+            - mssql_user_domain_azure_vault_username_key: Azure vault key in the key-value store.
+            - mssql_user_domain_azure_vault_secret_key: Azure vault key in the key-value store.
+            - mssql_user_domain_cyberark_vault_query_string: Query to find a credential in the CyberArk vault.
+            - diagnose_no_logging_faults: If true, NOLOGGING operations on this container are treat...
+            - pre_provisioning_enabled: If true, pre-provisioning will be performed after every s...
+            - backup_level_enabled: Boolean value indicates whether LEVEL-based incremental b...
+            - rman_channels: Number of parallel channels to use.
+            - files_per_set: Number of data files to include in each RMAN backup set.
+            - check_logical: True if extended block checking should be used for this l...
+            - encrypted_linking_enabled: True if SnapSync data from the source should be retrieved...
+            - compressed_linking_enabled: True if SnapSync data from the source should be compresse...
+            - bandwidth_limit: Bandwidth limit (MB/s) for SnapSync and LogSync network t...
+            - number_of_connections: Total number of transport connections to use during SnapS...
+            - data_connection_id: The ID of the associated DataConnection.
+
+        Filter Syntax:
+            Operators: EQ, NE, GT, GE, LT, LE, CONTAINS, IN, NOT_IN
+            Combine: AND, OR
+            Example: "name CONTAINS 'prod' AND status EQ 'RUNNING'"
+
+        Example:
+            >>> data_tool(action='search_dsources', limit=..., cursor=..., sort=..., permission=..., filter_expression="name CONTAINS 'test'")
+
+        ACTION: get_dsource
+        ----------------------------------------
+        Summary: Get a dSource by ID.
+        Method: GET
+        Endpoint: /dsources/{dsourceId}
+        Required Parameters: dsource_id
+
+        Example:
+            >>> data_tool(action='get_dsource', dsource_id='example-dsource-123')
+
+        ACTION: delete_dsource
+        ----------------------------------------
+        Summary: Delete the specified dSource.
+        Method: POST
+        Endpoint: /dsources/delete
+        Required Parameters: dsource_id
+        Key Parameters (provide as applicable): force, delete_all_dependent_vdbs, oracle_username, oracle_password
+
+        Example:
+            >>> data_tool(action='delete_dsource', force=..., delete_all_dependent_vdbs=..., dsource_id='example-dsource-123', oracle_username=..., oracle_password=...)
+
+        ACTION: enable_dsource
+        ----------------------------------------
+        Summary: Enable a dSource.
+        Method: POST
+        Endpoint: /dsources/{dsourceId}/enable
+        Required Parameters: dsource_id
+        Key Parameters (provide as applicable): attempt_start
+
+        Example:
+            >>> data_tool(action='enable_dsource', attempt_start=..., dsource_id='example-dsource-123')
+
+        ACTION: disable_dsource
+        ----------------------------------------
+        Summary: Disable a dSource.
+        Method: POST
+        Endpoint: /dsources/{dsourceId}/disable
+        Required Parameters: dsource_id
+        Key Parameters (provide as applicable): attempt_cleanup
+
+        Example:
+            >>> data_tool(action='disable_dsource', attempt_cleanup=..., dsource_id='example-dsource-123')
+
+        ACTION: list_dsource_snapshots
+        ----------------------------------------
+        Summary: List Snapshots for a dSource.
+        Method: GET
+        Endpoint: /dsources/{dsourceId}/snapshots
+        Required Parameters: limit, cursor, dsource_id
+
+        Example:
+            >>> data_tool(action='list_dsource_snapshots', limit=..., cursor=..., dsource_id='example-dsource-123')
+
+        ACTION: dsource_create_snapshot
+        ----------------------------------------
+        Summary: Snapshot a dSource.
+        Method: POST
+        Endpoint: /dsources/{dsourceId}/snapshots
+        Required Parameters: dsource_id
+        Key Parameters (provide as applicable): drop_and_recreate_devices, sync_strategy, ase_backup_files, mssql_backup_uuid, compression_enabled, availability_group_backup_policy, do_not_resume, double_sync, force_full_backup, skip_space_check, files_for_partial_full_backup, appdata_parameters, rman_rate_in__m_b
+
+        Example:
+            >>> data_tool(action='dsource_create_snapshot', dsource_id='example-dsource-123', drop_and_recreate_devices=..., sync_strategy=..., ase_backup_files=..., mssql_backup_uuid=..., compression_enabled=..., availability_group_backup_policy=..., do_not_resume=..., double_sync=..., force_full_backup=..., skip_space_check=..., files_for_partial_full_backup=..., appdata_parameters=..., rman_rate_in__m_b=...)
+
+        ACTION: upgrade_dsource
+        ----------------------------------------
+        Summary: Upgrade dSource
+        Method: POST
+        Endpoint: /dsources/{dsourceId}/upgrade
+        Required Parameters: repository_id, dsource_id
+        Key Parameters (provide as applicable): environment_user_id, ppt_repository
+
+        Example:
+            >>> data_tool(action='upgrade_dsource', environment_user_id='example-environment_user-123', repository_id='example-repository-123', ppt_repository=..., dsource_id='example-dsource-123')
+
+        ACTION: get_dsource_upgrade_compatible_repositories
+        ----------------------------------------
+        Summary: Returns a list of compatible repositories for dSource upgrade.
+        Method: GET
+        Endpoint: /dsources/{dsourceId}/upgrade_compatible_repositories
+        Required Parameters: dsource_id
+
+        Example:
+            >>> data_tool(action='get_dsource_upgrade_compatible_repositories', dsource_id='example-dsource-123')
+
+        ACTION: get_dsource_deletion_dependencies
+        ----------------------------------------
+        Summary: Get deletion dependencies for a dSource.
+        Method: GET
+        Endpoint: /dsources/{dsourceId}/deletion-dependencies
+        Required Parameters: dsource_id
+
+        Example:
+            >>> data_tool(action='get_dsource_deletion_dependencies', dsource_id='example-dsource-123')
+
+        ACTION: get_dsource_tags
+        ----------------------------------------
+        Summary: Get tags for a dSource.
+        Method: GET
+        Endpoint: /dsources/{dsourceId}/tags
+        Required Parameters: dsource_id
+
+        Example:
+            >>> data_tool(action='get_dsource_tags', dsource_id='example-dsource-123')
+
+        ACTION: add_dsource_tags
+        ----------------------------------------
+        Summary: Create tags for a dSource.
+        Method: POST
+        Endpoint: /dsources/{dsourceId}/tags
+        Required Parameters: tags, dsource_id
+
+        Example:
+            >>> data_tool(action='add_dsource_tags', tags=..., dsource_id='example-dsource-123')
+
+        ACTION: delete_dsource_tags
+        ----------------------------------------
+        Summary: Delete tags for a dSource.
+        Method: POST
+        Endpoint: /dsources/{dsourceId}/tags/delete
+        Required Parameters: dsource_id
+        Key Parameters (provide as applicable): tags, key, value
+
+        Example:
+            >>> data_tool(action='delete_dsource_tags', tags=..., dsource_id='example-dsource-123', key=..., value=...)
+
+        ACTION: dsource_link_oracle
+        ----------------------------------------
+        Summary: Link Oracle database as dSource.
+        Method: POST
+        Endpoint: /dsources/oracle
+        Key Parameters (provide as applicable): environment_user_id, rman_channels, do_not_resume, double_sync, force_full_backup, skip_space_check, rman_rate_in__m_b, external_file_path, backup_level_enabled, files_per_set, check_logical, encrypted_linking_enabled, compressed_linking_enabled, bandwidth_limit, number_of_connections, diagnose_no_logging_faults, pre_provisioning_enabled, link_now, files_for_full_backup, log_sync_mode, log_sync_interval, non_sys_username, non_sys_password, non_sys_vault_username, non_sys_vault, non_sys_hashicorp_vault_engine, non_sys_hashicorp_vault_secret_path, non_sys_hashicorp_vault_username_key, non_sys_hashicorp_vault_secret_key, non_sys_azure_vault_name, non_sys_azure_vault_username_key, non_sys_azure_vault_secret_key, non_sys_cyberark_vault_query_string, fallback_username, fallback_password, fallback_vault_username, fallback_vault, fallback_hashicorp_vault_engine, fallback_hashicorp_vault_secret_path, fallback_hashicorp_vault_username_key, fallback_hashicorp_vault_secret_key, fallback_azure_vault_name, fallback_azure_vault_username_key, fallback_azure_vault_secret_key, fallback_cyberark_vault_query_string, ops_pre_log_sync
+
+        Example:
+            >>> data_tool(action='dsource_link_oracle', environment_user_id='example-environment_user-123', rman_channels=..., do_not_resume=..., double_sync=..., force_full_backup=..., skip_space_check=..., rman_rate_in__m_b=..., external_file_path=..., backup_level_enabled=..., files_per_set=..., check_logical=..., encrypted_linking_enabled=..., compressed_linking_enabled=..., bandwidth_limit=..., number_of_connections=..., diagnose_no_logging_faults=..., pre_provisioning_enabled=..., link_now=..., files_for_full_backup=..., log_sync_mode=..., log_sync_interval=..., non_sys_username=..., non_sys_password=..., non_sys_vault_username=..., non_sys_vault=..., non_sys_hashicorp_vault_engine=..., non_sys_hashicorp_vault_secret_path=..., non_sys_hashicorp_vault_username_key=..., non_sys_hashicorp_vault_secret_key=..., non_sys_azure_vault_name=..., non_sys_azure_vault_username_key=..., non_sys_azure_vault_secret_key=..., non_sys_cyberark_vault_query_string=..., fallback_username=..., fallback_password=..., fallback_vault_username=..., fallback_vault=..., fallback_hashicorp_vault_engine=..., fallback_hashicorp_vault_secret_path=..., fallback_hashicorp_vault_username_key=..., fallback_hashicorp_vault_secret_key=..., fallback_azure_vault_name=..., fallback_azure_vault_username_key=..., fallback_azure_vault_secret_key=..., fallback_cyberark_vault_query_string=..., ops_pre_log_sync=...)
+
+        ACTION: dsource_link_oracle_defaults
+        ----------------------------------------
+        Summary: Get defaults for dSource linking.
+        Method: POST
+        Endpoint: /dsources/oracle/defaults
+        Required Parameters: source_id
+
+        Example:
+            >>> data_tool(action='dsource_link_oracle_defaults', source_id='example-source-123')
+
+        ACTION: dsource_link_oracle_staging_push
+        ----------------------------------------
+        Summary: Link an Oracle staging push database as dSource.
+        Method: POST
+        Endpoint: /dsources/oracle/staging-push
+        Key Parameters (provide as applicable): environment_user_id, template_id, database_name, tde_keystore_config_type, engine_id, mount_base, ops_pre_log_sync, container_type, repository, database_unique_name, sid, custom_env_variables_pairs, custom_env_variables_paths, auto_staging_restart, allow_auto_staging_restart_on_host_reboot, physical_standby, validate_snapshot_in_readonly, validate_by_opening_db_in_read_only_mode, staging_database_templates, staging_database_config_params, staging_container_database_reference
+
+        Example:
+            >>> data_tool(action='dsource_link_oracle_staging_push', environment_user_id='example-environment_user-123', template_id='example-template-123', database_name=..., tde_keystore_config_type=..., engine_id='example-engine-123', mount_base=..., ops_pre_log_sync=..., container_type=..., repository=..., database_unique_name=..., sid=..., custom_env_variables_pairs=..., custom_env_variables_paths=..., auto_staging_restart=..., allow_auto_staging_restart_on_host_reboot=..., physical_standby=..., validate_snapshot_in_readonly=..., validate_by_opening_db_in_read_only_mode=..., staging_database_templates=..., staging_database_config_params=..., staging_container_database_reference=...)
+
+        ACTION: dsource_link_oracle_staging_push_defaults
+        ----------------------------------------
+        Summary: Get defaults for a Oracle staging push dSource linking.
+        Method: POST
+        Endpoint: /dsources/oracle/staging-push/defaults
+        Required Parameters: environment_id
+        Key Parameters (provide as applicable): container_type
+
+        Example:
+            >>> data_tool(action='dsource_link_oracle_staging_push_defaults', environment_id='example-environment-123', container_type=...)
+
+        ACTION: update_oracle_dsource
+        ----------------------------------------
+        Summary: Update values of an Oracle dSource
+        Method: PATCH
+        Endpoint: /dsources/oracle/{dsourceId}
+        Required Parameters: dsource_id
+        Key Parameters (provide as applicable): name, description, db_username, db_password, validate_db_credentials, environment_user_id, template_id, hooks, rman_channels, external_file_path, backup_level_enabled, files_per_set, check_logical, encrypted_linking_enabled, compressed_linking_enabled, bandwidth_limit, number_of_connections, diagnose_no_logging_faults, pre_provisioning_enabled, non_sys_username, non_sys_password, repository, custom_env_variables_pairs, custom_env_variables_paths, allow_auto_staging_restart_on_host_reboot, physical_standby, validate_by_opening_db_in_read_only_mode, staging_database_config_params, rac_max_instance_lag, logsync_enabled, logsync_mode, logsync_interval
+
+        Example:
+            >>> data_tool(action='update_oracle_dsource', name=..., description=..., db_username=..., db_password=..., validate_db_credentials=..., environment_user_id='example-environment_user-123', template_id='example-template-123', hooks=..., rman_channels=..., dsource_id='example-dsource-123', external_file_path=..., backup_level_enabled=..., files_per_set=..., check_logical=..., encrypted_linking_enabled=..., compressed_linking_enabled=..., bandwidth_limit=..., number_of_connections=..., diagnose_no_logging_faults=..., pre_provisioning_enabled=..., non_sys_username=..., non_sys_password=..., repository=..., custom_env_variables_pairs=..., custom_env_variables_paths=..., allow_auto_staging_restart_on_host_reboot=..., physical_standby=..., validate_by_opening_db_in_read_only_mode=..., staging_database_config_params=..., rac_max_instance_lag=..., logsync_enabled=..., logsync_mode=..., logsync_interval=...)
+
+        ACTION: attach_oracle_dsource
+        ----------------------------------------
+        Summary: Attach an Oracle dSource to an Oracle database.
+        Method: POST
+        Endpoint: /dsources/oracle/{dsourceId}/attachSource
+        Required Parameters: dsource_id, source_id
+
+        Example:
+            >>> data_tool(action='attach_oracle_dsource', dsource_id='example-dsource-123', source_id='example-source-123')
+
+        ACTION: detach_oracle_dsource
+        ----------------------------------------
+        Summary: Detaches an Oracle source from an Oracle database.
+        Method: POST
+        Endpoint: /dsources/oracle/{dsourceId}/detachSource
+        Required Parameters: dsource_id
+
+        Example:
+            >>> data_tool(action='detach_oracle_dsource', dsource_id='example-dsource-123')
+
+        ACTION: upgrade_oracle_dsource
+        ----------------------------------------
+        Summary: Upgrade the requested Oracle dSource installation and user.
+        Method: POST
+        Endpoint: /dsources/oracle/{dsourceId}/upgrade
+        Required Parameters: environment_user_id, repository_id, dsource_id
+
+        Example:
+            >>> data_tool(action='upgrade_oracle_dsource', environment_user_id='example-environment_user-123', repository_id='example-repository-123', dsource_id='example-dsource-123')
+
+        ACTION: dsource_link_ase
+        ----------------------------------------
+        Summary: Link an ASE database as dSource.
+        Method: POST
+        Endpoint: /dsources/ase
+        Key Parameters (provide as applicable): db_password, mount_base, drop_and_recreate_devices, sync_strategy, ase_backup_files, external_file_path, load_backup_path, backup_server_name, backup_host_user, backup_host, dump_credentials, source_host_user, db_user, db_vault_username, db_vault, db_hashicorp_vault_engine, db_hashicorp_vault_secret_path, db_hashicorp_vault_username_key, db_hashicorp_vault_secret_key, db_azure_vault_name, db_azure_vault_username_key, db_azure_vault_secret_key, db_cyberark_vault_query_string, staging_repository, staging_host_user, validated_sync_mode, dump_history_file_enabled, pre_validated_sync, post_validated_sync
+
+        Example:
+            >>> data_tool(action='dsource_link_ase', db_password=..., mount_base=..., drop_and_recreate_devices=..., sync_strategy=..., ase_backup_files=..., external_file_path=..., load_backup_path=..., backup_server_name=..., backup_host_user=..., backup_host=..., dump_credentials=..., source_host_user=..., db_user=..., db_vault_username=..., db_vault=..., db_hashicorp_vault_engine=..., db_hashicorp_vault_secret_path=..., db_hashicorp_vault_username_key=..., db_hashicorp_vault_secret_key=..., db_azure_vault_name=..., db_azure_vault_username_key=..., db_azure_vault_secret_key=..., db_cyberark_vault_query_string=..., staging_repository=..., staging_host_user=..., validated_sync_mode=..., dump_history_file_enabled=..., pre_validated_sync=..., post_validated_sync=...)
+
+        ACTION: dsource_link_ase_defaults
+        ----------------------------------------
+        Summary: Get defaults for an ASE dSource linking.
+        Method: POST
+        Endpoint: /dsources/ase/defaults
+        Required Parameters: source_id
+
+        Example:
+            >>> data_tool(action='dsource_link_ase_defaults', source_id='example-source-123')
+
+        ACTION: update_ase_dsource
+        ----------------------------------------
+        Summary: Update values of an ASE dSource
+        Method: PATCH
+        Endpoint: /dsources/ase/{dsourceId}
+        Required Parameters: dsource_id
+        Key Parameters (provide as applicable): name, description, hooks, retention_policy_id, sync_policy_id
+
+        Example:
+            >>> data_tool(action='update_ase_dsource', name=..., description=..., hooks=..., retention_policy_id='example-retention_policy-123', dsource_id='example-dsource-123', sync_policy_id='example-sync_policy-123')
+
+        ACTION: dsource_link_appdata
+        ----------------------------------------
+        Summary: Link an AppData database as dSource.
+        Method: POST
+        Endpoint: /dsources/appdata
+        Key Parameters (provide as applicable): environment_user, link_type, staging_mount_base, staging_environment, staging_environment_user, excludes, follow_symlinks, parameters, sync_parameters
+
+        Example:
+            >>> data_tool(action='dsource_link_appdata', environment_user=..., link_type=..., staging_mount_base=..., staging_environment=..., staging_environment_user=..., excludes=..., follow_symlinks=..., parameters=..., sync_parameters=...)
+
+            IMPORTANT — AppData toolkit schema: Before populating toolkit-specific parameters, call toolkit_tool(action='search') to list available toolkits. Filter results by the engine_id of the environment you are operating on — use only toolkits whose engine_id matches.
+        Use the matching toolkit's 'linked_source_definition.parameters' schema to populate 'parameters', and 'snapshot_parameters_definition' for 'sync_parameters'.
+
+        ACTION: dsource_link_appdata_defaults
+        ----------------------------------------
+        Summary: Get defaults for an AppData dSource linking.
+        Method: POST
+        Endpoint: /dsources/appdata/defaults
+        Required Parameters: source_id
+
+        Example:
+            >>> data_tool(action='dsource_link_appdata_defaults', source_id='example-source-123')
+
+            IMPORTANT — AppData toolkit schema: Before populating toolkit-specific parameters, call toolkit_tool(action='search') to list available toolkits. Filter results by the engine_id of the environment you are operating on — use only toolkits whose engine_id matches.
+        Use the matching toolkit's 'linked_source_definition.parameters' schema to populate 'parameters', and 'snapshot_parameters_definition' for 'sync_parameters'.
+
+        ACTION: update_appdata_dsource
+        ----------------------------------------
+        Summary: Update values of an AppData dSource
+        Method: PATCH
+        Endpoint: /dsources/appdata/{dsourceId}
+        Required Parameters: dsource_id
+        Key Parameters (provide as applicable): name, description, hooks, retention_policy_id, sync_policy_id, ops_pre_sync, ops_post_sync, environment_user, staging_environment, staging_environment_user, parameters
+
+        Example:
+            >>> data_tool(action='update_appdata_dsource', name=..., description=..., hooks=..., retention_policy_id='example-retention_policy-123', dsource_id='example-dsource-123', sync_policy_id='example-sync_policy-123', ops_pre_sync=..., ops_post_sync=..., environment_user=..., staging_environment=..., staging_environment_user=..., parameters=...)
+
+            IMPORTANT — AppData toolkit schema: Before populating toolkit-specific parameters, call toolkit_tool(action='search') to list available toolkits. Filter results by the engine_id of the environment you are operating on — use only toolkits whose engine_id matches.
+        Use the matching toolkit's 'linked_source_definition.parameters' schema to populate 'parameters', and 'snapshot_parameters_definition' for 'sync_parameters'.
+
+        ACTION: dsource_link_mssql
+        ----------------------------------------
+        Summary: Link a MSSql database as dSource.
+        Method: POST
+        Endpoint: /dsources/mssql
+        Key Parameters (provide as applicable): ppt_repository, sync_strategy, mssql_backup_uuid, compression_enabled, availability_group_backup_policy, source_host_user, encryption_key, ppt_host_user, staging_pre_script, staging_post_script, sync_strategy_managed_type, mssql_user_environment_reference, mssql_user_domain_username, mssql_user_domain_password, mssql_user_domain_vault_username, mssql_user_domain_vault, mssql_user_domain_hashicorp_vault_engine, mssql_user_domain_hashicorp_vault_secret_path, mssql_user_domain_hashicorp_vault_username_key, mssql_user_domain_hashicorp_vault_secret_key, mssql_user_domain_azure_vault_name, mssql_user_domain_azure_vault_username_key, mssql_user_domain_azure_vault_secret_key, mssql_user_domain_cyberark_vault_query_string, mssql_database_username, mssql_database_password, delphix_managed_backup_compression_enabled, delphix_managed_backup_policy, external_managed_validate_sync_mode, external_managed_shared_backup_locations, external_netbackup_config_master_name, external_netbackup_config_source_client_name, external_netbackup_config_params, external_netbackup_config_templates, external_commserve_host_name, external_commvault_config_source_client_name, external_commvault_config_staging_client_name, external_commvault_config_params, external_commvault_config_templates
+
+        Example:
+            >>> data_tool(action='dsource_link_mssql', ppt_repository=..., sync_strategy=..., mssql_backup_uuid=..., compression_enabled=..., availability_group_backup_policy=..., source_host_user=..., encryption_key=..., ppt_host_user=..., staging_pre_script=..., staging_post_script=..., sync_strategy_managed_type=..., mssql_user_environment_reference=..., mssql_user_domain_username=..., mssql_user_domain_password=..., mssql_user_domain_vault_username=..., mssql_user_domain_vault=..., mssql_user_domain_hashicorp_vault_engine=..., mssql_user_domain_hashicorp_vault_secret_path=..., mssql_user_domain_hashicorp_vault_username_key=..., mssql_user_domain_hashicorp_vault_secret_key=..., mssql_user_domain_azure_vault_name=..., mssql_user_domain_azure_vault_username_key=..., mssql_user_domain_azure_vault_secret_key=..., mssql_user_domain_cyberark_vault_query_string=..., mssql_database_username=..., mssql_database_password=..., delphix_managed_backup_compression_enabled=..., delphix_managed_backup_policy=..., external_managed_validate_sync_mode=..., external_managed_shared_backup_locations=..., external_netbackup_config_master_name=..., external_netbackup_config_source_client_name=..., external_netbackup_config_params=..., external_netbackup_config_templates=..., external_commserve_host_name=..., external_commvault_config_source_client_name=..., external_commvault_config_staging_client_name=..., external_commvault_config_params=..., external_commvault_config_templates=...)
+
+        ACTION: dsource_link_mssql_defaults
+        ----------------------------------------
+        Summary: Get defaults for a MSSql dSource linking.
+        Method: POST
+        Endpoint: /dsources/mssql/defaults
+        Required Parameters: source_id
+
+        Example:
+            >>> data_tool(action='dsource_link_mssql_defaults', source_id='example-source-123')
+
+        ACTION: dsource_link_mssql_staging_push
+        ----------------------------------------
+        Summary: Link a MSSql staging push database as dSource.
+        Method: POST
+        Endpoint: /dsources/mssql/staging-push
+        Key Parameters (provide as applicable): engine_id, ppt_repository, encryption_key, ppt_host_user, staging_pre_script, staging_post_script, staging_database_name, db_state
+
+        Example:
+            >>> data_tool(action='dsource_link_mssql_staging_push', engine_id='example-engine-123', ppt_repository=..., encryption_key=..., ppt_host_user=..., staging_pre_script=..., staging_post_script=..., staging_database_name=..., db_state=...)
+
+        ACTION: dsource_link_mssql_staging_push_defaults
+        ----------------------------------------
+        Summary: Get defaults for a MSSql staging push dSource linking.
+        Method: POST
+        Endpoint: /dsources/mssql/staging-push/defaults
+        Required Parameters: environment_id
+
+        Example:
+            >>> data_tool(action='dsource_link_mssql_staging_push_defaults', environment_id='example-environment-123')
+
+        ACTION: attach_mssql_staging_push_dsource
+        ----------------------------------------
+        Summary: Attaches a MSSql staging push database to a previously detached dsource.
+        Method: POST
+        Endpoint: /dsources/mssql/staging-push/{dsourceId}/attachSource
+        Required Parameters: ppt_repository, dsource_id, staging_database_name
+        Key Parameters (provide as applicable): ops_pre_sync, ops_post_sync, encryption_key, ppt_host_user, staging_pre_script, staging_post_script, db_state
+
+        Example:
+            >>> data_tool(action='attach_mssql_staging_push_dsource', ppt_repository=..., dsource_id='example-dsource-123', ops_pre_sync=..., ops_post_sync=..., encryption_key=..., ppt_host_user=..., staging_pre_script=..., staging_post_script=..., staging_database_name=..., db_state=...)
+
+        ACTION: update_mssql_dsource
+        ----------------------------------------
+        Summary: Update values of an MSSql dSource
+        Method: PATCH
+        Endpoint: /dsources/mssql/{dsourceId}
+        Required Parameters: dsource_id
+        Key Parameters (provide as applicable): name, hooks, retention_policy_id, ppt_repository, sync_policy_id, logsync_enabled, source_host_user, encryption_key, ppt_host_user, sync_strategy_managed_type, mssql_user_environment_reference, mssql_user_domain_username, mssql_user_domain_password, mssql_user_domain_vault_username, mssql_user_domain_vault, mssql_user_domain_hashicorp_vault_engine, mssql_user_domain_hashicorp_vault_secret_path, mssql_user_domain_hashicorp_vault_username_key, mssql_user_domain_hashicorp_vault_secret_key, mssql_user_domain_azure_vault_name, mssql_user_domain_azure_vault_username_key, mssql_user_domain_azure_vault_secret_key, mssql_user_domain_cyberark_vault_query_string, mssql_database_username, mssql_database_password, delphix_managed_backup_compression_enabled, delphix_managed_backup_policy, external_managed_validate_sync_mode, external_managed_shared_backup_locations, external_netbackup_config_master_name, external_netbackup_config_source_client_name, external_netbackup_config_params, external_netbackup_config_templates, external_commserve_host_name, external_commvault_config_source_client_name, external_commvault_config_staging_client_name, external_commvault_config_params, external_commvault_config_templates, disable_netbackup_config, disable_commvault_config
+
+        Example:
+            >>> data_tool(action='update_mssql_dsource', name=..., hooks=..., retention_policy_id='example-retention_policy-123', ppt_repository=..., dsource_id='example-dsource-123', sync_policy_id='example-sync_policy-123', logsync_enabled=..., source_host_user=..., encryption_key=..., ppt_host_user=..., sync_strategy_managed_type=..., mssql_user_environment_reference=..., mssql_user_domain_username=..., mssql_user_domain_password=..., mssql_user_domain_vault_username=..., mssql_user_domain_vault=..., mssql_user_domain_hashicorp_vault_engine=..., mssql_user_domain_hashicorp_vault_secret_path=..., mssql_user_domain_hashicorp_vault_username_key=..., mssql_user_domain_hashicorp_vault_secret_key=..., mssql_user_domain_azure_vault_name=..., mssql_user_domain_azure_vault_username_key=..., mssql_user_domain_azure_vault_secret_key=..., mssql_user_domain_cyberark_vault_query_string=..., mssql_database_username=..., mssql_database_password=..., delphix_managed_backup_compression_enabled=..., delphix_managed_backup_policy=..., external_managed_validate_sync_mode=..., external_managed_shared_backup_locations=..., external_netbackup_config_master_name=..., external_netbackup_config_source_client_name=..., external_netbackup_config_params=..., external_netbackup_config_templates=..., external_commserve_host_name=..., external_commvault_config_source_client_name=..., external_commvault_config_staging_client_name=..., external_commvault_config_params=..., external_commvault_config_templates=..., disable_netbackup_config=..., disable_commvault_config=...)
+
+        ACTION: attach_mssql_dsource
+        ----------------------------------------
+        Summary: Attaches a MSSql source to a previously detached dsource.
+        Method: POST
+        Endpoint: /dsources/mssql/{dsourceId}/attachSource
+        Required Parameters: ppt_repository, dsource_id, source_id
+        Key Parameters (provide as applicable): ops_pre_sync, ops_post_sync, source_host_user, encryption_key, ppt_host_user, staging_pre_script, staging_post_script, sync_strategy_managed_type, mssql_user_environment_reference, mssql_user_domain_username, mssql_user_domain_password, mssql_user_domain_vault_username, mssql_user_domain_vault, mssql_user_domain_hashicorp_vault_engine, mssql_user_domain_hashicorp_vault_secret_path, mssql_user_domain_hashicorp_vault_username_key, mssql_user_domain_hashicorp_vault_secret_key, mssql_user_domain_azure_vault_name, mssql_user_domain_azure_vault_username_key, mssql_user_domain_azure_vault_secret_key, mssql_user_domain_cyberark_vault_query_string, mssql_database_username, mssql_database_password, delphix_managed_backup_compression_enabled, delphix_managed_backup_policy, external_managed_validate_sync_mode, external_managed_shared_backup_locations, external_netbackup_config_master_name, external_netbackup_config_source_client_name, external_netbackup_config_params, external_netbackup_config_templates, external_commserve_host_name, external_commvault_config_source_client_name, external_commvault_config_staging_client_name, external_commvault_config_params, external_commvault_config_templates
+
+        Example:
+            >>> data_tool(action='attach_mssql_dsource', ppt_repository=..., dsource_id='example-dsource-123', source_id='example-source-123', ops_pre_sync=..., ops_post_sync=..., source_host_user=..., encryption_key=..., ppt_host_user=..., staging_pre_script=..., staging_post_script=..., sync_strategy_managed_type=..., mssql_user_environment_reference=..., mssql_user_domain_username=..., mssql_user_domain_password=..., mssql_user_domain_vault_username=..., mssql_user_domain_vault=..., mssql_user_domain_hashicorp_vault_engine=..., mssql_user_domain_hashicorp_vault_secret_path=..., mssql_user_domain_hashicorp_vault_username_key=..., mssql_user_domain_hashicorp_vault_secret_key=..., mssql_user_domain_azure_vault_name=..., mssql_user_domain_azure_vault_username_key=..., mssql_user_domain_azure_vault_secret_key=..., mssql_user_domain_cyberark_vault_query_string=..., mssql_database_username=..., mssql_database_password=..., delphix_managed_backup_compression_enabled=..., delphix_managed_backup_policy=..., external_managed_validate_sync_mode=..., external_managed_shared_backup_locations=..., external_netbackup_config_master_name=..., external_netbackup_config_source_client_name=..., external_netbackup_config_params=..., external_netbackup_config_templates=..., external_commserve_host_name=..., external_commvault_config_source_client_name=..., external_commvault_config_staging_client_name=..., external_commvault_config_params=..., external_commvault_config_templates=...)
+
+        ACTION: detach_mssql_dsource
+        ----------------------------------------
+        Summary: Detaches a linked source from a MSSql database.
+        Method: POST
+        Endpoint: /dsources/mssql/{dsourceId}/detachSource
+        Required Parameters: dsource_id
+
+        Example:
+            >>> data_tool(action='detach_mssql_dsource', dsource_id='example-dsource-123')
+
+        ACTION: export_dsource_by_snapshot
+        ----------------------------------------
+        Summary: Export a dSource using snapshot to a physical file system
+        Method: POST
+        Endpoint: /dsources/{dsourceId}/export-by-snapshot
+        Required Parameters: dsource_id
+        Key Parameters (provide as applicable): snapshot_id, rman_channels, rman_file_section_size_in_gb
+
+        Example:
+            >>> data_tool(action='export_dsource_by_snapshot', snapshot_id='example-snapshot-123', rman_channels=..., rman_file_section_size_in_gb=..., dsource_id='example-dsource-123')
+
+        ACTION: export_dsource_by_timestamp
+        ----------------------------------------
+        Summary: Export a dSource using timestamp to a physical file system.
+        Method: POST
+        Endpoint: /dsources/{dsourceId}/export-by-timestamp
+        Required Parameters: timestamp, timeflow_id, dsource_id
+        Key Parameters (provide as applicable): rman_channels, rman_file_section_size_in_gb
+
+        Example:
+            >>> data_tool(action='export_dsource_by_timestamp', timestamp=..., timeflow_id='example-timeflow-123', rman_channels=..., rman_file_section_size_in_gb=..., dsource_id='example-dsource-123')
+
+        ACTION: export_dsource_by_location
+        ----------------------------------------
+        Summary: Export a dSource using timeflow location to a physical file system.
+        Method: POST
+        Endpoint: /dsources/{dsourceId}/export-by-location
+        Required Parameters: location, dsource_id
+        Key Parameters (provide as applicable): rman_channels, rman_file_section_size_in_gb
+
+        Example:
+            >>> data_tool(action='export_dsource_by_location', location=..., rman_channels=..., rman_file_section_size_in_gb=..., dsource_id='example-dsource-123')
+
+        ACTION: export_dsource_from_bookmark
+        ----------------------------------------
+        Summary: Export a dSource using bookmark to physical file system
+        Method: POST
+        Endpoint: /dsources/{dsourceId}/export-from-bookmark
+        Required Parameters: bookmark_id, dsource_id
+        Key Parameters (provide as applicable): rman_channels, rman_file_section_size_in_gb
+
+        Example:
+            >>> data_tool(action='export_dsource_from_bookmark', bookmark_id='example-bookmark-123', rman_channels=..., rman_file_section_size_in_gb=..., dsource_id='example-dsource-123')
+
+        ACTION: export_dsource_to_asm_by_snapshot
+        ----------------------------------------
+        Summary: Export a dSource by a snapshot to an ASM file system
+        Method: POST
+        Endpoint: /dsources/{dsourceId}/asm-export-by-snapshot
+        Required Parameters: default_data_diskgroup, dsource_id
+        Key Parameters (provide as applicable): snapshot_id, rman_channels, rman_file_section_size_in_gb, redo_diskgroup
+
+        Example:
+            >>> data_tool(action='export_dsource_to_asm_by_snapshot', snapshot_id='example-snapshot-123', rman_channels=..., rman_file_section_size_in_gb=..., default_data_diskgroup=..., redo_diskgroup=..., dsource_id='example-dsource-123')
+
+        ACTION: export_dsource_to_asm_by_timestamp
+        ----------------------------------------
+        Summary: Export a dSource using timestamp to an ASM file system
+        Method: POST
+        Endpoint: /dsources/{dsourceId}/asm-export-by-timestamp
+        Required Parameters: timestamp, timeflow_id, default_data_diskgroup, dsource_id
+        Key Parameters (provide as applicable): rman_channels, rman_file_section_size_in_gb, redo_diskgroup
+
+        Example:
+            >>> data_tool(action='export_dsource_to_asm_by_timestamp', timestamp=..., timeflow_id='example-timeflow-123', rman_channels=..., rman_file_section_size_in_gb=..., default_data_diskgroup=..., redo_diskgroup=..., dsource_id='example-dsource-123')
+
+        ACTION: export_dsource_to_asm_by_location
+        ----------------------------------------
+        Summary: Export a dSource using SCN to an ASM file system
+        Method: POST
+        Endpoint: /dsources/{dsourceId}/asm-export-by-location
+        Required Parameters: location, default_data_diskgroup, dsource_id
+        Key Parameters (provide as applicable): rman_channels, rman_file_section_size_in_gb, redo_diskgroup
+
+        Example:
+            >>> data_tool(action='export_dsource_to_asm_by_location', location=..., rman_channels=..., rman_file_section_size_in_gb=..., default_data_diskgroup=..., redo_diskgroup=..., dsource_id='example-dsource-123')
+
+        ACTION: export_dsource_to_asm_from_bookmark
+        ----------------------------------------
+        Summary: Export a dSource using bookmark to an ASM file system
+        Method: POST
+        Endpoint: /dsources/{dsourceId}/asm-export-from-bookmark
+        Required Parameters: bookmark_id, default_data_diskgroup, dsource_id
+        Key Parameters (provide as applicable): rman_channels, rman_file_section_size_in_gb, redo_diskgroup
+
+        Example:
+            >>> data_tool(action='export_dsource_to_asm_from_bookmark', bookmark_id='example-bookmark-123', rman_channels=..., rman_file_section_size_in_gb=..., default_data_diskgroup=..., redo_diskgroup=..., dsource_id='example-dsource-123')
+
+        ======================================================================
+        PARAMETERS
+        ======================================================================
+
+        Args:
+            action (str): The operation to perform. One of: list_vdbs, search_vdbs, get_vdb, update_vdb, provision_by_timestamp, provision_by_timestamp_defaults, provision_by_snapshot, provision_by_snapshot_defaults, provision_from_bookmark, provision_from_bookmark_defaults, provision_by_location, provision_by_location_defaults, provision_empty_vdb, delete_vdb, start_vdb, stop_vdb, enable_vdb, disable_vdb, refresh_vdb_by_timestamp, refresh_vdb_by_snapshot, refresh_vdb_from_bookmark, refresh_vdb_by_location, undo_vdb_refresh, rollback_vdb_by_timestamp, rollback_vdb_by_snapshot, rollback_vdb_from_bookmark, switch_vdb_timeflow, lock_vdb, unlock_vdb, migrate_vdb, get_migrate_compatible_repositories, upgrade_vdb, upgrade_oracle_vdb, get_upgrade_compatible_repositories, list_vdb_snapshots, snapshot_vdb, list_vdb_bookmarks, search_vdb_bookmarks, get_vdb_deletion_dependencies, verify_vdb_jdbc_connection, get_vdb_tags, add_vdb_tags, export_vdb_in_place, export_vdb_asm_in_place, export_vdb_by_snapshot, export_vdb_by_timestamp, export_vdb_by_location, export_vdb_from_bookmark, export_vdb_to_asm_by_snapshot, export_vdb_to_asm_by_timestamp, export_vdb_to_asm_by_location, export_vdb_to_asm_from_bookmark, export_cleanup, export_finalize, list_vdb_groups, search_vdb_groups, get_vdb_group, create_vdb_group, update_vdb_group, delete_vdb_group, provision_vdb_group_from_bookmark, refresh_vdb_group, refresh_vdb_group_from_bookmark, refresh_vdb_group_by_snapshot, refresh_vdb_group_by_timestamp, rollback_vdb_group, lock_vdb_group, unlock_vdb_group, start_vdb_group, stop_vdb_group, enable_vdb_group, disable_vdb_group, get_vdb_group_latest_snapshots, get_vdb_group_timestamp_summary, list_vdb_group_bookmarks, search_vdb_group_bookmarks, get_vdb_group_tags, add_vdb_group_tags, list_dsources, search_dsources, get_dsource, delete_dsource, enable_dsource, disable_dsource, list_dsource_snapshots, dsource_create_snapshot, upgrade_dsource, get_dsource_upgrade_compatible_repositories, get_dsource_deletion_dependencies, get_dsource_tags, add_dsource_tags, delete_dsource_tags, dsource_link_oracle, dsource_link_oracle_defaults, dsource_link_oracle_staging_push, dsource_link_oracle_staging_push_defaults, update_oracle_dsource, attach_oracle_dsource, detach_oracle_dsource, upgrade_oracle_dsource, dsource_link_ase, dsource_link_ase_defaults, update_ase_dsource, dsource_link_appdata, dsource_link_appdata_defaults, update_appdata_dsource, dsource_link_mssql, dsource_link_mssql_defaults, dsource_link_mssql_staging_push, dsource_link_mssql_staging_push_defaults, attach_mssql_staging_push_dsource, update_mssql_dsource, attach_mssql_dsource, detach_mssql_dsource, export_dsource_by_snapshot, export_dsource_by_timestamp, export_dsource_by_location, export_dsource_from_bookmark, export_dsource_to_asm_by_snapshot, export_dsource_to_asm_by_timestamp, export_dsource_to_asm_by_location, export_dsource_to_asm_from_bookmark
+
+          -- General parameters (all database types) --
+            abort (bool): Whether to issue 'shutdown abort' to shutdown Oracle Virtual DB instances. (D...
+                [Optional for all actions]
+            account_id (int): Id of the account on whose behalf this request is being made. Only accounts h...
+                [Optional for all actions]
+            additional_mount_points (list): Specifies additional locations on which to mount a subdirectory of an AppData...
+                [Optional for all actions]
+            allow_auto_staging_restart_on_host_reboot (bool): Boolean value indicates whether this staging database should automatically be...
+                [Optional for all actions]
+            appdata_config_params (dict): The parameters specified by the source config schema in the toolkit (Pass as ...
+                [Optional for all actions]
+            appdata_parameters (dict): The list of parameters specified by the snapshotParametersDefinition schema i...
+                [Optional for all actions]
+            appdata_source_params (dict): The JSON payload conforming to the DraftV4 schema based on the type of applic...
+                [Optional for all actions]
+            archive_directory (str): The directory for archive files.
+                [Optional for all actions]
+            ase_backup_files (list): When using the `specific_backup` sync_strategy, determines the backup files. ...
+                [Optional for all actions]
+            attempt_cleanup (bool): Whether to attempt a cleanup of the VDB before the disable. (Default: True)
+                [Optional for all actions]
+            attempt_start (bool): Whether to attempt a startup of the VDB after the enable. (Default: True)
+                [Optional for all actions]
+            auto_restart (bool): Whether to enable VDB restart.
+                [Optional for all actions]
+            auto_select_repository (bool): Option to automatically select a compatible environment and repository. Mutua...
+                [Optional for all actions]
+            auto_staging_restart (bool): Boolean value indicates whether this staging database should automatically be...
+                [Optional for all actions]
+            availability_group_backup_policy (str): When using the `new_backup` sync_strategy for an MSSql Availability Group, de...
+                [Optional for all actions]
+            backup_frequency_minutes (int): The frequency with which the incremental backup will be taken in minutes. (De...
+                [Optional for all actions]
+            backup_host (str): Host environment where the backup server is located.
+                [Optional for all actions]
+            backup_host_user (str): OS user for the host where the backup server is located.
+                [Optional for all actions]
+            backup_level_enabled (bool): Boolean value indicates whether LEVEL-based incremental backups can be used o...
+                [Optional for all actions]
+            backup_server_name (str): Name of the backup server instance.
+                [Optional for all actions]
+            bandwidth_limit (int): Bandwidth limit (MB/s) for SnapSync and LogSync network traffic. A value of 0...
+                [Optional for all actions]
+            bookmark_id (str): The ID of the bookmark from which to execute the operation. The bookmark must...
+                [Required for: provision_from_bookmark, provision_from_bookmark_defaults, refresh_vdb_from_bookmark, rollback_vdb_from_bookmark, export_vdb_from_bookmark, export_vdb_to_asm_from_bookmark, provision_vdb_group_from_bookmark, refresh_vdb_group, refresh_vdb_group_from_bookmark, rollback_vdb_group, export_dsource_from_bookmark, export_dsource_to_asm_from_bookmark]
+            cache_priority (str): When set to a value other than NORMAL (valid only for object storage engines)...
+                [Optional for all actions]
+            cdb_tde_keystore_password (str): The password for the Transparent Data Encryption keystore associated with the...
+                [Optional for all actions]
+            cdc_on_provision (bool): Whether to enable CDC on provision for MSSql
+                [Optional for all actions]
+            check_logical (bool): True if extended block checking should be used for this linked database. (Def...
+                [Optional for all actions]
+            cleanup_target_container (bool): Flag indicating whether to delete the temporary virtual source created for ex...
+                [Optional for all actions]
+            cleanup_target_physical_files (bool): Flag indicating whether to delete the database files already copied to target...
+                [Optional for all actions]
+            compressed_linking_enabled (bool): True if SnapSync data from the source should be compressed over the network. ...
+                [Optional for all actions]
+            compression_enabled (bool): When using the `new_backup` sync_strategy, determines if compression must be ...
+                [Optional for all actions]
+            config_params (dict): Database configuration parameter overrides. (Pass as JSON object)
+                [Optional for all actions]
+            configure_clone (list): The commands to execute on the target environment when the VDB is created or ...
+                [Optional for all actions]
+            container_type (str): The container type of this database.If not provided the request would be cons...
+                [Optional for all actions]
+            crs_database_name (str): The Oracle Clusterware database name.
+                [Optional for all actions]
+            cursor (str): Cursor to fetch the next or previous page of results. The value of this prope...
+                [Required for: list_vdbs, search_vdbs, list_vdb_snapshots, list_vdb_bookmarks, search_vdb_bookmarks, list_vdb_groups, search_vdb_groups, list_vdb_group_bookmarks, search_vdb_group_bookmarks, list_dsources, search_dsources, list_dsource_snapshots]
+            custom_env_files (list): Environment files to be sourced when the Engine administers a VDB. This path ...
+                [Optional for all actions]
+            custom_env_variables_pairs (list): An array of name value pair of environment variables. (Pass as JSON array)
+                [Optional for all actions]
+            custom_env_variables_paths (list): An array of strings of whitespace-separated parameters to be passed to the so...
+                [Optional for all actions]
+            custom_env_vars (dict): Environment variable to be set when the engine administers a VDB. See the Eng...
+                [Optional for all actions]
+            data_directory (str): The directory for data files.
+                [Optional for all actions]
+            database_name (str): The name of the database in the target environment (update not applicable for...
+                [Optional for all actions]
+            database_password (str): oracle database password.
+                [Required for: verify_vdb_jdbc_connection]
+            database_unique_name (str): The unique name of the database.
+                [Optional for all actions]
+            database_username (str): oracle database username.
+                [Required for: verify_vdb_jdbc_connection]
+            dataset_id (str): ID of the dataset to refresh to, mutually exclusive with timeflow_id.
+                [Optional for all actions]
+            db_azure_vault_name (str): Azure key vault name.
+                [Optional for all actions]
+            db_azure_vault_secret_key (str): Azure vault key for the password in the key-value store.
+                [Optional for all actions]
+            db_azure_vault_username_key (str): Azure vault key for the username in the key-value store.
+                [Optional for all actions]
+            db_cyberark_vault_query_string (str): Query to find a credential in the CyberArk vault.
+                [Optional for all actions]
+            db_hashicorp_vault_engine (str): Vault engine name where the credential is stored.
+                [Optional for all actions]
+            db_hashicorp_vault_secret_key (str): Hashicorp vault key for the password in the key-value store.
+                [Optional for all actions]
+            db_hashicorp_vault_secret_path (str): Path in the vault engine where the credential is stored.
+                [Optional for all actions]
+            db_hashicorp_vault_username_key (str): Hashicorp vault key for the username in the key-value store.
+                [Optional for all actions]
+            db_password (str): The password of the database user (Oracle, ASE Only).
+                [Optional for all actions]
+            db_state (str): User provided db state that will be used to create staging push db. Default i...
+                [Optional for all actions]
+            db_unique_name (str): Unique name to be given to the database after it is converted to physical.
+                [Optional for all actions]
+            db_user (str): The user name for the source DB user.
+                [Optional for all actions]
+            db_username (str): The username of the database user (Oracle, ASE Only).
+                [Optional for all actions]
+            db_vault (str): The name or reference of the vault from which to read the database credentials.
+                [Optional for all actions]
+            db_vault_username (str): Delphix display name for the vault user.
+                [Optional for all actions]
+            default_data_diskgroup (str): Default diskgroup for datafiles.
+                [Required for: export_vdb_asm_in_place, export_vdb_to_asm_by_snapshot, export_vdb_to_asm_by_timestamp, export_vdb_to_asm_by_location, export_vdb_to_asm_from_bookmark, export_dsource_to_asm_by_snapshot, export_dsource_to_asm_by_timestamp, export_dsource_to_asm_by_location, export_dsource_to_asm_from_bookmark]
+            delete_all_dependent_vdbs (bool): Flag indicating whether to delete all dependent VDBs before deleting the VDB....
+                [Optional for all actions]
+            delphix_managed_backup_compression_enabled (bool): Specify whether the backups taken should be compressed or uncompressed when D...
+                [Optional for all actions]
+            delphix_managed_backup_policy (str): Specify which node of an availability group to run the copy-only full backup ...
+                [Optional for all actions]
+            description (str): The container description of this VDB.
+                [Optional for all actions]
+            diagnose_no_logging_faults (bool): If true, NOLOGGING operations on this container are treated as faults and can...
+                [Optional for all actions]
+            disable_commvault_config (bool): Disable Commvault configuration.
+                [Optional for all actions]
+            disable_netbackup_config (bool): Disable NetBackup configuration.
+                [Optional for all actions]
+            do_not_resume (bool): Indicates whether a fresh SnapSync must be started regardless if it was possi...
+                [Optional for all actions]
+            double_sync (bool): True if two SnapSyncs should be performed in immediate succession to reduce t...
+                [Optional for all actions]
+            drop_and_recreate_devices (bool): If this parameter is set to true, it will drop the older devices and create n...
+                [Optional for all actions]
+            dsource_id (str): The unique identifier for the dsource.
+                [Required for: get_dsource, delete_dsource, enable_dsource, disable_dsource, list_dsource_snapshots, dsource_create_snapshot, upgrade_dsource, get_dsource_upgrade_compatible_repositories, get_dsource_deletion_dependencies, get_dsource_tags, add_dsource_tags, delete_dsource_tags, update_oracle_dsource, attach_oracle_dsource, detach_oracle_dsource, upgrade_oracle_dsource, update_ase_dsource, update_appdata_dsource, attach_mssql_staging_push_dsource, update_mssql_dsource, attach_mssql_dsource, detach_mssql_dsource, export_dsource_by_snapshot, export_dsource_by_timestamp, export_dsource_by_location, export_dsource_from_bookmark, export_dsource_to_asm_by_snapshot, export_dsource_to_asm_by_timestamp, export_dsource_to_asm_by_location, export_dsource_to_asm_from_bookmark]
+            dump_credentials (str): The password credential for the source DB user.
+                [Optional for all actions]
+            dump_history_file_enabled (bool): Specifies if Dump History File is enabled for backup history detection. (Defa...
+                [Optional for all actions]
+            enable_cdc (bool): Indicates whether to enable Change Data Capture (CDC) or not on exported data...
+                [Optional for all actions]
+            encrypted_linking_enabled (bool): True if SnapSync data from the source should be retrieved through an encrypte...
+                [Optional for all actions]
+            encryption_key (str): The encryption key to use when restoring encrypted backups.
+                [Optional for all actions]
+            engine_id (str): The ID of the Engine onto which to provision. If the source ID unambiguously ...
+                [Optional for all actions]
+            environment_id (str): The ID of the target environment where to provision the VDB. If repository_id...
+                [Required for: dsource_link_oracle_staging_push_defaults, dsource_link_mssql_staging_push_defaults]
+            environment_user (str): Reference to the user that should be used in the host.
+                [Optional for all actions]
+            environment_user_id (str): The environment user ID to use to connect to the target environment.
+                [Required for: upgrade_oracle_vdb, upgrade_oracle_dsource]
+            environment_user_ref (str): Reference of the environment user.
+                [Optional for all actions]
+            excludes (list): List of subdirectories in the source to exclude when syncing data. These path...
+                [Optional for all actions]
+            external_commserve_host_name (str): The commserve host name of this Commvault configuration.
+                [Optional for all actions]
+            external_commvault_config_params (dict): Commvault configuration parameter overrides. (Pass as JSON object)
+                [Optional for all actions]
+            external_commvault_config_source_client_name (str): The source client name of this Commvault configuration.
+                [Optional for all actions]
+            external_commvault_config_staging_client_name (str): The staging client name of this Commvault configuration.
+                [Optional for all actions]
+            external_commvault_config_templates (str): Optional config template selection for Commvault configurations. If set, conf...
+                [Optional for all actions]
+            external_directory (str): The directory for external files.
+                [Optional for all actions]
+            external_file_path (str): External file path.
+                [Optional for all actions]
+            external_managed_shared_backup_locations (list): Shared source database backup locations. (Pass as JSON array)
+                [Optional for all actions]
+            external_managed_validate_sync_mode (str): Specifies the backup types ValidatedSync will use to synchronize the dSource ...
+                [Optional for all actions]
+            external_netbackup_config_master_name (str): The master server name of this NetBackup configuration.
+                [Optional for all actions]
+            external_netbackup_config_params (dict): NetBackup configuration parameter overrides. (Pass as JSON object)
+                [Optional for all actions]
+            external_netbackup_config_source_client_name (str): The source's client server name of this NetBackup configuration.
+                [Optional for all actions]
+            external_netbackup_config_templates (str): Optional config template selection for NetBackup configurations. If set, exte...
+                [Optional for all actions]
+            fallback_azure_vault_name (str): Azure key vault name.
+                [Optional for all actions]
+            fallback_azure_vault_secret_key (str): Azure vault key for the password in the key-value store.
+                [Optional for all actions]
+            fallback_azure_vault_username_key (str): Azure vault key for the username in the key-value store.
+                [Optional for all actions]
+            fallback_cyberark_vault_query_string (str): Query to find a credential in the CyberArk vault.
+                [Optional for all actions]
+            fallback_hashicorp_vault_engine (str): Vault engine name where the credential is stored.
+                [Optional for all actions]
+            fallback_hashicorp_vault_secret_key (str): Hashicorp vault key for the password in the key-value store.
+                [Optional for all actions]
+            fallback_hashicorp_vault_secret_path (str): Path in the vault engine where the credential is stored.
+                [Optional for all actions]
+            fallback_hashicorp_vault_username_key (str): Hashicorp vault key for the username in the key-value store.
+                [Optional for all actions]
+            fallback_password (str): Password for fallback username.
+                [Optional for all actions]
+            fallback_username (str): The database fallback username. Optional if bequeath connections are enabled ...
+                [Optional for all actions]
+            fallback_vault (str): The name or reference of the vault from which to read the database credentials.
+                [Optional for all actions]
+            fallback_vault_username (str): Delphix display name for the fallback vault user.
+                [Optional for all actions]
+            files_for_full_backup (list): List of datafiles to take a full backup of. This would be useful in situation...
+                [Optional for all actions]
+            files_for_partial_full_backup (list): List of datafiles to take a full backup of. This would be useful in situation...
+                [Optional for all actions]
+            files_per_set (int): Number of data files to include in each RMAN backup set. (Default: 5)
+                [Optional for all actions]
+            filter_expression (str): Request body parameter
+                [Optional for all actions]
+            follow_symlinks (list): List of symlinks in the source to follow when syncing data. These paths are r...
+                [Optional for all actions]
+            force (bool): Whether to continue the operation upon failures. (Default: False)
+                [Optional for all actions]
+            force_full_backup (bool): Whether or not to take another full backup of the source database. (Default: ...
+                [Optional for all actions]
+            group_id (str): Id of the dataset group where this dSource should belong to.
+                [Optional for all actions]
+            hooks (dict): VDB operation hooks. (Pass as JSON object)
+                [Optional for all actions]
+            instance_number (int): The number of the instance.
+                [Optional for all actions]
+            instances (list): The instances of this RAC database. (Pass as JSON array)
+                [Optional for all actions]
+            invoke_datapatch (bool): Indicates whether datapatch should be invoked.
+                [Optional for all actions]
+            is_incremental_v2p (bool): Whether to enable incremental V2P (Virtual to Physical) export. When enabled,...
+                [Optional for all actions]
+            is_refresh_to_nearest (bool): If true, and the provided timestamp is not found for the VDB mapping, the sys...
+                [Optional for all actions]
+            jdbc_connection_string (str): Oracle jdbc connection string to validate.
+                [Required for: verify_vdb_jdbc_connection]
+            key (str): Key of the tag
+                [Optional for all actions]
+            limit (int): Maximum number of objects to return per query. The value must be between 1 an...
+                [Required for: list_vdbs, search_vdbs, list_vdb_snapshots, list_vdb_bookmarks, search_vdb_bookmarks, list_vdb_groups, search_vdb_groups, list_vdb_group_bookmarks, search_vdb_group_bookmarks, list_dsources, search_dsources, list_dsource_snapshots]
+            link_now (bool): True if initial load should be done immediately. (Default: False)
+                [Optional for all actions]
+            link_type (str): The type of link to create. Default is AppDataDirect.
+    * `AppDataDirect` - Rep...
+                [Optional for all actions]
+            listener_ids (list): The listener IDs for this provision operation (Oracle Only). (Pass as JSON ar...
+                [Optional for all actions]
+            load_backup_path (str): Source database backup location.
+                [Optional for all actions]
+            location (str): The location to provision from.
+                [Required for: export_vdb_by_location, export_vdb_to_asm_by_location, export_dsource_by_location, export_dsource_to_asm_by_location]
+            log_sync_enabled (bool): True if LogSync should run for this database. (Default: False)
+                [Optional for all actions]
+            log_sync_interval (int): Interval between LogSync requests, in seconds. (Default: 5)
+                [Optional for all actions]
+            log_sync_mode (str): LogSync operation mode for this database. Valid values: ARCHIVE_ONLY_MODE, AR...
+                [Optional for all actions]
+            logsync_enabled (bool): True if LogSync is enabled for this dSource.
+                [Optional for all actions]
+            logsync_interval (int): Interval between LogSync requests, in seconds.
+                [Optional for all actions]
+            logsync_mode (str): LogSync operation mode for this dSource. Valid values: ARCHIVE_ONLY_MODE, ARC...
+                [Optional for all actions]
+            make_current_account_owner (bool): Whether the account provisioning this VDB must be configured as owner of the ...
+                [Optional for all actions]
+            masked (bool): Indicates whether to mark this VDB as a masked VDB.
+                [Optional for all actions]
+            max_allowed_backups_pending_restore (int): The maximum number of pending backup restores at which export-finalize operat...
+                [Optional for all actions]
+            mirroring_state (str): Recovery model of the database (MSSql Only). Valid values: SUSPENDED, DISCONN...
+                [Optional for all actions]
+            mode (str): Refresh Mode either self or parent, if PARENT then VDB Group is refreshed fro...
+                [Optional for all actions]
+            mount_base (str): The base mount point to use for the NFS mounts for the temporary VDB.
+                [Optional for all actions]
+            mount_point (str): Mount point for the VDB (AppData only), can only be updated while the VDB is ...
+                [Optional for all actions]
+            mssql_ag_backup_based (bool): Indicates whether to do fast operations for VDB on AG which will use a health...
+                [Optional for all actions]
+            mssql_ag_backup_location (str): Shared backup location to be used for VDB provision on AG Cluster.
+                [Optional for all actions]
+            mssql_backup_uuid (str): When using the `specific_backup` sync_strategy, determines the Backup Set UUI...
+                [Optional for all actions]
+            mssql_database_password (str): Password for the database user.
+                [Optional for all actions]
+            mssql_database_username (str): The username for the source DB user.
+                [Optional for all actions]
+            mssql_incremental_export_backup_frequency_minutes (int): Frequency in minutes for incremental export backups for VDBs.
+                [Optional for all actions]
+            mssql_user_domain_azure_vault_name (str): Azure key vault name.
+                [Optional for all actions]
+            mssql_user_domain_azure_vault_secret_key (str): Azure vault key for the password in the key-value store.
+                [Optional for all actions]
+            mssql_user_domain_azure_vault_username_key (str): Azure vault key for the username in the key-value store.
+                [Optional for all actions]
+            mssql_user_domain_cyberark_vault_query_string (str): Query to find a credential in the CyberArk vault.
+                [Optional for all actions]
+            mssql_user_domain_hashicorp_vault_engine (str): Vault engine name where the credential is stored.
+                [Optional for all actions]
+            mssql_user_domain_hashicorp_vault_secret_key (str): Hashicorp vault key for the password in the key-value store.
+                [Optional for all actions]
+            mssql_user_domain_hashicorp_vault_secret_path (str): Path in the vault engine where the credential is stored.
+                [Optional for all actions]
+            mssql_user_domain_hashicorp_vault_username_key (str): Hashicorp vault key for the username in the key-value store.
+                [Optional for all actions]
+            mssql_user_domain_password (str): Password for the database user.
+                [Optional for all actions]
+            mssql_user_domain_username (str): The username for the source DB user.
+                [Optional for all actions]
+            mssql_user_domain_vault (str): The name or reference of the vault from which to read the database credentials.
+                [Optional for all actions]
+            mssql_user_domain_vault_username (str): Delphix display name for the vault user.
+                [Optional for all actions]
+            mssql_user_environment_reference (str): Reference to the source environment user to use for linking.
+                [Optional for all actions]
+            name (str): The unique name of the VDB within a group.
+                [Required for: create_vdb_group, provision_vdb_group_from_bookmark]
+            new_dbid (bool): Whether to enable new DBID for Oracle
+                [Optional for all actions]
+            non_sys_azure_vault_name (str): Azure key vault name (Single tenant only).
+                [Optional for all actions]
+            non_sys_azure_vault_secret_key (str): Azure vault key for the password in the key-value store (Single tenant only).
+                [Optional for all actions]
+            non_sys_azure_vault_username_key (str): Azure vault key for the username in the key-value store (Single tenant only).
+                [Optional for all actions]
+            non_sys_cyberark_vault_query_string (str): Query to find a credential in the CyberArk vault (Single tenant only).
+                [Optional for all actions]
+            non_sys_hashicorp_vault_engine (str): Vault engine name where the credential is stored (Single tenant only).
+                [Optional for all actions]
+            non_sys_hashicorp_vault_secret_key (str): Hashicorp vault key for the password in the key-value store (Single tenant on...
+                [Optional for all actions]
+            non_sys_hashicorp_vault_secret_path (str): Path in the vault engine where the credential is stored (Single tenant only).
+                [Optional for all actions]
+            non_sys_hashicorp_vault_username_key (str): Hashicorp vault key for the username in the key-value store (Single tenant on...
+                [Optional for all actions]
+            non_sys_password (str): Password for non sys user authentication (Single tenant only).
+                [Optional for all actions]
+            non_sys_username (str): Non-SYS database user to access this database. Only required for username-pas...
+                [Optional for all actions]
+            non_sys_vault (str): The name or reference of the vault from which to read the database credential...
+                [Optional for all actions]
+            non_sys_vault_username (str): Delphix display name for the non sys vault user(Single tenant only).
+                [Optional for all actions]
+            number_of_connections (int): Total number of transport connections to use during SnapSync. (Default: 1)
+                [Optional for all actions]
+            operations (list): Operations to perform after syncing a created dSource and before running the ...
+                [Optional for all actions]
+            operations_post_v2_p (bool): Indicates operations allowed on virtual source post V2P. (Default: False)
+                [Optional for all actions]
+            ops_post_sync (list): Operations to perform after syncing a created dSource. (Pass as JSON array)
+                [Optional for all actions]
+            ops_pre_log_sync (list): Operations to perform after syncing a created dSource and before running the ...
+                [Optional for all actions]
+            ops_pre_sync (list): Operations to perform before syncing the created dSource. These operations ca...
+                [Optional for all actions]
+            oracle_fallback_credentials (str): Password for fallback username.
+                [Optional for all actions]
+            oracle_fallback_user (str): The database fallback username. Optional if bequeath connections are enabled ...
+                [Optional for all actions]
+            oracle_password (str): Password for privileged user (Oracle only).
+                [Optional for all actions]
+            oracle_rac_custom_env_files (list): Environment files to be sourced when the Engine administers an Oracle RAC VDB...
+                [Optional for all actions]
+            oracle_rac_custom_env_vars (list): Environment variable to be set when the engine administers an Oracle RAC VDB....
+                [Optional for all actions]
+            oracle_services (list): List of jdbc connection strings which are used to connect with the database. ...
+                [Optional for all actions]
+            oracle_username (str): The name of the privileged user to run the delete operation as (Oracle only).
+                [Optional for all actions]
+            ownership_spec (str): The uid:gid string that NFS mounts should belong to.
+                [Optional for all actions]
+            parameters (dict): The JSON payload conforming to the DraftV4 schema based on the type of applic...
+                [Optional for all actions]
+            parent_pdb_tde_keystore_password (str): The password of the parent PDB keystore. (Oracle Multitenant Only)
+                [Optional for all actions]
+            parent_pdb_tde_keystore_path (str): Path to a copy of the parent PDB's Oracle transparent data encryption keystor...
+                [Optional for all actions]
+            parent_tde_keystore_password (str): The password of the keystore specified in parentTdeKeystorePath. (Oracle Mult...
+                [Optional for all actions]
+            parent_tde_keystore_path (str): Path to a copy of the parent's Oracle transparent data encryption keystore on...
+                [Optional for all actions]
+            pdb_name (str): The name to be given to the PDB after it is exported in-place.
+                [Optional for all actions]
+            permission (str): Restrict the objects, which are allowed.
+                [Required for: list_vdbs, search_vdbs, list_dsources, search_dsources]
+            physical_standby (bool): Boolean value indicates whether this staging database will be configured as a...
+                [Optional for all actions]
+            post_refresh (list): The commands to execute on the target environment after refreshing the VDB. (...
+                [Optional for all actions]
+            post_rollback (list): The commands to execute on the target environment after rewinding the VDB. (P...
+                [Optional for all actions]
+            post_script (str): Post script for MSSql.
+                [Optional for all actions]
+            post_self_refresh (list): The commands to execute on the target environment after refreshing the VDB wi...
+                [Optional for all actions]
+            post_snapshot (list): The commands to execute on the target environment after snapshotting a virtua...
+                [Optional for all actions]
+            post_start (list): The commands to execute on the target environment after starting a virtual so...
+                [Optional for all actions]
+            post_stop (list): The commands to execute on the target environment after stopping a virtual so...
+                [Optional for all actions]
+            post_validated_sync (list): Operations to perform on the staging source after performing a validated sync...
+                [Optional for all actions]
+            ppt_host_user (str): Reference of the host OS user on the PPT host to use for linking.
+                [Optional for all actions]
+            ppt_repository (str): The id of the SQL instance on the PPT environment that we want to use for pre...
+                [Required for: attach_mssql_staging_push_dsource, attach_mssql_dsource]
+            pre_provisioning_enabled (bool): If true, pre-provisioning will be performed after every sync. (Default: False)
+                [Optional for all actions]
+            pre_refresh (list): The commands to execute on the target environment before refreshing the VDB. ...
+                [Optional for all actions]
+            pre_rollback (list): The commands to execute on the target environment before rewinding the VDB. (...
+                [Optional for all actions]
+            pre_script (str): Pre script for MSSql.
+                [Optional for all actions]
+            pre_self_refresh (list): The commands to execute on the target environment before refreshing the VDB w...
+                [Optional for all actions]
+            pre_snapshot (list): The commands to execute on the target environment before snapshotting a virtu...
+                [Optional for all actions]
+            pre_start (list): The commands to execute on the target environment before starting a virtual s...
+                [Optional for all actions]
+            pre_stop (list): The commands to execute on the target environment before stopping a virtual s...
+                [Optional for all actions]
+            pre_validated_sync (list): Operations to perform on the staging source before performing a validated syn...
+                [Optional for all actions]
+            provision_parameters (dict): Provision parameters for each of the VDBs which will need to be provisioned. ...
+                [Required for: provision_vdb_group_from_bookmark]
+            rac_max_instance_lag (int): Maximum number of log sequences to allow a RAC instance to lag before conside...
+                [Optional for all actions]
+            recover_database (bool): If specified, then take the exported database through recovery procedures, if...
+                [Optional for all actions]
+            redo_diskgroup (str): Diskgroup for archive logs. Optional as it is not required for PDB databases.
+                [Optional for all actions]
+            refresh_immediately (bool): If true, VDB Group will be refreshed immediately after creation. (Default: Fa...
+                [Optional for all actions]
+            repository (str): The repository reference to link.
+                [Optional for all actions]
+            repository_id (str): The ID of the target repository where to provision the VDB. A repository typi...
+                [Required for: upgrade_vdb, upgrade_oracle_vdb, upgrade_dsource, upgrade_oracle_dsource]
+            retention_policy_id (str): The ID of the retention policy for the VDB.
+                [Optional for all actions]
+            rman_channels (int): Number of data streams to connect to the database. (Default: 8)
+                [Optional for all actions]
+            rman_channels_for_incremental_backup (int): Number of data streams to connect to the database for incremental backup. (De...
+                [Optional for all actions]
+            rman_file_section_size_in_gb (int): Number of GigaBytes in which RMAN will break large files to back them in para...
+                [Optional for all actions]
+            rman_file_section_size_in_gb_for_incremental_backup (int): Number of GigaBytes in which RMAN will break large files to back them up in p...
+                [Optional for all actions]
+            rman_files_per_set_for_incremental_backup (int): Number of data files to include in each RMAN backup set for incremental backu...
+                [Optional for all actions]
+            rman_rate_in__m_b (int): RMAN rate in megabytes to be used. This is the upper limit for bytes read so ...
+                [Optional for all actions]
+            script_directory (str): The directory for script files.
+                [Optional for all actions]
+            sid (str): The name (sid) of the instance.
+                [Optional for all actions]
+            skip_space_check (bool): Skip check that tests if there is enough space available to store the databas...
+                [Optional for all actions]
+            snapshot_id (str): The ID of the snapshot from which to execute the operation. If the snapshot_i...
+                [Optional for all actions]
+            snapshot_policy_id (str): The ID of the snapshot policy for the VDB.
+                [Optional for all actions]
+            sort (str): The field to sort results by. A property name with a prepended '-' signifies ...
+                [Required for: list_vdbs, search_vdbs, list_vdb_bookmarks, search_vdb_bookmarks, list_vdb_groups, search_vdb_groups, list_vdb_group_bookmarks, search_vdb_group_bookmarks, list_dsources, search_dsources]
+            source_data_id (str): The ID of the source object (dSource or VDB) to provision from. All other obj...
+                [Required for: provision_by_timestamp, provision_by_timestamp_defaults]
+            source_host_user (str): ID or user reference of the host OS user to use for linking.
+                [Optional for all actions]
+            source_id (str): Id of the source to link.
+                [Required for: dsource_link_oracle_defaults, attach_oracle_dsource, dsource_link_ase_defaults, dsource_link_appdata_defaults, dsource_link_mssql_defaults, attach_mssql_dsource]
+            staging_container_database_reference (str): Reference of the CDB source config.
+                [Optional for all actions]
+            staging_database_config_params (dict): Oracle database configuration parameter overrides. If both staging_database_t...
+                [Optional for all actions]
+            staging_database_name (str): The name of the database to create on the staging environment. This property ...
+                [Required for: attach_mssql_staging_push_dsource]
+            staging_database_templates (list): An array of name value pair of Oracle database configuration parameter overri...
+                [Optional for all actions]
+            staging_environment (str): The environment used as an intermediate stage to pull data into Delphix [AppD...
+                [Optional for all actions]
+            staging_environment_user (str): The environment user used to access the staging environment [AppDataStaged on...
+                [Optional for all actions]
+            staging_host_user (str): Information about the host OS user on the staging environment to use for link...
+                [Optional for all actions]
+            staging_mount_base (str): The base mount point for the NFS mount on the staging environment [AppDataSta...
+                [Optional for all actions]
+            staging_post_script (str): A user-provided PowerShell script or executable to run after restoring from a...
+                [Optional for all actions]
+            staging_pre_script (str): A user-provided PowerShell script or executable to run prior to restoring fro...
+                [Optional for all actions]
+            staging_repository (str): The SAP ASE instance on the staging environment that we want to use for valid...
+                [Optional for all actions]
+            sync_parameters (dict): The JSON payload conforming to the snapshot parameters definition in a LUA to...
+                [Optional for all actions]
+            sync_policy_id (str): The ID of the SnapSync policy for the dSource.
+                [Optional for all actions]
+            sync_strategy (str): Determines how the Delphix Engine will take a backup:
+    * `latest_backup` - Use...
+                [Optional for all actions]
+            sync_strategy_managed_type (str): MSSQL specific parameters for source based sync strategy.:
+    * `external` - MSS...
+                [Optional for all actions]
+            tags (list): The tags to be created for VDB. (Pass as JSON array)
+                [Required for: add_vdb_tags, add_vdb_group_tags, add_dsource_tags]
+            target_directory (str): The base directory to use for the exported database.
+                [Optional for all actions]
+            target_group_id (str): The ID of the group into which the VDB will be provisioned. This field must b...
+                [Optional for all actions]
+            target_pdb_tde_keystore_password (str): The password for the isolated mode TDE keystore of the target virtual PDB. (O...
+                [Optional for all actions]
+            target_vcdb_tde_keystore_path (str): Path to the keystore of the target vCDB. (Oracle Multitenant Only)
+                [Optional for all actions]
+            tde_exported_keyfile_secret (str): Secret to be used while exporting and importing vPDB encryption keys.
+                [Optional for all actions]
+            tde_key_identifier (str): ID of the key created by Delphix. (Oracle Multitenant Only)
+                [Optional for all actions]
+            tde_keystore_config_type (str): Oracle TDE keystore configuration type. Valid values: FILE, OKV, HSM, OKV|FIL...
+                [Optional for all actions]
+            tde_keystore_password (str): The password for the Transparent Data Encryption keystore associated with thi...
+                [Optional for all actions]
+            temp_directory (str): The directory for temporary files.
+                [Optional for all actions]
+            template_id (str): The ID of the target VDB Template (Oracle and MSSql Only).
+                [Optional for all actions]
+            timeflow_id (str): The Timeflow ID.
+                [Required for: export_vdb_by_timestamp, export_vdb_to_asm_by_timestamp, export_dsource_by_timestamp, export_dsource_to_asm_by_timestamp]
+            timestamp (str): The point in time from which to execute the operation. Mutually exclusive wit...
+                [Required for: export_vdb_by_timestamp, export_vdb_to_asm_by_timestamp, export_dsource_by_timestamp, export_dsource_to_asm_by_timestamp]
+            timestamp_in_database_timezone (str): The point in time from which to execute the operation, expressed as a date-ti...
+                [Optional for all actions]
+            use_absolute_path_for_data_files (bool): Whether to use absolute path for data files (Oracle only).
+                [Optional for all actions]
+            validate_by_opening_db_in_read_only_mode (bool): Boolean value indicates whether this staging database snapshot will be valida...
+                [Optional for all actions]
+            validate_db_credentials (bool): Whether db_username and db_password must be validated, if present, against th...
+                [Optional for all actions]
+            validate_snapshot_in_readonly (bool): Boolean value indicates whether this staging database snapshot will be valida...
+                [Optional for all actions]
+            validated_sync_mode (str): Information about the host OS user on the staging environment to use for link...
+                [Optional for all actions]
+            value (str): Value of the tag
+                [Optional for all actions]
+            vdb_disable_param_mappings (list): Request body parameter (Pass as JSON array)
+                [Optional for all actions]
+            vdb_enable_param_mappings (list): Request body parameter (Pass as JSON array)
+                [Optional for all actions]
+            vdb_group_id (str): The unique identifier for the vdbGroup.
+                [Required for: get_vdb_group, update_vdb_group, delete_vdb_group, refresh_vdb_group, refresh_vdb_group_from_bookmark, refresh_vdb_group_by_snapshot, refresh_vdb_group_by_timestamp, rollback_vdb_group, lock_vdb_group, unlock_vdb_group, start_vdb_group, stop_vdb_group, enable_vdb_group, disable_vdb_group, get_vdb_group_latest_snapshots, get_vdb_group_timestamp_summary, list_vdb_group_bookmarks, search_vdb_group_bookmarks, get_vdb_group_tags, add_vdb_group_tags]
+            vdb_id (str): The unique identifier for the vdb.
+                [Required for: get_vdb, update_vdb, delete_vdb, start_vdb, stop_vdb, enable_vdb, disable_vdb, refresh_vdb_by_timestamp, refresh_vdb_by_snapshot, refresh_vdb_from_bookmark, refresh_vdb_by_location, undo_vdb_refresh, rollback_vdb_by_timestamp, rollback_vdb_by_snapshot, rollback_vdb_from_bookmark, switch_vdb_timeflow, lock_vdb, unlock_vdb, migrate_vdb, get_migrate_compatible_repositories, upgrade_vdb, upgrade_oracle_vdb, get_upgrade_compatible_repositories, list_vdb_snapshots, snapshot_vdb, list_vdb_bookmarks, search_vdb_bookmarks, get_vdb_deletion_dependencies, verify_vdb_jdbc_connection, get_vdb_tags, add_vdb_tags, export_vdb_in_place, export_vdb_asm_in_place, export_vdb_by_snapshot, export_vdb_by_timestamp, export_vdb_by_location, export_vdb_from_bookmark, export_vdb_to_asm_by_snapshot, export_vdb_to_asm_by_timestamp, export_vdb_to_asm_by_location, export_vdb_to_asm_from_bookmark, export_cleanup, export_finalize]
+            vdb_ids (list): Request body parameter (Pass as JSON array)
+                [Optional for all actions]
+            vdb_restart (bool): Indicates whether the Engine should automatically restart this virtual source...
+                [Optional for all actions]
+            vdb_snapshot_mappings (list): List of the pair of VDB and snapshot to refresh from. If this is not set, all...
+                [Optional for all actions]
+            vdb_start_param_mappings (list): Request body parameter (Pass as JSON array)
+                [Optional for all actions]
+            vdb_stop_param_mappings (list): Request body parameter (Pass as JSON array)
+                [Optional for all actions]
+            vdb_timestamp_mappings (list): List of the pair of VDB and timestamp to refresh from. If this is not set, al...
+                [Optional for all actions]
+            vdbs (list): Dictates order of operations on VDBs. Operations can be performed in parallel...
+                [Optional for all actions]
+
+          -- MSSql-specific parameters (SKIP if not provisioning mssql) --
+            mssql_failover_drive_letter (str): [MSSql only] Base drive letter location for mount points. (MSSql Only).
+                [Optional for all actions]
+            recovery_model (str): Recovery model of the database (MSSql Only). Valid values: FULL, SIMPLE, BULK...
+                [Optional for all actions]
+
+          -- Oracle-specific parameters (SKIP if not provisioning oracle) --
+            archive_log (bool): [Oracle only] Option to create a VDB in archivelog mode (Oracle Only).
+                [Optional for all actions]
+            auxiliary_template_id (str): [Oracle only] The ID of the configuration template to apply to the auxiliary ...
+                [Optional for all actions]
+            cdb_id (str): [Oracle only] The ID of the container database (CDB) to provision an Oracle M...
+                [Optional for all actions]
+            cluster_node_ids (list): [Oracle only] The cluster node ids, name or addresses for this provision oper...
+                [Optional for all actions]
+            cluster_node_instances (list): [Oracle only] The cluster node instances details for this provision operation...
+                [Optional for all actions]
+            container_mode (bool): [Oracle only] Whether the virtual database will be provisioned for a containe...
+                [Optional for all actions]
+            file_mapping_rules (str): [Oracle only] Target VDB file mapping rules (Oracle Only). Rules must be line...
+                [Optional for all actions]
+            okv_client_id (str): [Oracle only] The id of the OKV client used by the target new vCDB for TDE ke...
+                [Optional for all actions]
+            online_log_groups (int): [Oracle only] Number of online log groups (Oracle Only).
+                [Optional for all actions]
+            online_log_size (int): [Oracle only] Online log size in MB (Oracle Only).
+                [Optional for all actions]
+            open_reset_logs (bool): [Oracle only] Whether to open the database after provision (Oracle Only).
+                [Optional for all actions]
+            oracle_instance_name (str): [Oracle only] Target VDB SID name (Oracle Only).
+                [Optional for all actions]
+            os_password (str): [Oracle only] The password of the privileged user to run the provision operat...
+                [Optional for all actions]
+            os_username (str): [Oracle only] The name of the privileged user to run the provision operation ...
+                [Optional for all actions]
+            tde_exported_key_file_secret (str): [Oracle only] Secret to be used while exporting and importing vPDB encryption...
+                [Optional for all actions]
+            unique_name (str): [Oracle only] Target VDB db_unique_name (Oracle Only).
+                [Optional for all actions]
+            vcdb_database_name (str): [Oracle only] When provisioning an Oracle Multitenant vCDB (when the cdb_id p...
+                [Optional for all actions]
+            vcdb_name (str): [Oracle only] When provisioning an Oracle Multitenant vCDB (when the cdb_id p...
+                [Optional for all actions]
+            vcdb_restart (bool): [Oracle only] Indicates whether the Engine should automatically restart this ...
+                [Optional for all actions]
+            vcdb_tde_key_identifier (str): [Oracle only] ID of the key created by Delphix. (Oracle Multitenant Only)
+                [Optional for all actions]
+
+          -- Postgres-specific parameters (SKIP if not provisioning postgres) --
+            config_settings_stg (list): [Postgres only] Custom Database-Level config settings (postgres only). (Pass ...
+                [Optional for all actions]
+            postgres_port (int): [Postgres only] Port number for Postgres target database (postgres only).
+                [Optional for all actions]
+            privileged_os_user (str): [Postgres only] This privileged unix username will be used to create the VDB....
+                [Optional for all actions]
+
+          -- ASE/Sybase-specific parameters (SKIP if not provisioning sybase) --
+            truncate_log_on_checkpoint (bool): [ASE/Sybase only] Whether to truncate log on checkpoint (ASE only).
+                [Optional for all actions]
+
+        Returns:
+            Dict[str, Any]: The API response containing operation results
+
+        Raises:
+            Returns error dict if required parameters are missing for the action
     """
     # Route to appropriate API based on action
-    if action == 'list_vdbs':
-        params = build_params(limit=limit, cursor=cursor, sort=sort, permission=permission)
-        conf = check_confirmation('GET', '/vdbs', action, 'data_tool', confirmed or False, request_params=params, request_body=None)
+    if action == "list_vdbs":
+        params = build_params(
+            limit=limit, cursor=cursor, sort=sort, permission=permission
+        )
+        conf = check_confirmation(
+            "GET",
+            "/vdbs",
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', '/vdbs', params=params)
-    elif action == 'search_vdbs':
-        params = build_params(limit=limit, cursor=cursor, sort=sort, permission=permission)
-        body = {'filter_expression': filter_expression} if filter_expression else {}
-        conf = check_confirmation('POST', '/vdbs/search', action, 'data_tool', confirmed or False, request_params=params, request_body=body)
+        return make_api_request("GET", "/vdbs", params=params)
+    elif action == "search_vdbs":
+        params = build_params(
+            limit=limit, cursor=cursor, sort=sort, permission=permission
+        )
+        body = {"filter_expression": filter_expression} if filter_expression else {}
+        conf = check_confirmation(
+            "POST",
+            "/vdbs/search",
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', '/vdbs/search', params=params, json_body=body)
-    elif action == 'get_vdb':
+        return make_api_request("POST", "/vdbs/search", params=params, json_body=body)
+    elif action == "get_vdb":
         if vdb_id is None:
-            return {'error': 'Missing required parameter: vdb_id for action get_vdb'}
-        endpoint = f'/vdbs/{vdb_id}'
+            return {"error": "Missing required parameter: vdb_id for action get_vdb"}
+        endpoint = f"/vdbs/{vdb_id}"
         params = build_params()
-        conf = check_confirmation('GET', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', endpoint, params=params)
-    elif action == 'update_vdb':
+        return make_api_request("GET", endpoint, params=params)
+    elif action == "update_vdb":
         if vdb_id is None:
-            return {'error': 'Missing required parameter: vdb_id for action update_vdb'}
-        endpoint = f'/vdbs/{vdb_id}'
+            return {"error": "Missing required parameter: vdb_id for action update_vdb"}
+        endpoint = f"/vdbs/{vdb_id}"
         params = build_params()
         if not environment_user_id:
             environment_user_id = environment_user_ref or environment_user
-        body = {k: v for k, v in {'name': name, 'description': description, 'db_username': db_username, 'db_password': db_password, 'validate_db_credentials': validate_db_credentials, 'auto_restart': auto_restart, 'environment_user_id': environment_user_id, 'template_id': template_id, 'listener_ids': listener_ids, 'new_dbid': new_dbid, 'cdc_on_provision': cdc_on_provision, 'pre_script': pre_script, 'post_script': post_script, 'hooks': hooks, 'custom_env_vars': custom_env_vars, 'custom_env_files': custom_env_files, 'oracle_rac_custom_env_files': oracle_rac_custom_env_files, 'oracle_rac_custom_env_vars': oracle_rac_custom_env_vars, 'parent_tde_keystore_path': parent_tde_keystore_path, 'parent_tde_keystore_password': parent_tde_keystore_password, 'tde_key_identifier': tde_key_identifier, 'target_vcdb_tde_keystore_path': target_vcdb_tde_keystore_path, 'cdb_tde_keystore_password': cdb_tde_keystore_password, 'parent_pdb_tde_keystore_path': parent_pdb_tde_keystore_path, 'parent_pdb_tde_keystore_password': parent_pdb_tde_keystore_password, 'target_pdb_tde_keystore_password': target_pdb_tde_keystore_password, 'appdata_source_params': appdata_source_params, 'additional_mount_points': additional_mount_points, 'appdata_config_params': appdata_config_params, 'config_params': config_params, 'mount_point': mount_point, 'oracle_services': oracle_services, 'instances': instances, 'invoke_datapatch': invoke_datapatch, 'mssql_ag_backup_location': mssql_ag_backup_location, 'mssql_ag_backup_based': mssql_ag_backup_based, 'cache_priority': cache_priority, 'mssql_incremental_export_backup_frequency_minutes': mssql_incremental_export_backup_frequency_minutes, 'database_name': database_name}.items() if v is not None}
-        conf = check_confirmation('PATCH', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "name": name,
+                "description": description,
+                "db_username": db_username,
+                "db_password": db_password,
+                "validate_db_credentials": validate_db_credentials,
+                "auto_restart": auto_restart,
+                "environment_user_id": environment_user_id,
+                "template_id": template_id,
+                "listener_ids": listener_ids,
+                "new_dbid": new_dbid,
+                "cdc_on_provision": cdc_on_provision,
+                "pre_script": pre_script,
+                "post_script": post_script,
+                "hooks": hooks,
+                "custom_env_vars": custom_env_vars,
+                "custom_env_files": custom_env_files,
+                "oracle_rac_custom_env_files": oracle_rac_custom_env_files,
+                "oracle_rac_custom_env_vars": oracle_rac_custom_env_vars,
+                "parent_tde_keystore_path": parent_tde_keystore_path,
+                "parent_tde_keystore_password": parent_tde_keystore_password,
+                "tde_key_identifier": tde_key_identifier,
+                "target_vcdb_tde_keystore_path": target_vcdb_tde_keystore_path,
+                "cdb_tde_keystore_password": cdb_tde_keystore_password,
+                "parent_pdb_tde_keystore_path": parent_pdb_tde_keystore_path,
+                "parent_pdb_tde_keystore_password": parent_pdb_tde_keystore_password,
+                "target_pdb_tde_keystore_password": target_pdb_tde_keystore_password,
+                "appdata_source_params": appdata_source_params,
+                "additional_mount_points": additional_mount_points,
+                "appdata_config_params": appdata_config_params,
+                "config_params": config_params,
+                "mount_point": mount_point,
+                "oracle_services": oracle_services,
+                "instances": instances,
+                "invoke_datapatch": invoke_datapatch,
+                "mssql_ag_backup_location": mssql_ag_backup_location,
+                "mssql_ag_backup_based": mssql_ag_backup_based,
+                "cache_priority": cache_priority,
+                "mssql_incremental_export_backup_frequency_minutes": mssql_incremental_export_backup_frequency_minutes,
+                "database_name": database_name,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "PATCH",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('PATCH', endpoint, params=params, json_body=body if body else None)
-    elif action == 'provision_by_timestamp':
+        return make_api_request(
+            "PATCH", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "provision_by_timestamp":
         params = build_params()
         if not environment_user_id:
             environment_user_id = environment_user_ref or environment_user
-        body = {k: v for k, v in {'pre_refresh': pre_refresh, 'post_refresh': post_refresh, 'pre_self_refresh': pre_self_refresh, 'post_self_refresh': post_self_refresh, 'pre_rollback': pre_rollback, 'post_rollback': post_rollback, 'configure_clone': configure_clone, 'pre_snapshot': pre_snapshot, 'post_snapshot': post_snapshot, 'pre_start': pre_start, 'post_start': post_start, 'pre_stop': pre_stop, 'post_stop': post_stop, 'target_group_id': target_group_id, 'name': name, 'database_name': database_name, 'cdb_id': cdb_id, 'cluster_node_ids': cluster_node_ids, 'cluster_node_instances': cluster_node_instances, 'truncate_log_on_checkpoint': truncate_log_on_checkpoint, 'os_username': os_username, 'os_password': os_password, 'environment_id': environment_id, 'environment_user_id': environment_user_id, 'repository_id': repository_id, 'auto_select_repository': auto_select_repository, 'vdb_restart': vdb_restart, 'template_id': template_id, 'auxiliary_template_id': auxiliary_template_id, 'file_mapping_rules': file_mapping_rules, 'oracle_instance_name': oracle_instance_name, 'unique_name': unique_name, 'vcdb_name': vcdb_name, 'vcdb_database_name': vcdb_database_name, 'mount_point': mount_point, 'open_reset_logs': open_reset_logs, 'snapshot_policy_id': snapshot_policy_id, 'retention_policy_id': retention_policy_id, 'recovery_model': recovery_model, 'pre_script': pre_script, 'post_script': post_script, 'cdc_on_provision': cdc_on_provision, 'online_log_size': online_log_size, 'online_log_groups': online_log_groups, 'archive_log': archive_log, 'new_dbid': new_dbid, 'masked': masked, 'listener_ids': listener_ids, 'custom_env_vars': custom_env_vars, 'custom_env_files': custom_env_files, 'oracle_rac_custom_env_files': oracle_rac_custom_env_files, 'oracle_rac_custom_env_vars': oracle_rac_custom_env_vars, 'parentTdeKeystorePath': parent_tde_keystore_path, 'parent_tde_keystore_password': parent_tde_keystore_password, 'parent_pdb_tde_keystore_path': parent_pdb_tde_keystore_path, 'parent_pdb_tde_keystore_password': parent_pdb_tde_keystore_password, 'target_pdb_tde_keystore_password': target_pdb_tde_keystore_password, 'tde_exported_key_file_secret': tde_exported_key_file_secret, 'tde_key_identifier': tde_key_identifier, 'target_vcdb_tde_keystore_path': target_vcdb_tde_keystore_path, 'cdb_tde_keystore_password': cdb_tde_keystore_password, 'vcdb_tde_key_identifier': vcdb_tde_key_identifier, 'tde_keystore_config_type': tde_keystore_config_type, 'okv_client_id': okv_client_id, 'appdata_source_params': appdata_source_params, 'additional_mount_points': additional_mount_points, 'appdata_config_params': appdata_config_params, 'config_params': config_params, 'privileged_os_user': privileged_os_user, 'postgres_port': postgres_port, 'config_settings_stg': config_settings_stg, 'vcdb_restart': vcdb_restart, 'mssql_failover_drive_letter': mssql_failover_drive_letter, 'tags': tags, 'invoke_datapatch': invoke_datapatch, 'container_mode': container_mode, 'mssql_ag_backup_location': mssql_ag_backup_location, 'mssql_ag_backup_based': mssql_ag_backup_based, 'cache_priority': cache_priority, 'mssql_incremental_export_backup_frequency_minutes': mssql_incremental_export_backup_frequency_minutes, 'timestamp': timestamp, 'timestamp_in_database_timezone': timestamp_in_database_timezone, 'timeflow_id': timeflow_id, 'engine_id': engine_id, 'source_data_id': source_data_id, 'make_current_account_owner': make_current_account_owner}.items() if v is not None}
-        conf = check_confirmation('POST', '/vdbs/provision_by_timestamp', action, 'data_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "pre_refresh": pre_refresh,
+                "post_refresh": post_refresh,
+                "pre_self_refresh": pre_self_refresh,
+                "post_self_refresh": post_self_refresh,
+                "pre_rollback": pre_rollback,
+                "post_rollback": post_rollback,
+                "configure_clone": configure_clone,
+                "pre_snapshot": pre_snapshot,
+                "post_snapshot": post_snapshot,
+                "pre_start": pre_start,
+                "post_start": post_start,
+                "pre_stop": pre_stop,
+                "post_stop": post_stop,
+                "target_group_id": target_group_id,
+                "name": name,
+                "database_name": database_name,
+                "cdb_id": cdb_id,
+                "cluster_node_ids": cluster_node_ids,
+                "cluster_node_instances": cluster_node_instances,
+                "truncate_log_on_checkpoint": truncate_log_on_checkpoint,
+                "os_username": os_username,
+                "os_password": os_password,
+                "environment_id": environment_id,
+                "environment_user_id": environment_user_id,
+                "repository_id": repository_id,
+                "auto_select_repository": auto_select_repository,
+                "vdb_restart": vdb_restart,
+                "template_id": template_id,
+                "auxiliary_template_id": auxiliary_template_id,
+                "file_mapping_rules": file_mapping_rules,
+                "oracle_instance_name": oracle_instance_name,
+                "unique_name": unique_name,
+                "vcdb_name": vcdb_name,
+                "vcdb_database_name": vcdb_database_name,
+                "mount_point": mount_point,
+                "open_reset_logs": open_reset_logs,
+                "snapshot_policy_id": snapshot_policy_id,
+                "retention_policy_id": retention_policy_id,
+                "recovery_model": recovery_model,
+                "pre_script": pre_script,
+                "post_script": post_script,
+                "cdc_on_provision": cdc_on_provision,
+                "online_log_size": online_log_size,
+                "online_log_groups": online_log_groups,
+                "archive_log": archive_log,
+                "new_dbid": new_dbid,
+                "masked": masked,
+                "listener_ids": listener_ids,
+                "custom_env_vars": custom_env_vars,
+                "custom_env_files": custom_env_files,
+                "oracle_rac_custom_env_files": oracle_rac_custom_env_files,
+                "oracle_rac_custom_env_vars": oracle_rac_custom_env_vars,
+                "parentTdeKeystorePath": parent_tde_keystore_path,
+                "parent_tde_keystore_password": parent_tde_keystore_password,
+                "parent_pdb_tde_keystore_path": parent_pdb_tde_keystore_path,
+                "parent_pdb_tde_keystore_password": parent_pdb_tde_keystore_password,
+                "target_pdb_tde_keystore_password": target_pdb_tde_keystore_password,
+                "tde_exported_key_file_secret": tde_exported_key_file_secret,
+                "tde_key_identifier": tde_key_identifier,
+                "target_vcdb_tde_keystore_path": target_vcdb_tde_keystore_path,
+                "cdb_tde_keystore_password": cdb_tde_keystore_password,
+                "vcdb_tde_key_identifier": vcdb_tde_key_identifier,
+                "tde_keystore_config_type": tde_keystore_config_type,
+                "okv_client_id": okv_client_id,
+                "appdata_source_params": appdata_source_params,
+                "additional_mount_points": additional_mount_points,
+                "appdata_config_params": appdata_config_params,
+                "config_params": config_params,
+                "privileged_os_user": privileged_os_user,
+                "postgres_port": postgres_port,
+                "config_settings_stg": config_settings_stg,
+                "vcdb_restart": vcdb_restart,
+                "mssql_failover_drive_letter": mssql_failover_drive_letter,
+                "tags": tags,
+                "invoke_datapatch": invoke_datapatch,
+                "container_mode": container_mode,
+                "mssql_ag_backup_location": mssql_ag_backup_location,
+                "mssql_ag_backup_based": mssql_ag_backup_based,
+                "cache_priority": cache_priority,
+                "mssql_incremental_export_backup_frequency_minutes": mssql_incremental_export_backup_frequency_minutes,
+                "timestamp": timestamp,
+                "timestamp_in_database_timezone": timestamp_in_database_timezone,
+                "timeflow_id": timeflow_id,
+                "engine_id": engine_id,
+                "source_data_id": source_data_id,
+                "make_current_account_owner": make_current_account_owner,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            "/vdbs/provision_by_timestamp",
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', '/vdbs/provision_by_timestamp', params=params, json_body=body if body else None)
-    elif action == 'provision_by_timestamp_defaults':
+        return make_api_request(
+            "POST",
+            "/vdbs/provision_by_timestamp",
+            params=params,
+            json_body=body if body else None,
+        )
+    elif action == "provision_by_timestamp_defaults":
         params = build_params()
-        body = {k: v for k, v in {'timestamp': timestamp, 'timestamp_in_database_timezone': timestamp_in_database_timezone, 'engine_id': engine_id, 'source_data_id': source_data_id, 'timeflow_id': timeflow_id}.items() if v is not None}
-        conf = check_confirmation('POST', '/vdbs/provision_by_timestamp/defaults', action, 'data_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "timestamp": timestamp,
+                "timestamp_in_database_timezone": timestamp_in_database_timezone,
+                "engine_id": engine_id,
+                "source_data_id": source_data_id,
+                "timeflow_id": timeflow_id,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            "/vdbs/provision_by_timestamp/defaults",
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', '/vdbs/provision_by_timestamp/defaults', params=params, json_body=body if body else None)
-    elif action == 'provision_by_snapshot':
-        params = build_params()
-        if not environment_user_id:
-            environment_user_id = environment_user_ref or environment_user
-        body = {k: v for k, v in {'pre_refresh': pre_refresh, 'post_refresh': post_refresh, 'pre_self_refresh': pre_self_refresh, 'post_self_refresh': post_self_refresh, 'pre_rollback': pre_rollback, 'post_rollback': post_rollback, 'configure_clone': configure_clone, 'pre_snapshot': pre_snapshot, 'post_snapshot': post_snapshot, 'pre_start': pre_start, 'post_start': post_start, 'pre_stop': pre_stop, 'post_stop': post_stop, 'target_group_id': target_group_id, 'name': name, 'database_name': database_name, 'cdb_id': cdb_id, 'cluster_node_ids': cluster_node_ids, 'cluster_node_instances': cluster_node_instances, 'truncate_log_on_checkpoint': truncate_log_on_checkpoint, 'os_username': os_username, 'os_password': os_password, 'environment_id': environment_id, 'environment_user_id': environment_user_id, 'repository_id': repository_id, 'auto_select_repository': auto_select_repository, 'vdb_restart': vdb_restart, 'template_id': template_id, 'auxiliary_template_id': auxiliary_template_id, 'file_mapping_rules': file_mapping_rules, 'oracle_instance_name': oracle_instance_name, 'unique_name': unique_name, 'vcdb_name': vcdb_name, 'vcdb_database_name': vcdb_database_name, 'mount_point': mount_point, 'open_reset_logs': open_reset_logs, 'snapshot_policy_id': snapshot_policy_id, 'retention_policy_id': retention_policy_id, 'recovery_model': recovery_model, 'pre_script': pre_script, 'post_script': post_script, 'cdc_on_provision': cdc_on_provision, 'online_log_size': online_log_size, 'online_log_groups': online_log_groups, 'archive_log': archive_log, 'new_dbid': new_dbid, 'masked': masked, 'listener_ids': listener_ids, 'custom_env_vars': custom_env_vars, 'custom_env_files': custom_env_files, 'oracle_rac_custom_env_files': oracle_rac_custom_env_files, 'oracle_rac_custom_env_vars': oracle_rac_custom_env_vars, 'parentTdeKeystorePath': parent_tde_keystore_path, 'parent_tde_keystore_password': parent_tde_keystore_password, 'parent_pdb_tde_keystore_path': parent_pdb_tde_keystore_path, 'parent_pdb_tde_keystore_password': parent_pdb_tde_keystore_password, 'target_pdb_tde_keystore_password': target_pdb_tde_keystore_password, 'tde_exported_key_file_secret': tde_exported_key_file_secret, 'tde_key_identifier': tde_key_identifier, 'target_vcdb_tde_keystore_path': target_vcdb_tde_keystore_path, 'cdb_tde_keystore_password': cdb_tde_keystore_password, 'vcdb_tde_key_identifier': vcdb_tde_key_identifier, 'tde_keystore_config_type': tde_keystore_config_type, 'okv_client_id': okv_client_id, 'appdata_source_params': appdata_source_params, 'additional_mount_points': additional_mount_points, 'appdata_config_params': appdata_config_params, 'config_params': config_params, 'privileged_os_user': privileged_os_user, 'postgres_port': postgres_port, 'config_settings_stg': config_settings_stg, 'vcdb_restart': vcdb_restart, 'mssql_failover_drive_letter': mssql_failover_drive_letter, 'tags': tags, 'invoke_datapatch': invoke_datapatch, 'container_mode': container_mode, 'mssql_ag_backup_location': mssql_ag_backup_location, 'mssql_ag_backup_based': mssql_ag_backup_based, 'cache_priority': cache_priority, 'mssql_incremental_export_backup_frequency_minutes': mssql_incremental_export_backup_frequency_minutes, 'snapshot_id': snapshot_id, 'engine_id': engine_id, 'source_data_id': source_data_id, 'make_current_account_owner': make_current_account_owner}.items() if v is not None}
-        conf = check_confirmation('POST', '/vdbs/provision_by_snapshot', action, 'data_tool', confirmed or False, request_params=params, request_body=body)
-        if conf:
-            return conf
-        return make_api_request('POST', '/vdbs/provision_by_snapshot', params=params, json_body=body if body else None)
-    elif action == 'provision_by_snapshot_defaults':
-        params = build_params()
-        body = {k: v for k, v in {'snapshot_id': snapshot_id, 'engine_id': engine_id, 'source_data_id': source_data_id}.items() if v is not None}
-        conf = check_confirmation('POST', '/vdbs/provision_by_snapshot/defaults', action, 'data_tool', confirmed or False, request_params=params, request_body=body)
-        if conf:
-            return conf
-        return make_api_request('POST', '/vdbs/provision_by_snapshot/defaults', params=params, json_body=body if body else None)
-    elif action == 'provision_from_bookmark':
-        params = build_params()
-        if not environment_user_id:
-            environment_user_id = environment_user_ref or environment_user
-        body = {k: v for k, v in {'pre_refresh': pre_refresh, 'post_refresh': post_refresh, 'pre_self_refresh': pre_self_refresh, 'post_self_refresh': post_self_refresh, 'pre_rollback': pre_rollback, 'post_rollback': post_rollback, 'configure_clone': configure_clone, 'pre_snapshot': pre_snapshot, 'post_snapshot': post_snapshot, 'pre_start': pre_start, 'post_start': post_start, 'pre_stop': pre_stop, 'post_stop': post_stop, 'target_group_id': target_group_id, 'name': name, 'database_name': database_name, 'cdb_id': cdb_id, 'cluster_node_ids': cluster_node_ids, 'cluster_node_instances': cluster_node_instances, 'truncate_log_on_checkpoint': truncate_log_on_checkpoint, 'os_username': os_username, 'os_password': os_password, 'environment_id': environment_id, 'environment_user_id': environment_user_id, 'repository_id': repository_id, 'auto_select_repository': auto_select_repository, 'vdb_restart': vdb_restart, 'template_id': template_id, 'auxiliary_template_id': auxiliary_template_id, 'file_mapping_rules': file_mapping_rules, 'oracle_instance_name': oracle_instance_name, 'unique_name': unique_name, 'vcdb_name': vcdb_name, 'vcdb_database_name': vcdb_database_name, 'mount_point': mount_point, 'open_reset_logs': open_reset_logs, 'snapshot_policy_id': snapshot_policy_id, 'retention_policy_id': retention_policy_id, 'recovery_model': recovery_model, 'pre_script': pre_script, 'post_script': post_script, 'cdc_on_provision': cdc_on_provision, 'online_log_size': online_log_size, 'online_log_groups': online_log_groups, 'archive_log': archive_log, 'new_dbid': new_dbid, 'masked': masked, 'listener_ids': listener_ids, 'custom_env_vars': custom_env_vars, 'custom_env_files': custom_env_files, 'oracle_rac_custom_env_files': oracle_rac_custom_env_files, 'oracle_rac_custom_env_vars': oracle_rac_custom_env_vars, 'parentTdeKeystorePath': parent_tde_keystore_path, 'parent_tde_keystore_password': parent_tde_keystore_password, 'parent_pdb_tde_keystore_path': parent_pdb_tde_keystore_path, 'parent_pdb_tde_keystore_password': parent_pdb_tde_keystore_password, 'target_pdb_tde_keystore_password': target_pdb_tde_keystore_password, 'tde_exported_key_file_secret': tde_exported_key_file_secret, 'tde_key_identifier': tde_key_identifier, 'target_vcdb_tde_keystore_path': target_vcdb_tde_keystore_path, 'cdb_tde_keystore_password': cdb_tde_keystore_password, 'vcdb_tde_key_identifier': vcdb_tde_key_identifier, 'tde_keystore_config_type': tde_keystore_config_type, 'okv_client_id': okv_client_id, 'appdata_source_params': appdata_source_params, 'additional_mount_points': additional_mount_points, 'appdata_config_params': appdata_config_params, 'config_params': config_params, 'privileged_os_user': privileged_os_user, 'postgres_port': postgres_port, 'config_settings_stg': config_settings_stg, 'vcdb_restart': vcdb_restart, 'mssql_failover_drive_letter': mssql_failover_drive_letter, 'tags': tags, 'invoke_datapatch': invoke_datapatch, 'container_mode': container_mode, 'mssql_ag_backup_location': mssql_ag_backup_location, 'mssql_ag_backup_based': mssql_ag_backup_based, 'cache_priority': cache_priority, 'mssql_incremental_export_backup_frequency_minutes': mssql_incremental_export_backup_frequency_minutes, 'bookmark_id': bookmark_id, 'make_current_account_owner': make_current_account_owner}.items() if v is not None}
-        conf = check_confirmation('POST', '/vdbs/provision_from_bookmark', action, 'data_tool', confirmed or False, request_params=params, request_body=body)
-        if conf:
-            return conf
-        return make_api_request('POST', '/vdbs/provision_from_bookmark', params=params, json_body=body if body else None)
-    elif action == 'provision_from_bookmark_defaults':
-        params = build_params()
-        body = {k: v for k, v in {'bookmark_id': bookmark_id}.items() if v is not None}
-        conf = check_confirmation('POST', '/vdbs/provision_from_bookmark/defaults', action, 'data_tool', confirmed or False, request_params=params, request_body=body)
-        if conf:
-            return conf
-        return make_api_request('POST', '/vdbs/provision_from_bookmark/defaults', params=params, json_body=body if body else None)
-    elif action == 'provision_by_location':
-        params = build_params()
-        if not environment_user_id:
-            environment_user_id = environment_user_ref or environment_user
-        body = {k: v for k, v in {'pre_refresh': pre_refresh, 'post_refresh': post_refresh, 'pre_self_refresh': pre_self_refresh, 'post_self_refresh': post_self_refresh, 'pre_rollback': pre_rollback, 'post_rollback': post_rollback, 'configure_clone': configure_clone, 'pre_snapshot': pre_snapshot, 'post_snapshot': post_snapshot, 'pre_start': pre_start, 'post_start': post_start, 'pre_stop': pre_stop, 'post_stop': post_stop, 'target_group_id': target_group_id, 'name': name, 'database_name': database_name, 'cdb_id': cdb_id, 'cluster_node_ids': cluster_node_ids, 'cluster_node_instances': cluster_node_instances, 'truncate_log_on_checkpoint': truncate_log_on_checkpoint, 'os_username': os_username, 'os_password': os_password, 'environment_id': environment_id, 'environment_user_id': environment_user_id, 'repository_id': repository_id, 'auto_select_repository': auto_select_repository, 'vdb_restart': vdb_restart, 'template_id': template_id, 'auxiliary_template_id': auxiliary_template_id, 'file_mapping_rules': file_mapping_rules, 'oracle_instance_name': oracle_instance_name, 'unique_name': unique_name, 'vcdb_name': vcdb_name, 'vcdb_database_name': vcdb_database_name, 'mount_point': mount_point, 'open_reset_logs': open_reset_logs, 'snapshot_policy_id': snapshot_policy_id, 'retention_policy_id': retention_policy_id, 'recovery_model': recovery_model, 'pre_script': pre_script, 'post_script': post_script, 'cdc_on_provision': cdc_on_provision, 'online_log_size': online_log_size, 'online_log_groups': online_log_groups, 'archive_log': archive_log, 'new_dbid': new_dbid, 'masked': masked, 'listener_ids': listener_ids, 'custom_env_vars': custom_env_vars, 'custom_env_files': custom_env_files, 'oracle_rac_custom_env_files': oracle_rac_custom_env_files, 'oracle_rac_custom_env_vars': oracle_rac_custom_env_vars, 'parentTdeKeystorePath': parent_tde_keystore_path, 'parent_tde_keystore_password': parent_tde_keystore_password, 'parent_pdb_tde_keystore_path': parent_pdb_tde_keystore_path, 'parent_pdb_tde_keystore_password': parent_pdb_tde_keystore_password, 'target_pdb_tde_keystore_password': target_pdb_tde_keystore_password, 'tde_exported_key_file_secret': tde_exported_key_file_secret, 'tde_key_identifier': tde_key_identifier, 'target_vcdb_tde_keystore_path': target_vcdb_tde_keystore_path, 'cdb_tde_keystore_password': cdb_tde_keystore_password, 'vcdb_tde_key_identifier': vcdb_tde_key_identifier, 'tde_keystore_config_type': tde_keystore_config_type, 'okv_client_id': okv_client_id, 'appdata_source_params': appdata_source_params, 'additional_mount_points': additional_mount_points, 'appdata_config_params': appdata_config_params, 'config_params': config_params, 'privileged_os_user': privileged_os_user, 'postgres_port': postgres_port, 'config_settings_stg': config_settings_stg, 'vcdb_restart': vcdb_restart, 'mssql_failover_drive_letter': mssql_failover_drive_letter, 'tags': tags, 'invoke_datapatch': invoke_datapatch, 'container_mode': container_mode, 'mssql_ag_backup_location': mssql_ag_backup_location, 'mssql_ag_backup_based': mssql_ag_backup_based, 'cache_priority': cache_priority, 'mssql_incremental_export_backup_frequency_minutes': mssql_incremental_export_backup_frequency_minutes, 'location': location, 'timeflow_id': timeflow_id, 'engine_id': engine_id, 'source_data_id': source_data_id, 'make_current_account_owner': make_current_account_owner}.items() if v is not None}
-        conf = check_confirmation('POST', '/vdbs/provision_by_location', action, 'data_tool', confirmed or False, request_params=params, request_body=body)
-        if conf:
-            return conf
-        return make_api_request('POST', '/vdbs/provision_by_location', params=params, json_body=body if body else None)
-    elif action == 'provision_by_location_defaults':
-        params = build_params()
-        body = {k: v for k, v in {'source_data_id': source_data_id, 'engine_id': engine_id, 'location': location, 'timeflow_id': timeflow_id}.items() if v is not None}
-        conf = check_confirmation('POST', '/vdbs/provision_by_location/defaults', action, 'data_tool', confirmed or False, request_params=params, request_body=body)
-        if conf:
-            return conf
-        return make_api_request('POST', '/vdbs/provision_by_location/defaults', params=params, json_body=body if body else None)
-    elif action == 'provision_empty_vdb':
-        params = build_params()
-        if not environment_user_id:
-            environment_user_id = environment_user_ref or environment_user
-        body = {k: v for k, v in {'pre_refresh': pre_refresh, 'post_refresh': post_refresh, 'pre_self_refresh': pre_self_refresh, 'post_self_refresh': post_self_refresh, 'pre_rollback': pre_rollback, 'post_rollback': post_rollback, 'configure_clone': configure_clone, 'pre_snapshot': pre_snapshot, 'post_snapshot': post_snapshot, 'pre_start': pre_start, 'post_start': post_start, 'pre_stop': pre_stop, 'post_stop': post_stop, 'target_group_id': target_group_id, 'name': name, 'database_name': database_name, 'cdb_id': cdb_id, 'cluster_node_ids': cluster_node_ids, 'cluster_node_instances': cluster_node_instances, 'truncate_log_on_checkpoint': truncate_log_on_checkpoint, 'os_username': os_username, 'os_password': os_password, 'environment_id': environment_id, 'environment_user_id': environment_user_id, 'repository_id': repository_id, 'auto_select_repository': auto_select_repository, 'vdb_restart': vdb_restart, 'template_id': template_id, 'auxiliary_template_id': auxiliary_template_id, 'file_mapping_rules': file_mapping_rules, 'oracle_instance_name': oracle_instance_name, 'unique_name': unique_name, 'vcdb_name': vcdb_name, 'vcdb_database_name': vcdb_database_name, 'mount_point': mount_point, 'open_reset_logs': open_reset_logs, 'snapshot_policy_id': snapshot_policy_id, 'retention_policy_id': retention_policy_id, 'recovery_model': recovery_model, 'pre_script': pre_script, 'post_script': post_script, 'cdc_on_provision': cdc_on_provision, 'online_log_size': online_log_size, 'online_log_groups': online_log_groups, 'archive_log': archive_log, 'new_dbid': new_dbid, 'masked': masked, 'listener_ids': listener_ids, 'custom_env_vars': custom_env_vars, 'custom_env_files': custom_env_files, 'oracle_rac_custom_env_files': oracle_rac_custom_env_files, 'oracle_rac_custom_env_vars': oracle_rac_custom_env_vars, 'parentTdeKeystorePath': parent_tde_keystore_path, 'parent_tde_keystore_password': parent_tde_keystore_password, 'parent_pdb_tde_keystore_path': parent_pdb_tde_keystore_path, 'parent_pdb_tde_keystore_password': parent_pdb_tde_keystore_password, 'target_pdb_tde_keystore_password': target_pdb_tde_keystore_password, 'tde_exported_key_file_secret': tde_exported_key_file_secret, 'tde_key_identifier': tde_key_identifier, 'target_vcdb_tde_keystore_path': target_vcdb_tde_keystore_path, 'cdb_tde_keystore_password': cdb_tde_keystore_password, 'vcdb_tde_key_identifier': vcdb_tde_key_identifier, 'tde_keystore_config_type': tde_keystore_config_type, 'okv_client_id': okv_client_id, 'appdata_source_params': appdata_source_params, 'additional_mount_points': additional_mount_points, 'appdata_config_params': appdata_config_params, 'config_params': config_params, 'privileged_os_user': privileged_os_user, 'postgres_port': postgres_port, 'config_settings_stg': config_settings_stg, 'vcdb_restart': vcdb_restart, 'mssql_failover_drive_letter': mssql_failover_drive_letter, 'tags': tags, 'invoke_datapatch': invoke_datapatch, 'container_mode': container_mode, 'mssql_ag_backup_location': mssql_ag_backup_location, 'mssql_ag_backup_based': mssql_ag_backup_based, 'cache_priority': cache_priority, 'mssql_incremental_export_backup_frequency_minutes': mssql_incremental_export_backup_frequency_minutes, 'engine_id': engine_id}.items() if v is not None}
-        conf = check_confirmation('POST', '/vdbs/empty_vdb', action, 'data_tool', confirmed or False, request_params=params, request_body=body)
-        if conf:
-            return conf
-        return make_api_request('POST', '/vdbs/empty_vdb', params=params, json_body=body if body else None)
-    elif action == 'delete_vdb':
-        if vdb_id is None:
-            return {'error': 'Missing required parameter: vdb_id for action delete_vdb'}
-        endpoint = f'/vdbs/{vdb_id}/delete'
-        params = build_params()
-        body = {k: v for k, v in {'force': force, 'delete_all_dependent_vdbs': delete_all_dependent_vdbs}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=body)
-        if conf:
-            return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'start_vdb':
-        if vdb_id is None:
-            return {'error': 'Missing required parameter: vdb_id for action start_vdb'}
-        endpoint = f'/vdbs/{vdb_id}/start'
-        params = build_params()
-        body = {k: v for k, v in {'instances': instances}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=body)
-        if conf:
-            return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'stop_vdb':
-        if vdb_id is None:
-            return {'error': 'Missing required parameter: vdb_id for action stop_vdb'}
-        endpoint = f'/vdbs/{vdb_id}/stop'
-        params = build_params()
-        body = {k: v for k, v in {'instances': instances, 'abort': abort}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=body)
-        if conf:
-            return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'enable_vdb':
-        if vdb_id is None:
-            return {'error': 'Missing required parameter: vdb_id for action enable_vdb'}
-        endpoint = f'/vdbs/{vdb_id}/enable'
-        params = build_params()
-        body = {k: v for k, v in {'attempt_start': attempt_start, 'container_mode': container_mode, 'ownership_spec': ownership_spec}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=body)
-        if conf:
-            return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'disable_vdb':
-        if vdb_id is None:
-            return {'error': 'Missing required parameter: vdb_id for action disable_vdb'}
-        endpoint = f'/vdbs/{vdb_id}/disable'
-        params = build_params()
-        body = {k: v for k, v in {'attempt_cleanup': attempt_cleanup, 'container_mode': container_mode}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=body)
-        if conf:
-            return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'refresh_vdb_by_timestamp':
-        if vdb_id is None:
-            return {'error': 'Missing required parameter: vdb_id for action refresh_vdb_by_timestamp'}
-        endpoint = f'/vdbs/{vdb_id}/refresh_by_timestamp'
-        params = build_params()
-        body = {k: v for k, v in {'timestamp': timestamp, 'timestamp_in_database_timezone': timestamp_in_database_timezone, 'timeflow_id': timeflow_id, 'dataset_id': dataset_id}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=body)
-        if conf:
-            return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'refresh_vdb_by_snapshot':
-        if vdb_id is None:
-            return {'error': 'Missing required parameter: vdb_id for action refresh_vdb_by_snapshot'}
-        endpoint = f'/vdbs/{vdb_id}/refresh_by_snapshot'
-        params = build_params()
-        body = {k: v for k, v in {'snapshot_id': snapshot_id}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=body)
-        if conf:
-            return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'refresh_vdb_from_bookmark':
-        if vdb_id is None:
-            return {'error': 'Missing required parameter: vdb_id for action refresh_vdb_from_bookmark'}
-        endpoint = f'/vdbs/{vdb_id}/refresh_from_bookmark'
-        params = build_params()
-        body = {k: v for k, v in {'bookmark_id': bookmark_id}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=body)
-        if conf:
-            return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'refresh_vdb_by_location':
-        if vdb_id is None:
-            return {'error': 'Missing required parameter: vdb_id for action refresh_vdb_by_location'}
-        endpoint = f'/vdbs/{vdb_id}/refresh_by_location'
-        params = build_params()
-        body = {k: v for k, v in {'location': location, 'dataset_id': dataset_id, 'timeflow_id': timeflow_id}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=body)
-        if conf:
-            return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'undo_vdb_refresh':
-        if vdb_id is None:
-            return {'error': 'Missing required parameter: vdb_id for action undo_vdb_refresh'}
-        endpoint = f'/vdbs/{vdb_id}/undo_refresh'
-        params = build_params()
-        conf = check_confirmation('POST', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=None)
-        if conf:
-            return conf
-        return make_api_request('POST', endpoint, params=params)
-    elif action == 'rollback_vdb_by_timestamp':
-        if vdb_id is None:
-            return {'error': 'Missing required parameter: vdb_id for action rollback_vdb_by_timestamp'}
-        endpoint = f'/vdbs/{vdb_id}/rollback_by_timestamp'
-        params = build_params()
-        body = {k: v for k, v in {'timestamp': timestamp, 'timestamp_in_database_timezone': timestamp_in_database_timezone, 'timeflow_id': timeflow_id}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=body)
-        if conf:
-            return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'rollback_vdb_by_snapshot':
-        if vdb_id is None:
-            return {'error': 'Missing required parameter: vdb_id for action rollback_vdb_by_snapshot'}
-        endpoint = f'/vdbs/{vdb_id}/rollback_by_snapshot'
-        params = build_params()
-        body = {k: v for k, v in {'snapshot_id': snapshot_id}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=body)
-        if conf:
-            return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'rollback_vdb_from_bookmark':
-        if vdb_id is None:
-            return {'error': 'Missing required parameter: vdb_id for action rollback_vdb_from_bookmark'}
-        endpoint = f'/vdbs/{vdb_id}/rollback_from_bookmark'
-        params = build_params()
-        body = {k: v for k, v in {'bookmark_id': bookmark_id}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=body)
-        if conf:
-            return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'switch_vdb_timeflow':
-        if vdb_id is None:
-            return {'error': 'Missing required parameter: vdb_id for action switch_vdb_timeflow'}
-        endpoint = f'/vdbs/{vdb_id}/switch_timeflow'
-        params = build_params()
-        body = {k: v for k, v in {'timeflow_id': timeflow_id}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=body)
-        if conf:
-            return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'lock_vdb':
-        if vdb_id is None:
-            return {'error': 'Missing required parameter: vdb_id for action lock_vdb'}
-        endpoint = f'/vdbs/{vdb_id}/lock'
-        params = build_params()
-        body = {k: v for k, v in {'account_id': account_id}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=body)
-        if conf:
-            return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'unlock_vdb':
-        if vdb_id is None:
-            return {'error': 'Missing required parameter: vdb_id for action unlock_vdb'}
-        endpoint = f'/vdbs/{vdb_id}/unlock'
-        params = build_params()
-        conf = check_confirmation('POST', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=None)
-        if conf:
-            return conf
-        return make_api_request('POST', endpoint, params=params)
-    elif action == 'migrate_vdb':
-        if vdb_id is None:
-            return {'error': 'Missing required parameter: vdb_id for action migrate_vdb'}
-        endpoint = f'/vdbs/{vdb_id}/migrate'
-        params = build_params()
-        body = {k: v for k, v in {'environment_id': environment_id, 'environment_user_ref': environment_user_ref, 'repository_id': repository_id, 'cdb_id': cdb_id, 'cluster_node_ids': cluster_node_ids, 'cluster_node_instances': cluster_node_instances}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=body)
-        if conf:
-            return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'get_migrate_compatible_repositories':
-        if vdb_id is None:
-            return {'error': 'Missing required parameter: vdb_id for action get_migrate_compatible_repositories'}
-        endpoint = f'/vdbs/{vdb_id}/migrate_compatible_repositories'
-        params = build_params()
-        conf = check_confirmation('GET', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=None)
-        if conf:
-            return conf
-        return make_api_request('GET', endpoint, params=params)
-    elif action == 'upgrade_vdb':
-        if vdb_id is None:
-            return {'error': 'Missing required parameter: vdb_id for action upgrade_vdb'}
-        endpoint = f'/vdbs/{vdb_id}/upgrade'
+        return make_api_request(
+            "POST",
+            "/vdbs/provision_by_timestamp/defaults",
+            params=params,
+            json_body=body if body else None,
+        )
+    elif action == "provision_by_snapshot":
         params = build_params()
         if not environment_user_id:
             environment_user_id = environment_user_ref or environment_user
-        body = {k: v for k, v in {'repository_id': repository_id, 'environment_user_id': environment_user_id, 'ppt_repository': ppt_repository}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "pre_refresh": pre_refresh,
+                "post_refresh": post_refresh,
+                "pre_self_refresh": pre_self_refresh,
+                "post_self_refresh": post_self_refresh,
+                "pre_rollback": pre_rollback,
+                "post_rollback": post_rollback,
+                "configure_clone": configure_clone,
+                "pre_snapshot": pre_snapshot,
+                "post_snapshot": post_snapshot,
+                "pre_start": pre_start,
+                "post_start": post_start,
+                "pre_stop": pre_stop,
+                "post_stop": post_stop,
+                "target_group_id": target_group_id,
+                "name": name,
+                "database_name": database_name,
+                "cdb_id": cdb_id,
+                "cluster_node_ids": cluster_node_ids,
+                "cluster_node_instances": cluster_node_instances,
+                "truncate_log_on_checkpoint": truncate_log_on_checkpoint,
+                "os_username": os_username,
+                "os_password": os_password,
+                "environment_id": environment_id,
+                "environment_user_id": environment_user_id,
+                "repository_id": repository_id,
+                "auto_select_repository": auto_select_repository,
+                "vdb_restart": vdb_restart,
+                "template_id": template_id,
+                "auxiliary_template_id": auxiliary_template_id,
+                "file_mapping_rules": file_mapping_rules,
+                "oracle_instance_name": oracle_instance_name,
+                "unique_name": unique_name,
+                "vcdb_name": vcdb_name,
+                "vcdb_database_name": vcdb_database_name,
+                "mount_point": mount_point,
+                "open_reset_logs": open_reset_logs,
+                "snapshot_policy_id": snapshot_policy_id,
+                "retention_policy_id": retention_policy_id,
+                "recovery_model": recovery_model,
+                "pre_script": pre_script,
+                "post_script": post_script,
+                "cdc_on_provision": cdc_on_provision,
+                "online_log_size": online_log_size,
+                "online_log_groups": online_log_groups,
+                "archive_log": archive_log,
+                "new_dbid": new_dbid,
+                "masked": masked,
+                "listener_ids": listener_ids,
+                "custom_env_vars": custom_env_vars,
+                "custom_env_files": custom_env_files,
+                "oracle_rac_custom_env_files": oracle_rac_custom_env_files,
+                "oracle_rac_custom_env_vars": oracle_rac_custom_env_vars,
+                "parentTdeKeystorePath": parent_tde_keystore_path,
+                "parent_tde_keystore_password": parent_tde_keystore_password,
+                "parent_pdb_tde_keystore_path": parent_pdb_tde_keystore_path,
+                "parent_pdb_tde_keystore_password": parent_pdb_tde_keystore_password,
+                "target_pdb_tde_keystore_password": target_pdb_tde_keystore_password,
+                "tde_exported_key_file_secret": tde_exported_key_file_secret,
+                "tde_key_identifier": tde_key_identifier,
+                "target_vcdb_tde_keystore_path": target_vcdb_tde_keystore_path,
+                "cdb_tde_keystore_password": cdb_tde_keystore_password,
+                "vcdb_tde_key_identifier": vcdb_tde_key_identifier,
+                "tde_keystore_config_type": tde_keystore_config_type,
+                "okv_client_id": okv_client_id,
+                "appdata_source_params": appdata_source_params,
+                "additional_mount_points": additional_mount_points,
+                "appdata_config_params": appdata_config_params,
+                "config_params": config_params,
+                "privileged_os_user": privileged_os_user,
+                "postgres_port": postgres_port,
+                "config_settings_stg": config_settings_stg,
+                "vcdb_restart": vcdb_restart,
+                "mssql_failover_drive_letter": mssql_failover_drive_letter,
+                "tags": tags,
+                "invoke_datapatch": invoke_datapatch,
+                "container_mode": container_mode,
+                "mssql_ag_backup_location": mssql_ag_backup_location,
+                "mssql_ag_backup_based": mssql_ag_backup_based,
+                "cache_priority": cache_priority,
+                "mssql_incremental_export_backup_frequency_minutes": mssql_incremental_export_backup_frequency_minutes,
+                "snapshot_id": snapshot_id,
+                "engine_id": engine_id,
+                "source_data_id": source_data_id,
+                "make_current_account_owner": make_current_account_owner,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            "/vdbs/provision_by_snapshot",
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'upgrade_oracle_vdb':
-        if vdb_id is None:
-            return {'error': 'Missing required parameter: vdb_id for action upgrade_oracle_vdb'}
-        endpoint = f'/vdbs/oracle/{vdb_id}/upgrade'
+        return make_api_request(
+            "POST",
+            "/vdbs/provision_by_snapshot",
+            params=params,
+            json_body=body if body else None,
+        )
+    elif action == "provision_by_snapshot_defaults":
+        params = build_params()
+        body = {
+            k: v
+            for k, v in {
+                "snapshot_id": snapshot_id,
+                "engine_id": engine_id,
+                "source_data_id": source_data_id,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            "/vdbs/provision_by_snapshot/defaults",
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
+        if conf:
+            return conf
+        return make_api_request(
+            "POST",
+            "/vdbs/provision_by_snapshot/defaults",
+            params=params,
+            json_body=body if body else None,
+        )
+    elif action == "provision_from_bookmark":
         params = build_params()
         if not environment_user_id:
             environment_user_id = environment_user_ref or environment_user
-        body = {k: v for k, v in {'repository_id': repository_id, 'environment_user_id': environment_user_id}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "pre_refresh": pre_refresh,
+                "post_refresh": post_refresh,
+                "pre_self_refresh": pre_self_refresh,
+                "post_self_refresh": post_self_refresh,
+                "pre_rollback": pre_rollback,
+                "post_rollback": post_rollback,
+                "configure_clone": configure_clone,
+                "pre_snapshot": pre_snapshot,
+                "post_snapshot": post_snapshot,
+                "pre_start": pre_start,
+                "post_start": post_start,
+                "pre_stop": pre_stop,
+                "post_stop": post_stop,
+                "target_group_id": target_group_id,
+                "name": name,
+                "database_name": database_name,
+                "cdb_id": cdb_id,
+                "cluster_node_ids": cluster_node_ids,
+                "cluster_node_instances": cluster_node_instances,
+                "truncate_log_on_checkpoint": truncate_log_on_checkpoint,
+                "os_username": os_username,
+                "os_password": os_password,
+                "environment_id": environment_id,
+                "environment_user_id": environment_user_id,
+                "repository_id": repository_id,
+                "auto_select_repository": auto_select_repository,
+                "vdb_restart": vdb_restart,
+                "template_id": template_id,
+                "auxiliary_template_id": auxiliary_template_id,
+                "file_mapping_rules": file_mapping_rules,
+                "oracle_instance_name": oracle_instance_name,
+                "unique_name": unique_name,
+                "vcdb_name": vcdb_name,
+                "vcdb_database_name": vcdb_database_name,
+                "mount_point": mount_point,
+                "open_reset_logs": open_reset_logs,
+                "snapshot_policy_id": snapshot_policy_id,
+                "retention_policy_id": retention_policy_id,
+                "recovery_model": recovery_model,
+                "pre_script": pre_script,
+                "post_script": post_script,
+                "cdc_on_provision": cdc_on_provision,
+                "online_log_size": online_log_size,
+                "online_log_groups": online_log_groups,
+                "archive_log": archive_log,
+                "new_dbid": new_dbid,
+                "masked": masked,
+                "listener_ids": listener_ids,
+                "custom_env_vars": custom_env_vars,
+                "custom_env_files": custom_env_files,
+                "oracle_rac_custom_env_files": oracle_rac_custom_env_files,
+                "oracle_rac_custom_env_vars": oracle_rac_custom_env_vars,
+                "parentTdeKeystorePath": parent_tde_keystore_path,
+                "parent_tde_keystore_password": parent_tde_keystore_password,
+                "parent_pdb_tde_keystore_path": parent_pdb_tde_keystore_path,
+                "parent_pdb_tde_keystore_password": parent_pdb_tde_keystore_password,
+                "target_pdb_tde_keystore_password": target_pdb_tde_keystore_password,
+                "tde_exported_key_file_secret": tde_exported_key_file_secret,
+                "tde_key_identifier": tde_key_identifier,
+                "target_vcdb_tde_keystore_path": target_vcdb_tde_keystore_path,
+                "cdb_tde_keystore_password": cdb_tde_keystore_password,
+                "vcdb_tde_key_identifier": vcdb_tde_key_identifier,
+                "tde_keystore_config_type": tde_keystore_config_type,
+                "okv_client_id": okv_client_id,
+                "appdata_source_params": appdata_source_params,
+                "additional_mount_points": additional_mount_points,
+                "appdata_config_params": appdata_config_params,
+                "config_params": config_params,
+                "privileged_os_user": privileged_os_user,
+                "postgres_port": postgres_port,
+                "config_settings_stg": config_settings_stg,
+                "vcdb_restart": vcdb_restart,
+                "mssql_failover_drive_letter": mssql_failover_drive_letter,
+                "tags": tags,
+                "invoke_datapatch": invoke_datapatch,
+                "container_mode": container_mode,
+                "mssql_ag_backup_location": mssql_ag_backup_location,
+                "mssql_ag_backup_based": mssql_ag_backup_based,
+                "cache_priority": cache_priority,
+                "mssql_incremental_export_backup_frequency_minutes": mssql_incremental_export_backup_frequency_minutes,
+                "bookmark_id": bookmark_id,
+                "make_current_account_owner": make_current_account_owner,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            "/vdbs/provision_from_bookmark",
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'get_upgrade_compatible_repositories':
-        if vdb_id is None:
-            return {'error': 'Missing required parameter: vdb_id for action get_upgrade_compatible_repositories'}
-        endpoint = f'/vdbs/{vdb_id}/upgrade_compatible_repositories'
+        return make_api_request(
+            "POST",
+            "/vdbs/provision_from_bookmark",
+            params=params,
+            json_body=body if body else None,
+        )
+    elif action == "provision_from_bookmark_defaults":
         params = build_params()
-        conf = check_confirmation('GET', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=None)
+        body = {k: v for k, v in {"bookmark_id": bookmark_id}.items() if v is not None}
+        conf = check_confirmation(
+            "POST",
+            "/vdbs/provision_from_bookmark/defaults",
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('GET', endpoint, params=params)
-    elif action == 'list_vdb_snapshots':
+        return make_api_request(
+            "POST",
+            "/vdbs/provision_from_bookmark/defaults",
+            params=params,
+            json_body=body if body else None,
+        )
+    elif action == "provision_by_location":
+        params = build_params()
+        if not environment_user_id:
+            environment_user_id = environment_user_ref or environment_user
+        body = {
+            k: v
+            for k, v in {
+                "pre_refresh": pre_refresh,
+                "post_refresh": post_refresh,
+                "pre_self_refresh": pre_self_refresh,
+                "post_self_refresh": post_self_refresh,
+                "pre_rollback": pre_rollback,
+                "post_rollback": post_rollback,
+                "configure_clone": configure_clone,
+                "pre_snapshot": pre_snapshot,
+                "post_snapshot": post_snapshot,
+                "pre_start": pre_start,
+                "post_start": post_start,
+                "pre_stop": pre_stop,
+                "post_stop": post_stop,
+                "target_group_id": target_group_id,
+                "name": name,
+                "database_name": database_name,
+                "cdb_id": cdb_id,
+                "cluster_node_ids": cluster_node_ids,
+                "cluster_node_instances": cluster_node_instances,
+                "truncate_log_on_checkpoint": truncate_log_on_checkpoint,
+                "os_username": os_username,
+                "os_password": os_password,
+                "environment_id": environment_id,
+                "environment_user_id": environment_user_id,
+                "repository_id": repository_id,
+                "auto_select_repository": auto_select_repository,
+                "vdb_restart": vdb_restart,
+                "template_id": template_id,
+                "auxiliary_template_id": auxiliary_template_id,
+                "file_mapping_rules": file_mapping_rules,
+                "oracle_instance_name": oracle_instance_name,
+                "unique_name": unique_name,
+                "vcdb_name": vcdb_name,
+                "vcdb_database_name": vcdb_database_name,
+                "mount_point": mount_point,
+                "open_reset_logs": open_reset_logs,
+                "snapshot_policy_id": snapshot_policy_id,
+                "retention_policy_id": retention_policy_id,
+                "recovery_model": recovery_model,
+                "pre_script": pre_script,
+                "post_script": post_script,
+                "cdc_on_provision": cdc_on_provision,
+                "online_log_size": online_log_size,
+                "online_log_groups": online_log_groups,
+                "archive_log": archive_log,
+                "new_dbid": new_dbid,
+                "masked": masked,
+                "listener_ids": listener_ids,
+                "custom_env_vars": custom_env_vars,
+                "custom_env_files": custom_env_files,
+                "oracle_rac_custom_env_files": oracle_rac_custom_env_files,
+                "oracle_rac_custom_env_vars": oracle_rac_custom_env_vars,
+                "parentTdeKeystorePath": parent_tde_keystore_path,
+                "parent_tde_keystore_password": parent_tde_keystore_password,
+                "parent_pdb_tde_keystore_path": parent_pdb_tde_keystore_path,
+                "parent_pdb_tde_keystore_password": parent_pdb_tde_keystore_password,
+                "target_pdb_tde_keystore_password": target_pdb_tde_keystore_password,
+                "tde_exported_key_file_secret": tde_exported_key_file_secret,
+                "tde_key_identifier": tde_key_identifier,
+                "target_vcdb_tde_keystore_path": target_vcdb_tde_keystore_path,
+                "cdb_tde_keystore_password": cdb_tde_keystore_password,
+                "vcdb_tde_key_identifier": vcdb_tde_key_identifier,
+                "tde_keystore_config_type": tde_keystore_config_type,
+                "okv_client_id": okv_client_id,
+                "appdata_source_params": appdata_source_params,
+                "additional_mount_points": additional_mount_points,
+                "appdata_config_params": appdata_config_params,
+                "config_params": config_params,
+                "privileged_os_user": privileged_os_user,
+                "postgres_port": postgres_port,
+                "config_settings_stg": config_settings_stg,
+                "vcdb_restart": vcdb_restart,
+                "mssql_failover_drive_letter": mssql_failover_drive_letter,
+                "tags": tags,
+                "invoke_datapatch": invoke_datapatch,
+                "container_mode": container_mode,
+                "mssql_ag_backup_location": mssql_ag_backup_location,
+                "mssql_ag_backup_based": mssql_ag_backup_based,
+                "cache_priority": cache_priority,
+                "mssql_incremental_export_backup_frequency_minutes": mssql_incremental_export_backup_frequency_minutes,
+                "location": location,
+                "timeflow_id": timeflow_id,
+                "engine_id": engine_id,
+                "source_data_id": source_data_id,
+                "make_current_account_owner": make_current_account_owner,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            "/vdbs/provision_by_location",
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
+        if conf:
+            return conf
+        return make_api_request(
+            "POST",
+            "/vdbs/provision_by_location",
+            params=params,
+            json_body=body if body else None,
+        )
+    elif action == "provision_by_location_defaults":
+        params = build_params()
+        body = {
+            k: v
+            for k, v in {
+                "source_data_id": source_data_id,
+                "engine_id": engine_id,
+                "location": location,
+                "timeflow_id": timeflow_id,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            "/vdbs/provision_by_location/defaults",
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
+        if conf:
+            return conf
+        return make_api_request(
+            "POST",
+            "/vdbs/provision_by_location/defaults",
+            params=params,
+            json_body=body if body else None,
+        )
+    elif action == "provision_empty_vdb":
+        params = build_params()
+        if not environment_user_id:
+            environment_user_id = environment_user_ref or environment_user
+        body = {
+            k: v
+            for k, v in {
+                "pre_refresh": pre_refresh,
+                "post_refresh": post_refresh,
+                "pre_self_refresh": pre_self_refresh,
+                "post_self_refresh": post_self_refresh,
+                "pre_rollback": pre_rollback,
+                "post_rollback": post_rollback,
+                "configure_clone": configure_clone,
+                "pre_snapshot": pre_snapshot,
+                "post_snapshot": post_snapshot,
+                "pre_start": pre_start,
+                "post_start": post_start,
+                "pre_stop": pre_stop,
+                "post_stop": post_stop,
+                "target_group_id": target_group_id,
+                "name": name,
+                "database_name": database_name,
+                "cdb_id": cdb_id,
+                "cluster_node_ids": cluster_node_ids,
+                "cluster_node_instances": cluster_node_instances,
+                "truncate_log_on_checkpoint": truncate_log_on_checkpoint,
+                "os_username": os_username,
+                "os_password": os_password,
+                "environment_id": environment_id,
+                "environment_user_id": environment_user_id,
+                "repository_id": repository_id,
+                "auto_select_repository": auto_select_repository,
+                "vdb_restart": vdb_restart,
+                "template_id": template_id,
+                "auxiliary_template_id": auxiliary_template_id,
+                "file_mapping_rules": file_mapping_rules,
+                "oracle_instance_name": oracle_instance_name,
+                "unique_name": unique_name,
+                "vcdb_name": vcdb_name,
+                "vcdb_database_name": vcdb_database_name,
+                "mount_point": mount_point,
+                "open_reset_logs": open_reset_logs,
+                "snapshot_policy_id": snapshot_policy_id,
+                "retention_policy_id": retention_policy_id,
+                "recovery_model": recovery_model,
+                "pre_script": pre_script,
+                "post_script": post_script,
+                "cdc_on_provision": cdc_on_provision,
+                "online_log_size": online_log_size,
+                "online_log_groups": online_log_groups,
+                "archive_log": archive_log,
+                "new_dbid": new_dbid,
+                "masked": masked,
+                "listener_ids": listener_ids,
+                "custom_env_vars": custom_env_vars,
+                "custom_env_files": custom_env_files,
+                "oracle_rac_custom_env_files": oracle_rac_custom_env_files,
+                "oracle_rac_custom_env_vars": oracle_rac_custom_env_vars,
+                "parentTdeKeystorePath": parent_tde_keystore_path,
+                "parent_tde_keystore_password": parent_tde_keystore_password,
+                "parent_pdb_tde_keystore_path": parent_pdb_tde_keystore_path,
+                "parent_pdb_tde_keystore_password": parent_pdb_tde_keystore_password,
+                "target_pdb_tde_keystore_password": target_pdb_tde_keystore_password,
+                "tde_exported_key_file_secret": tde_exported_key_file_secret,
+                "tde_key_identifier": tde_key_identifier,
+                "target_vcdb_tde_keystore_path": target_vcdb_tde_keystore_path,
+                "cdb_tde_keystore_password": cdb_tde_keystore_password,
+                "vcdb_tde_key_identifier": vcdb_tde_key_identifier,
+                "tde_keystore_config_type": tde_keystore_config_type,
+                "okv_client_id": okv_client_id,
+                "appdata_source_params": appdata_source_params,
+                "additional_mount_points": additional_mount_points,
+                "appdata_config_params": appdata_config_params,
+                "config_params": config_params,
+                "privileged_os_user": privileged_os_user,
+                "postgres_port": postgres_port,
+                "config_settings_stg": config_settings_stg,
+                "vcdb_restart": vcdb_restart,
+                "mssql_failover_drive_letter": mssql_failover_drive_letter,
+                "tags": tags,
+                "invoke_datapatch": invoke_datapatch,
+                "container_mode": container_mode,
+                "mssql_ag_backup_location": mssql_ag_backup_location,
+                "mssql_ag_backup_based": mssql_ag_backup_based,
+                "cache_priority": cache_priority,
+                "mssql_incremental_export_backup_frequency_minutes": mssql_incremental_export_backup_frequency_minutes,
+                "engine_id": engine_id,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            "/vdbs/empty_vdb",
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
+        if conf:
+            return conf
+        return make_api_request(
+            "POST", "/vdbs/empty_vdb", params=params, json_body=body if body else None
+        )
+    elif action == "delete_vdb":
         if vdb_id is None:
-            return {'error': 'Missing required parameter: vdb_id for action list_vdb_snapshots'}
-        endpoint = f'/vdbs/{vdb_id}/snapshots'
+            return {"error": "Missing required parameter: vdb_id for action delete_vdb"}
+        endpoint = f"/vdbs/{vdb_id}/delete"
+        params = build_params()
+        body = {
+            k: v
+            for k, v in {
+                "force": force,
+                "delete_all_dependent_vdbs": delete_all_dependent_vdbs,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
+        if conf:
+            return conf
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "start_vdb":
+        if vdb_id is None:
+            return {"error": "Missing required parameter: vdb_id for action start_vdb"}
+        endpoint = f"/vdbs/{vdb_id}/start"
+        params = build_params()
+        body = {k: v for k, v in {"instances": instances}.items() if v is not None}
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
+        if conf:
+            return conf
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "stop_vdb":
+        if vdb_id is None:
+            return {"error": "Missing required parameter: vdb_id for action stop_vdb"}
+        endpoint = f"/vdbs/{vdb_id}/stop"
+        params = build_params()
+        body = {
+            k: v
+            for k, v in {"instances": instances, "abort": abort}.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
+        if conf:
+            return conf
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "enable_vdb":
+        if vdb_id is None:
+            return {"error": "Missing required parameter: vdb_id for action enable_vdb"}
+        endpoint = f"/vdbs/{vdb_id}/enable"
+        params = build_params()
+        body = {
+            k: v
+            for k, v in {
+                "attempt_start": attempt_start,
+                "container_mode": container_mode,
+                "ownership_spec": ownership_spec,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
+        if conf:
+            return conf
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "disable_vdb":
+        if vdb_id is None:
+            return {
+                "error": "Missing required parameter: vdb_id for action disable_vdb"
+            }
+        endpoint = f"/vdbs/{vdb_id}/disable"
+        params = build_params()
+        body = {
+            k: v
+            for k, v in {
+                "attempt_cleanup": attempt_cleanup,
+                "container_mode": container_mode,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
+        if conf:
+            return conf
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "refresh_vdb_by_timestamp":
+        if vdb_id is None:
+            return {
+                "error": "Missing required parameter: vdb_id for action refresh_vdb_by_timestamp"
+            }
+        endpoint = f"/vdbs/{vdb_id}/refresh_by_timestamp"
+        params = build_params()
+        body = {
+            k: v
+            for k, v in {
+                "timestamp": timestamp,
+                "timestamp_in_database_timezone": timestamp_in_database_timezone,
+                "timeflow_id": timeflow_id,
+                "dataset_id": dataset_id,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
+        if conf:
+            return conf
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "refresh_vdb_by_snapshot":
+        if vdb_id is None:
+            return {
+                "error": "Missing required parameter: vdb_id for action refresh_vdb_by_snapshot"
+            }
+        endpoint = f"/vdbs/{vdb_id}/refresh_by_snapshot"
+        params = build_params()
+        body = {k: v for k, v in {"snapshot_id": snapshot_id}.items() if v is not None}
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
+        if conf:
+            return conf
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "refresh_vdb_from_bookmark":
+        if vdb_id is None:
+            return {
+                "error": "Missing required parameter: vdb_id for action refresh_vdb_from_bookmark"
+            }
+        endpoint = f"/vdbs/{vdb_id}/refresh_from_bookmark"
+        params = build_params()
+        body = {k: v for k, v in {"bookmark_id": bookmark_id}.items() if v is not None}
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
+        if conf:
+            return conf
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "refresh_vdb_by_location":
+        if vdb_id is None:
+            return {
+                "error": "Missing required parameter: vdb_id for action refresh_vdb_by_location"
+            }
+        endpoint = f"/vdbs/{vdb_id}/refresh_by_location"
+        params = build_params()
+        body = {
+            k: v
+            for k, v in {
+                "location": location,
+                "dataset_id": dataset_id,
+                "timeflow_id": timeflow_id,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
+        if conf:
+            return conf
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "undo_vdb_refresh":
+        if vdb_id is None:
+            return {
+                "error": "Missing required parameter: vdb_id for action undo_vdb_refresh"
+            }
+        endpoint = f"/vdbs/{vdb_id}/undo_refresh"
+        params = build_params()
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
+        if conf:
+            return conf
+        return make_api_request("POST", endpoint, params=params)
+    elif action == "rollback_vdb_by_timestamp":
+        if vdb_id is None:
+            return {
+                "error": "Missing required parameter: vdb_id for action rollback_vdb_by_timestamp"
+            }
+        endpoint = f"/vdbs/{vdb_id}/rollback_by_timestamp"
+        params = build_params()
+        body = {
+            k: v
+            for k, v in {
+                "timestamp": timestamp,
+                "timestamp_in_database_timezone": timestamp_in_database_timezone,
+                "timeflow_id": timeflow_id,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
+        if conf:
+            return conf
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "rollback_vdb_by_snapshot":
+        if vdb_id is None:
+            return {
+                "error": "Missing required parameter: vdb_id for action rollback_vdb_by_snapshot"
+            }
+        endpoint = f"/vdbs/{vdb_id}/rollback_by_snapshot"
+        params = build_params()
+        body = {k: v for k, v in {"snapshot_id": snapshot_id}.items() if v is not None}
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
+        if conf:
+            return conf
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "rollback_vdb_from_bookmark":
+        if vdb_id is None:
+            return {
+                "error": "Missing required parameter: vdb_id for action rollback_vdb_from_bookmark"
+            }
+        endpoint = f"/vdbs/{vdb_id}/rollback_from_bookmark"
+        params = build_params()
+        body = {k: v for k, v in {"bookmark_id": bookmark_id}.items() if v is not None}
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
+        if conf:
+            return conf
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "switch_vdb_timeflow":
+        if vdb_id is None:
+            return {
+                "error": "Missing required parameter: vdb_id for action switch_vdb_timeflow"
+            }
+        endpoint = f"/vdbs/{vdb_id}/switch_timeflow"
+        params = build_params()
+        body = {k: v for k, v in {"timeflow_id": timeflow_id}.items() if v is not None}
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
+        if conf:
+            return conf
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "lock_vdb":
+        if vdb_id is None:
+            return {"error": "Missing required parameter: vdb_id for action lock_vdb"}
+        endpoint = f"/vdbs/{vdb_id}/lock"
+        params = build_params()
+        body = {k: v for k, v in {"account_id": account_id}.items() if v is not None}
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
+        if conf:
+            return conf
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "unlock_vdb":
+        if vdb_id is None:
+            return {"error": "Missing required parameter: vdb_id for action unlock_vdb"}
+        endpoint = f"/vdbs/{vdb_id}/unlock"
+        params = build_params()
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
+        if conf:
+            return conf
+        return make_api_request("POST", endpoint, params=params)
+    elif action == "migrate_vdb":
+        if vdb_id is None:
+            return {
+                "error": "Missing required parameter: vdb_id for action migrate_vdb"
+            }
+        endpoint = f"/vdbs/{vdb_id}/migrate"
+        params = build_params()
+        body = {
+            k: v
+            for k, v in {
+                "environment_id": environment_id,
+                "environment_user_ref": environment_user_ref,
+                "repository_id": repository_id,
+                "cdb_id": cdb_id,
+                "cluster_node_ids": cluster_node_ids,
+                "cluster_node_instances": cluster_node_instances,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
+        if conf:
+            return conf
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "get_migrate_compatible_repositories":
+        if vdb_id is None:
+            return {
+                "error": "Missing required parameter: vdb_id for action get_migrate_compatible_repositories"
+            }
+        endpoint = f"/vdbs/{vdb_id}/migrate_compatible_repositories"
+        params = build_params()
+        conf = check_confirmation(
+            "GET",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
+        if conf:
+            return conf
+        return make_api_request("GET", endpoint, params=params)
+    elif action == "upgrade_vdb":
+        if vdb_id is None:
+            return {
+                "error": "Missing required parameter: vdb_id for action upgrade_vdb"
+            }
+        endpoint = f"/vdbs/{vdb_id}/upgrade"
+        params = build_params()
+        if not environment_user_id:
+            environment_user_id = environment_user_ref or environment_user
+        body = {
+            k: v
+            for k, v in {
+                "repository_id": repository_id,
+                "environment_user_id": environment_user_id,
+                "ppt_repository": ppt_repository,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
+        if conf:
+            return conf
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "upgrade_oracle_vdb":
+        if vdb_id is None:
+            return {
+                "error": "Missing required parameter: vdb_id for action upgrade_oracle_vdb"
+            }
+        endpoint = f"/vdbs/oracle/{vdb_id}/upgrade"
+        params = build_params()
+        if not environment_user_id:
+            environment_user_id = environment_user_ref or environment_user
+        body = {
+            k: v
+            for k, v in {
+                "repository_id": repository_id,
+                "environment_user_id": environment_user_id,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
+        if conf:
+            return conf
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "get_upgrade_compatible_repositories":
+        if vdb_id is None:
+            return {
+                "error": "Missing required parameter: vdb_id for action get_upgrade_compatible_repositories"
+            }
+        endpoint = f"/vdbs/{vdb_id}/upgrade_compatible_repositories"
+        params = build_params()
+        conf = check_confirmation(
+            "GET",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
+        if conf:
+            return conf
+        return make_api_request("GET", endpoint, params=params)
+    elif action == "list_vdb_snapshots":
+        if vdb_id is None:
+            return {
+                "error": "Missing required parameter: vdb_id for action list_vdb_snapshots"
+            }
+        endpoint = f"/vdbs/{vdb_id}/snapshots"
         params = build_params(limit=limit, cursor=cursor)
-        conf = check_confirmation('GET', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', endpoint, params=params)
-    elif action == 'snapshot_vdb':
+        return make_api_request("GET", endpoint, params=params)
+    elif action == "snapshot_vdb":
         if vdb_id is None:
-            return {'error': 'Missing required parameter: vdb_id for action snapshot_vdb'}
-        endpoint = f'/vdbs/{vdb_id}/snapshots'
+            return {
+                "error": "Missing required parameter: vdb_id for action snapshot_vdb"
+            }
+        endpoint = f"/vdbs/{vdb_id}/snapshots"
         params = build_params()
-        conf = check_confirmation('POST', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params)
-    elif action == 'list_vdb_bookmarks':
+        return make_api_request("POST", endpoint, params=params)
+    elif action == "list_vdb_bookmarks":
         if vdb_id is None:
-            return {'error': 'Missing required parameter: vdb_id for action list_vdb_bookmarks'}
-        endpoint = f'/vdbs/{vdb_id}/bookmarks'
+            return {
+                "error": "Missing required parameter: vdb_id for action list_vdb_bookmarks"
+            }
+        endpoint = f"/vdbs/{vdb_id}/bookmarks"
         params = build_params(limit=limit, cursor=cursor, sort=sort)
-        conf = check_confirmation('GET', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', endpoint, params=params)
-    elif action == 'search_vdb_bookmarks':
+        return make_api_request("GET", endpoint, params=params)
+    elif action == "search_vdb_bookmarks":
         if vdb_id is None:
-            return {'error': 'Missing required parameter: vdb_id for action search_vdb_bookmarks'}
-        endpoint = f'/vdbs/{vdb_id}/bookmarks/search'
+            return {
+                "error": "Missing required parameter: vdb_id for action search_vdb_bookmarks"
+            }
+        endpoint = f"/vdbs/{vdb_id}/bookmarks/search"
         params = build_params(limit=limit, cursor=cursor, sort=sort)
-        body = {'filter_expression': filter_expression} if filter_expression else {}
-        conf = check_confirmation('POST', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=body)
+        body = {"filter_expression": filter_expression} if filter_expression else {}
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body)
-    elif action == 'get_vdb_deletion_dependencies':
+        return make_api_request("POST", endpoint, params=params, json_body=body)
+    elif action == "get_vdb_deletion_dependencies":
         if vdb_id is None:
-            return {'error': 'Missing required parameter: vdb_id for action get_vdb_deletion_dependencies'}
-        endpoint = f'/vdbs/{vdb_id}/deletion-dependencies'
+            return {
+                "error": "Missing required parameter: vdb_id for action get_vdb_deletion_dependencies"
+            }
+        endpoint = f"/vdbs/{vdb_id}/deletion-dependencies"
         params = build_params()
-        conf = check_confirmation('GET', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', endpoint, params=params)
-    elif action == 'verify_vdb_jdbc_connection':
+        return make_api_request("GET", endpoint, params=params)
+    elif action == "verify_vdb_jdbc_connection":
         if vdb_id is None:
-            return {'error': 'Missing required parameter: vdb_id for action verify_vdb_jdbc_connection'}
-        endpoint = f'/vdbs/{vdb_id}/jdbc-check'
-        params = build_params(database_username=database_username, database_password=database_password, jdbc_connection_string=jdbc_connection_string)
-        body = {k: v for k, v in {'database_username': database_username, 'database_password': database_password, 'jdbc_connection_string': jdbc_connection_string}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=body)
+            return {
+                "error": "Missing required parameter: vdb_id for action verify_vdb_jdbc_connection"
+            }
+        endpoint = f"/vdbs/{vdb_id}/jdbc-check"
+        params = build_params(
+            database_username=database_username,
+            database_password=database_password,
+            jdbc_connection_string=jdbc_connection_string,
+        )
+        body = {
+            k: v
+            for k, v in {
+                "database_username": database_username,
+                "database_password": database_password,
+                "jdbc_connection_string": jdbc_connection_string,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'get_vdb_tags':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "get_vdb_tags":
         if vdb_id is None:
-            return {'error': 'Missing required parameter: vdb_id for action get_vdb_tags'}
-        endpoint = f'/vdbs/{vdb_id}/tags'
+            return {
+                "error": "Missing required parameter: vdb_id for action get_vdb_tags"
+            }
+        endpoint = f"/vdbs/{vdb_id}/tags"
         params = build_params()
-        conf = check_confirmation('GET', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', endpoint, params=params)
-    elif action == 'add_vdb_tags':
+        return make_api_request("GET", endpoint, params=params)
+    elif action == "add_vdb_tags":
         if vdb_id is None:
-            return {'error': 'Missing required parameter: vdb_id for action add_vdb_tags'}
-        endpoint = f'/vdbs/{vdb_id}/tags'
+            return {
+                "error": "Missing required parameter: vdb_id for action add_vdb_tags"
+            }
+        endpoint = f"/vdbs/{vdb_id}/tags"
         params = build_params(tags=tags)
-        body = {k: v for k, v in {'tags': tags}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=body)
+        body = {k: v for k, v in {"tags": tags}.items() if v is not None}
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'export_vdb_in_place':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "export_vdb_in_place":
         if vdb_id is None:
-            return {'error': 'Missing required parameter: vdb_id for action export_vdb_in_place'}
-        endpoint = f'/vdbs/{vdb_id}/in-place-export'
+            return {
+                "error": "Missing required parameter: vdb_id for action export_vdb_in_place"
+            }
+        endpoint = f"/vdbs/{vdb_id}/in-place-export"
         params = build_params()
-        body = {k: v for k, v in {'targetDirectory': target_directory, 'dataDirectory': data_directory, 'archiveDirectory': archive_directory, 'externalDirectory': external_directory, 'tempDirectory': temp_directory, 'scriptDirectory': script_directory, 'useAbsolutePathForDataFiles': use_absolute_path_for_data_files, 'rman_channels': rman_channels, 'rman_file_section_size_in_gb': rman_file_section_size_in_gb, 'db_unique_name': db_unique_name, 'pdb_name': pdb_name, 'operations_postV2P': operations_post_v2_p}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "targetDirectory": target_directory,
+                "dataDirectory": data_directory,
+                "archiveDirectory": archive_directory,
+                "externalDirectory": external_directory,
+                "tempDirectory": temp_directory,
+                "scriptDirectory": script_directory,
+                "useAbsolutePathForDataFiles": use_absolute_path_for_data_files,
+                "rman_channels": rman_channels,
+                "rman_file_section_size_in_gb": rman_file_section_size_in_gb,
+                "db_unique_name": db_unique_name,
+                "pdb_name": pdb_name,
+                "operations_postV2P": operations_post_v2_p,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'export_vdb_asm_in_place':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "export_vdb_asm_in_place":
         if vdb_id is None:
-            return {'error': 'Missing required parameter: vdb_id for action export_vdb_asm_in_place'}
-        endpoint = f'/vdbs/{vdb_id}/asm-in-place-export'
+            return {
+                "error": "Missing required parameter: vdb_id for action export_vdb_asm_in_place"
+            }
+        endpoint = f"/vdbs/{vdb_id}/asm-in-place-export"
         params = build_params(default_data_diskgroup=default_data_diskgroup)
-        body = {k: v for k, v in {'default_data_diskgroup': default_data_diskgroup, 'redo_diskgroup': redo_diskgroup, 'rman_channels': rman_channels, 'rman_file_section_size_in_gb': rman_file_section_size_in_gb, 'db_unique_name': db_unique_name, 'pdb_name': pdb_name, 'operations_postV2P': operations_post_v2_p}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "default_data_diskgroup": default_data_diskgroup,
+                "redo_diskgroup": redo_diskgroup,
+                "rman_channels": rman_channels,
+                "rman_file_section_size_in_gb": rman_file_section_size_in_gb,
+                "db_unique_name": db_unique_name,
+                "pdb_name": pdb_name,
+                "operations_postV2P": operations_post_v2_p,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'export_vdb_by_snapshot':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "export_vdb_by_snapshot":
         if vdb_id is None:
-            return {'error': 'Missing required parameter: vdb_id for action export_vdb_by_snapshot'}
-        endpoint = f'/vdbs/{vdb_id}/export-by-snapshot'
+            return {
+                "error": "Missing required parameter: vdb_id for action export_vdb_by_snapshot"
+            }
+        endpoint = f"/vdbs/{vdb_id}/export-by-snapshot"
         params = build_params()
-        body = {k: v for k, v in {'unique_name': unique_name, 'database_name': database_name, 'repository_id': repository_id, 'environment_user_ref': environment_user_ref, 'tde_keystore_password': tde_keystore_password, 'tde_keystore_config_type': tde_keystore_config_type, 'oracle_instance_name': oracle_instance_name, 'instance_number': instance_number, 'instances': instances, 'mount_base': mount_base, 'config_params': config_params, 'cdb_id': cdb_id, 'parent_tde_keystore_path': parent_tde_keystore_path, 'parent_tde_keystore_password': parent_tde_keystore_password, 'tde_exported_keyfile_secret': tde_exported_keyfile_secret, 'tde_key_identifier': tde_key_identifier, 'parent_pdb_tde_keystore_path': parent_pdb_tde_keystore_path, 'parent_pdb_tde_keystore_password': parent_pdb_tde_keystore_password, 'target_pdb_tde_keystore_password': target_pdb_tde_keystore_password, 'crs_database_name': crs_database_name, 'recover_database': recover_database, 'file_mapping_rules': file_mapping_rules, 'enable_cdc': enable_cdc, 'recovery_model': recovery_model, 'mirroring_state': mirroring_state, 'is_incremental_v2p': is_incremental_v2p, 'backup_frequency_minutes': backup_frequency_minutes, 'rman_channels_for_incremental_backup': rman_channels_for_incremental_backup, 'rman_files_per_set_for_incremental_backup': rman_files_per_set_for_incremental_backup, 'rman_file_section_size_in_gb_for_incremental_backup': rman_file_section_size_in_gb_for_incremental_backup, 'targetDirectory': target_directory, 'dataDirectory': data_directory, 'archiveDirectory': archive_directory, 'externalDirectory': external_directory, 'tempDirectory': temp_directory, 'scriptDirectory': script_directory, 'useAbsolutePathForDataFiles': use_absolute_path_for_data_files, 'rman_channels': rman_channels, 'rman_file_section_size_in_gb': rman_file_section_size_in_gb, 'snapshot_id': snapshot_id}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "unique_name": unique_name,
+                "database_name": database_name,
+                "repository_id": repository_id,
+                "environment_user_ref": environment_user_ref,
+                "tde_keystore_password": tde_keystore_password,
+                "tde_keystore_config_type": tde_keystore_config_type,
+                "oracle_instance_name": oracle_instance_name,
+                "instance_number": instance_number,
+                "instances": instances,
+                "mount_base": mount_base,
+                "config_params": config_params,
+                "cdb_id": cdb_id,
+                "parent_tde_keystore_path": parent_tde_keystore_path,
+                "parent_tde_keystore_password": parent_tde_keystore_password,
+                "tde_exported_keyfile_secret": tde_exported_keyfile_secret,
+                "tde_key_identifier": tde_key_identifier,
+                "parent_pdb_tde_keystore_path": parent_pdb_tde_keystore_path,
+                "parent_pdb_tde_keystore_password": parent_pdb_tde_keystore_password,
+                "target_pdb_tde_keystore_password": target_pdb_tde_keystore_password,
+                "crs_database_name": crs_database_name,
+                "recover_database": recover_database,
+                "file_mapping_rules": file_mapping_rules,
+                "enable_cdc": enable_cdc,
+                "recovery_model": recovery_model,
+                "mirroring_state": mirroring_state,
+                "is_incremental_v2p": is_incremental_v2p,
+                "backup_frequency_minutes": backup_frequency_minutes,
+                "rman_channels_for_incremental_backup": rman_channels_for_incremental_backup,
+                "rman_files_per_set_for_incremental_backup": rman_files_per_set_for_incremental_backup,
+                "rman_file_section_size_in_gb_for_incremental_backup": rman_file_section_size_in_gb_for_incremental_backup,
+                "targetDirectory": target_directory,
+                "dataDirectory": data_directory,
+                "archiveDirectory": archive_directory,
+                "externalDirectory": external_directory,
+                "tempDirectory": temp_directory,
+                "scriptDirectory": script_directory,
+                "useAbsolutePathForDataFiles": use_absolute_path_for_data_files,
+                "rman_channels": rman_channels,
+                "rman_file_section_size_in_gb": rman_file_section_size_in_gb,
+                "snapshot_id": snapshot_id,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'export_vdb_by_timestamp':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "export_vdb_by_timestamp":
         if vdb_id is None:
-            return {'error': 'Missing required parameter: vdb_id for action export_vdb_by_timestamp'}
-        endpoint = f'/vdbs/{vdb_id}/export-by-timestamp'
+            return {
+                "error": "Missing required parameter: vdb_id for action export_vdb_by_timestamp"
+            }
+        endpoint = f"/vdbs/{vdb_id}/export-by-timestamp"
         params = build_params(timestamp=timestamp)
-        body = {k: v for k, v in {'unique_name': unique_name, 'database_name': database_name, 'repository_id': repository_id, 'environment_user_ref': environment_user_ref, 'tde_keystore_password': tde_keystore_password, 'tde_keystore_config_type': tde_keystore_config_type, 'oracle_instance_name': oracle_instance_name, 'instance_number': instance_number, 'instances': instances, 'mount_base': mount_base, 'config_params': config_params, 'cdb_id': cdb_id, 'parent_tde_keystore_path': parent_tde_keystore_path, 'parent_tde_keystore_password': parent_tde_keystore_password, 'tde_exported_keyfile_secret': tde_exported_keyfile_secret, 'tde_key_identifier': tde_key_identifier, 'parent_pdb_tde_keystore_path': parent_pdb_tde_keystore_path, 'parent_pdb_tde_keystore_password': parent_pdb_tde_keystore_password, 'target_pdb_tde_keystore_password': target_pdb_tde_keystore_password, 'crs_database_name': crs_database_name, 'recover_database': recover_database, 'file_mapping_rules': file_mapping_rules, 'enable_cdc': enable_cdc, 'recovery_model': recovery_model, 'mirroring_state': mirroring_state, 'is_incremental_v2p': is_incremental_v2p, 'backup_frequency_minutes': backup_frequency_minutes, 'rman_channels_for_incremental_backup': rman_channels_for_incremental_backup, 'rman_files_per_set_for_incremental_backup': rman_files_per_set_for_incremental_backup, 'rman_file_section_size_in_gb_for_incremental_backup': rman_file_section_size_in_gb_for_incremental_backup, 'targetDirectory': target_directory, 'dataDirectory': data_directory, 'archiveDirectory': archive_directory, 'externalDirectory': external_directory, 'tempDirectory': temp_directory, 'scriptDirectory': script_directory, 'useAbsolutePathForDataFiles': use_absolute_path_for_data_files, 'rman_channels': rman_channels, 'rman_file_section_size_in_gb': rman_file_section_size_in_gb, 'timeflow_id': timeflow_id, 'timestamp': timestamp}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "unique_name": unique_name,
+                "database_name": database_name,
+                "repository_id": repository_id,
+                "environment_user_ref": environment_user_ref,
+                "tde_keystore_password": tde_keystore_password,
+                "tde_keystore_config_type": tde_keystore_config_type,
+                "oracle_instance_name": oracle_instance_name,
+                "instance_number": instance_number,
+                "instances": instances,
+                "mount_base": mount_base,
+                "config_params": config_params,
+                "cdb_id": cdb_id,
+                "parent_tde_keystore_path": parent_tde_keystore_path,
+                "parent_tde_keystore_password": parent_tde_keystore_password,
+                "tde_exported_keyfile_secret": tde_exported_keyfile_secret,
+                "tde_key_identifier": tde_key_identifier,
+                "parent_pdb_tde_keystore_path": parent_pdb_tde_keystore_path,
+                "parent_pdb_tde_keystore_password": parent_pdb_tde_keystore_password,
+                "target_pdb_tde_keystore_password": target_pdb_tde_keystore_password,
+                "crs_database_name": crs_database_name,
+                "recover_database": recover_database,
+                "file_mapping_rules": file_mapping_rules,
+                "enable_cdc": enable_cdc,
+                "recovery_model": recovery_model,
+                "mirroring_state": mirroring_state,
+                "is_incremental_v2p": is_incremental_v2p,
+                "backup_frequency_minutes": backup_frequency_minutes,
+                "rman_channels_for_incremental_backup": rman_channels_for_incremental_backup,
+                "rman_files_per_set_for_incremental_backup": rman_files_per_set_for_incremental_backup,
+                "rman_file_section_size_in_gb_for_incremental_backup": rman_file_section_size_in_gb_for_incremental_backup,
+                "targetDirectory": target_directory,
+                "dataDirectory": data_directory,
+                "archiveDirectory": archive_directory,
+                "externalDirectory": external_directory,
+                "tempDirectory": temp_directory,
+                "scriptDirectory": script_directory,
+                "useAbsolutePathForDataFiles": use_absolute_path_for_data_files,
+                "rman_channels": rman_channels,
+                "rman_file_section_size_in_gb": rman_file_section_size_in_gb,
+                "timeflow_id": timeflow_id,
+                "timestamp": timestamp,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'export_vdb_by_location':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "export_vdb_by_location":
         if vdb_id is None:
-            return {'error': 'Missing required parameter: vdb_id for action export_vdb_by_location'}
-        endpoint = f'/vdbs/{vdb_id}/export-by-location'
+            return {
+                "error": "Missing required parameter: vdb_id for action export_vdb_by_location"
+            }
+        endpoint = f"/vdbs/{vdb_id}/export-by-location"
         params = build_params(location=location)
-        body = {k: v for k, v in {'unique_name': unique_name, 'database_name': database_name, 'repository_id': repository_id, 'environment_user_ref': environment_user_ref, 'tde_keystore_password': tde_keystore_password, 'tde_keystore_config_type': tde_keystore_config_type, 'oracle_instance_name': oracle_instance_name, 'instance_number': instance_number, 'instances': instances, 'mount_base': mount_base, 'config_params': config_params, 'cdb_id': cdb_id, 'parent_tde_keystore_path': parent_tde_keystore_path, 'parent_tde_keystore_password': parent_tde_keystore_password, 'tde_exported_keyfile_secret': tde_exported_keyfile_secret, 'tde_key_identifier': tde_key_identifier, 'parent_pdb_tde_keystore_path': parent_pdb_tde_keystore_path, 'parent_pdb_tde_keystore_password': parent_pdb_tde_keystore_password, 'target_pdb_tde_keystore_password': target_pdb_tde_keystore_password, 'crs_database_name': crs_database_name, 'recover_database': recover_database, 'file_mapping_rules': file_mapping_rules, 'enable_cdc': enable_cdc, 'recovery_model': recovery_model, 'mirroring_state': mirroring_state, 'is_incremental_v2p': is_incremental_v2p, 'backup_frequency_minutes': backup_frequency_minutes, 'rman_channels_for_incremental_backup': rman_channels_for_incremental_backup, 'rman_files_per_set_for_incremental_backup': rman_files_per_set_for_incremental_backup, 'rman_file_section_size_in_gb_for_incremental_backup': rman_file_section_size_in_gb_for_incremental_backup, 'targetDirectory': target_directory, 'dataDirectory': data_directory, 'archiveDirectory': archive_directory, 'externalDirectory': external_directory, 'tempDirectory': temp_directory, 'scriptDirectory': script_directory, 'useAbsolutePathForDataFiles': use_absolute_path_for_data_files, 'rman_channels': rman_channels, 'rman_file_section_size_in_gb': rman_file_section_size_in_gb, 'location': location}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "unique_name": unique_name,
+                "database_name": database_name,
+                "repository_id": repository_id,
+                "environment_user_ref": environment_user_ref,
+                "tde_keystore_password": tde_keystore_password,
+                "tde_keystore_config_type": tde_keystore_config_type,
+                "oracle_instance_name": oracle_instance_name,
+                "instance_number": instance_number,
+                "instances": instances,
+                "mount_base": mount_base,
+                "config_params": config_params,
+                "cdb_id": cdb_id,
+                "parent_tde_keystore_path": parent_tde_keystore_path,
+                "parent_tde_keystore_password": parent_tde_keystore_password,
+                "tde_exported_keyfile_secret": tde_exported_keyfile_secret,
+                "tde_key_identifier": tde_key_identifier,
+                "parent_pdb_tde_keystore_path": parent_pdb_tde_keystore_path,
+                "parent_pdb_tde_keystore_password": parent_pdb_tde_keystore_password,
+                "target_pdb_tde_keystore_password": target_pdb_tde_keystore_password,
+                "crs_database_name": crs_database_name,
+                "recover_database": recover_database,
+                "file_mapping_rules": file_mapping_rules,
+                "enable_cdc": enable_cdc,
+                "recovery_model": recovery_model,
+                "mirroring_state": mirroring_state,
+                "is_incremental_v2p": is_incremental_v2p,
+                "backup_frequency_minutes": backup_frequency_minutes,
+                "rman_channels_for_incremental_backup": rman_channels_for_incremental_backup,
+                "rman_files_per_set_for_incremental_backup": rman_files_per_set_for_incremental_backup,
+                "rman_file_section_size_in_gb_for_incremental_backup": rman_file_section_size_in_gb_for_incremental_backup,
+                "targetDirectory": target_directory,
+                "dataDirectory": data_directory,
+                "archiveDirectory": archive_directory,
+                "externalDirectory": external_directory,
+                "tempDirectory": temp_directory,
+                "scriptDirectory": script_directory,
+                "useAbsolutePathForDataFiles": use_absolute_path_for_data_files,
+                "rman_channels": rman_channels,
+                "rman_file_section_size_in_gb": rman_file_section_size_in_gb,
+                "location": location,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'export_vdb_from_bookmark':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "export_vdb_from_bookmark":
         if vdb_id is None:
-            return {'error': 'Missing required parameter: vdb_id for action export_vdb_from_bookmark'}
-        endpoint = f'/vdbs/{vdb_id}/export-from-bookmark'
+            return {
+                "error": "Missing required parameter: vdb_id for action export_vdb_from_bookmark"
+            }
+        endpoint = f"/vdbs/{vdb_id}/export-from-bookmark"
         params = build_params()
-        body = {k: v for k, v in {'unique_name': unique_name, 'database_name': database_name, 'repository_id': repository_id, 'environment_user_ref': environment_user_ref, 'tde_keystore_password': tde_keystore_password, 'tde_keystore_config_type': tde_keystore_config_type, 'oracle_instance_name': oracle_instance_name, 'instance_number': instance_number, 'instances': instances, 'mount_base': mount_base, 'config_params': config_params, 'cdb_id': cdb_id, 'parent_tde_keystore_path': parent_tde_keystore_path, 'parent_tde_keystore_password': parent_tde_keystore_password, 'tde_exported_keyfile_secret': tde_exported_keyfile_secret, 'tde_key_identifier': tde_key_identifier, 'parent_pdb_tde_keystore_path': parent_pdb_tde_keystore_path, 'parent_pdb_tde_keystore_password': parent_pdb_tde_keystore_password, 'target_pdb_tde_keystore_password': target_pdb_tde_keystore_password, 'crs_database_name': crs_database_name, 'recover_database': recover_database, 'file_mapping_rules': file_mapping_rules, 'enable_cdc': enable_cdc, 'recovery_model': recovery_model, 'mirroring_state': mirroring_state, 'is_incremental_v2p': is_incremental_v2p, 'backup_frequency_minutes': backup_frequency_minutes, 'rman_channels_for_incremental_backup': rman_channels_for_incremental_backup, 'rman_files_per_set_for_incremental_backup': rman_files_per_set_for_incremental_backup, 'rman_file_section_size_in_gb_for_incremental_backup': rman_file_section_size_in_gb_for_incremental_backup, 'targetDirectory': target_directory, 'dataDirectory': data_directory, 'archiveDirectory': archive_directory, 'externalDirectory': external_directory, 'tempDirectory': temp_directory, 'scriptDirectory': script_directory, 'useAbsolutePathForDataFiles': use_absolute_path_for_data_files, 'rman_channels': rman_channels, 'rman_file_section_size_in_gb': rman_file_section_size_in_gb, 'bookmark_id': bookmark_id}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "unique_name": unique_name,
+                "database_name": database_name,
+                "repository_id": repository_id,
+                "environment_user_ref": environment_user_ref,
+                "tde_keystore_password": tde_keystore_password,
+                "tde_keystore_config_type": tde_keystore_config_type,
+                "oracle_instance_name": oracle_instance_name,
+                "instance_number": instance_number,
+                "instances": instances,
+                "mount_base": mount_base,
+                "config_params": config_params,
+                "cdb_id": cdb_id,
+                "parent_tde_keystore_path": parent_tde_keystore_path,
+                "parent_tde_keystore_password": parent_tde_keystore_password,
+                "tde_exported_keyfile_secret": tde_exported_keyfile_secret,
+                "tde_key_identifier": tde_key_identifier,
+                "parent_pdb_tde_keystore_path": parent_pdb_tde_keystore_path,
+                "parent_pdb_tde_keystore_password": parent_pdb_tde_keystore_password,
+                "target_pdb_tde_keystore_password": target_pdb_tde_keystore_password,
+                "crs_database_name": crs_database_name,
+                "recover_database": recover_database,
+                "file_mapping_rules": file_mapping_rules,
+                "enable_cdc": enable_cdc,
+                "recovery_model": recovery_model,
+                "mirroring_state": mirroring_state,
+                "is_incremental_v2p": is_incremental_v2p,
+                "backup_frequency_minutes": backup_frequency_minutes,
+                "rman_channels_for_incremental_backup": rman_channels_for_incremental_backup,
+                "rman_files_per_set_for_incremental_backup": rman_files_per_set_for_incremental_backup,
+                "rman_file_section_size_in_gb_for_incremental_backup": rman_file_section_size_in_gb_for_incremental_backup,
+                "targetDirectory": target_directory,
+                "dataDirectory": data_directory,
+                "archiveDirectory": archive_directory,
+                "externalDirectory": external_directory,
+                "tempDirectory": temp_directory,
+                "scriptDirectory": script_directory,
+                "useAbsolutePathForDataFiles": use_absolute_path_for_data_files,
+                "rman_channels": rman_channels,
+                "rman_file_section_size_in_gb": rman_file_section_size_in_gb,
+                "bookmark_id": bookmark_id,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'export_vdb_to_asm_by_snapshot':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "export_vdb_to_asm_by_snapshot":
         if vdb_id is None:
-            return {'error': 'Missing required parameter: vdb_id for action export_vdb_to_asm_by_snapshot'}
-        endpoint = f'/vdbs/{vdb_id}/asm-export-by-snapshot'
+            return {
+                "error": "Missing required parameter: vdb_id for action export_vdb_to_asm_by_snapshot"
+            }
+        endpoint = f"/vdbs/{vdb_id}/asm-export-by-snapshot"
         params = build_params(default_data_diskgroup=default_data_diskgroup)
-        body = {k: v for k, v in {'unique_name': unique_name, 'database_name': database_name, 'repository_id': repository_id, 'environment_user_ref': environment_user_ref, 'tde_keystore_password': tde_keystore_password, 'tde_keystore_config_type': tde_keystore_config_type, 'oracle_instance_name': oracle_instance_name, 'instance_number': instance_number, 'instances': instances, 'mount_base': mount_base, 'config_params': config_params, 'cdb_id': cdb_id, 'parent_tde_keystore_path': parent_tde_keystore_path, 'parent_tde_keystore_password': parent_tde_keystore_password, 'tde_exported_keyfile_secret': tde_exported_keyfile_secret, 'tde_key_identifier': tde_key_identifier, 'parent_pdb_tde_keystore_path': parent_pdb_tde_keystore_path, 'parent_pdb_tde_keystore_password': parent_pdb_tde_keystore_password, 'target_pdb_tde_keystore_password': target_pdb_tde_keystore_password, 'crs_database_name': crs_database_name, 'recover_database': recover_database, 'file_mapping_rules': file_mapping_rules, 'enable_cdc': enable_cdc, 'recovery_model': recovery_model, 'mirroring_state': mirroring_state, 'is_incremental_v2p': is_incremental_v2p, 'backup_frequency_minutes': backup_frequency_minutes, 'rman_channels_for_incremental_backup': rman_channels_for_incremental_backup, 'rman_files_per_set_for_incremental_backup': rman_files_per_set_for_incremental_backup, 'rman_file_section_size_in_gb_for_incremental_backup': rman_file_section_size_in_gb_for_incremental_backup, 'default_data_diskgroup': default_data_diskgroup, 'redo_diskgroup': redo_diskgroup, 'rman_channels': rman_channels, 'rman_file_section_size_in_gb': rman_file_section_size_in_gb, 'snapshot_id': snapshot_id}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "unique_name": unique_name,
+                "database_name": database_name,
+                "repository_id": repository_id,
+                "environment_user_ref": environment_user_ref,
+                "tde_keystore_password": tde_keystore_password,
+                "tde_keystore_config_type": tde_keystore_config_type,
+                "oracle_instance_name": oracle_instance_name,
+                "instance_number": instance_number,
+                "instances": instances,
+                "mount_base": mount_base,
+                "config_params": config_params,
+                "cdb_id": cdb_id,
+                "parent_tde_keystore_path": parent_tde_keystore_path,
+                "parent_tde_keystore_password": parent_tde_keystore_password,
+                "tde_exported_keyfile_secret": tde_exported_keyfile_secret,
+                "tde_key_identifier": tde_key_identifier,
+                "parent_pdb_tde_keystore_path": parent_pdb_tde_keystore_path,
+                "parent_pdb_tde_keystore_password": parent_pdb_tde_keystore_password,
+                "target_pdb_tde_keystore_password": target_pdb_tde_keystore_password,
+                "crs_database_name": crs_database_name,
+                "recover_database": recover_database,
+                "file_mapping_rules": file_mapping_rules,
+                "enable_cdc": enable_cdc,
+                "recovery_model": recovery_model,
+                "mirroring_state": mirroring_state,
+                "is_incremental_v2p": is_incremental_v2p,
+                "backup_frequency_minutes": backup_frequency_minutes,
+                "rman_channels_for_incremental_backup": rman_channels_for_incremental_backup,
+                "rman_files_per_set_for_incremental_backup": rman_files_per_set_for_incremental_backup,
+                "rman_file_section_size_in_gb_for_incremental_backup": rman_file_section_size_in_gb_for_incremental_backup,
+                "default_data_diskgroup": default_data_diskgroup,
+                "redo_diskgroup": redo_diskgroup,
+                "rman_channels": rman_channels,
+                "rman_file_section_size_in_gb": rman_file_section_size_in_gb,
+                "snapshot_id": snapshot_id,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'export_vdb_to_asm_by_timestamp':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "export_vdb_to_asm_by_timestamp":
         if vdb_id is None:
-            return {'error': 'Missing required parameter: vdb_id for action export_vdb_to_asm_by_timestamp'}
-        endpoint = f'/vdbs/{vdb_id}/asm-export-by-timestamp'
-        params = build_params(timestamp=timestamp, default_data_diskgroup=default_data_diskgroup)
-        body = {k: v for k, v in {'unique_name': unique_name, 'database_name': database_name, 'repository_id': repository_id, 'environment_user_ref': environment_user_ref, 'tde_keystore_password': tde_keystore_password, 'tde_keystore_config_type': tde_keystore_config_type, 'oracle_instance_name': oracle_instance_name, 'instance_number': instance_number, 'instances': instances, 'mount_base': mount_base, 'config_params': config_params, 'cdb_id': cdb_id, 'parent_tde_keystore_path': parent_tde_keystore_path, 'parent_tde_keystore_password': parent_tde_keystore_password, 'tde_exported_keyfile_secret': tde_exported_keyfile_secret, 'tde_key_identifier': tde_key_identifier, 'parent_pdb_tde_keystore_path': parent_pdb_tde_keystore_path, 'parent_pdb_tde_keystore_password': parent_pdb_tde_keystore_password, 'target_pdb_tde_keystore_password': target_pdb_tde_keystore_password, 'crs_database_name': crs_database_name, 'recover_database': recover_database, 'file_mapping_rules': file_mapping_rules, 'enable_cdc': enable_cdc, 'recovery_model': recovery_model, 'mirroring_state': mirroring_state, 'is_incremental_v2p': is_incremental_v2p, 'backup_frequency_minutes': backup_frequency_minutes, 'rman_channels_for_incremental_backup': rman_channels_for_incremental_backup, 'rman_files_per_set_for_incremental_backup': rman_files_per_set_for_incremental_backup, 'rman_file_section_size_in_gb_for_incremental_backup': rman_file_section_size_in_gb_for_incremental_backup, 'default_data_diskgroup': default_data_diskgroup, 'redo_diskgroup': redo_diskgroup, 'rman_channels': rman_channels, 'rman_file_section_size_in_gb': rman_file_section_size_in_gb, 'timeflow_id': timeflow_id, 'timestamp': timestamp}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=body)
+            return {
+                "error": "Missing required parameter: vdb_id for action export_vdb_to_asm_by_timestamp"
+            }
+        endpoint = f"/vdbs/{vdb_id}/asm-export-by-timestamp"
+        params = build_params(
+            timestamp=timestamp, default_data_diskgroup=default_data_diskgroup
+        )
+        body = {
+            k: v
+            for k, v in {
+                "unique_name": unique_name,
+                "database_name": database_name,
+                "repository_id": repository_id,
+                "environment_user_ref": environment_user_ref,
+                "tde_keystore_password": tde_keystore_password,
+                "tde_keystore_config_type": tde_keystore_config_type,
+                "oracle_instance_name": oracle_instance_name,
+                "instance_number": instance_number,
+                "instances": instances,
+                "mount_base": mount_base,
+                "config_params": config_params,
+                "cdb_id": cdb_id,
+                "parent_tde_keystore_path": parent_tde_keystore_path,
+                "parent_tde_keystore_password": parent_tde_keystore_password,
+                "tde_exported_keyfile_secret": tde_exported_keyfile_secret,
+                "tde_key_identifier": tde_key_identifier,
+                "parent_pdb_tde_keystore_path": parent_pdb_tde_keystore_path,
+                "parent_pdb_tde_keystore_password": parent_pdb_tde_keystore_password,
+                "target_pdb_tde_keystore_password": target_pdb_tde_keystore_password,
+                "crs_database_name": crs_database_name,
+                "recover_database": recover_database,
+                "file_mapping_rules": file_mapping_rules,
+                "enable_cdc": enable_cdc,
+                "recovery_model": recovery_model,
+                "mirroring_state": mirroring_state,
+                "is_incremental_v2p": is_incremental_v2p,
+                "backup_frequency_minutes": backup_frequency_minutes,
+                "rman_channels_for_incremental_backup": rman_channels_for_incremental_backup,
+                "rman_files_per_set_for_incremental_backup": rman_files_per_set_for_incremental_backup,
+                "rman_file_section_size_in_gb_for_incremental_backup": rman_file_section_size_in_gb_for_incremental_backup,
+                "default_data_diskgroup": default_data_diskgroup,
+                "redo_diskgroup": redo_diskgroup,
+                "rman_channels": rman_channels,
+                "rman_file_section_size_in_gb": rman_file_section_size_in_gb,
+                "timeflow_id": timeflow_id,
+                "timestamp": timestamp,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'export_vdb_to_asm_by_location':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "export_vdb_to_asm_by_location":
         if vdb_id is None:
-            return {'error': 'Missing required parameter: vdb_id for action export_vdb_to_asm_by_location'}
-        endpoint = f'/vdbs/{vdb_id}/asm-export-by-location'
-        params = build_params(location=location, default_data_diskgroup=default_data_diskgroup)
-        body = {k: v for k, v in {'unique_name': unique_name, 'database_name': database_name, 'repository_id': repository_id, 'environment_user_ref': environment_user_ref, 'tde_keystore_password': tde_keystore_password, 'tde_keystore_config_type': tde_keystore_config_type, 'oracle_instance_name': oracle_instance_name, 'instance_number': instance_number, 'instances': instances, 'mount_base': mount_base, 'config_params': config_params, 'cdb_id': cdb_id, 'parent_tde_keystore_path': parent_tde_keystore_path, 'parent_tde_keystore_password': parent_tde_keystore_password, 'tde_exported_keyfile_secret': tde_exported_keyfile_secret, 'tde_key_identifier': tde_key_identifier, 'parent_pdb_tde_keystore_path': parent_pdb_tde_keystore_path, 'parent_pdb_tde_keystore_password': parent_pdb_tde_keystore_password, 'target_pdb_tde_keystore_password': target_pdb_tde_keystore_password, 'crs_database_name': crs_database_name, 'recover_database': recover_database, 'file_mapping_rules': file_mapping_rules, 'enable_cdc': enable_cdc, 'recovery_model': recovery_model, 'mirroring_state': mirroring_state, 'is_incremental_v2p': is_incremental_v2p, 'backup_frequency_minutes': backup_frequency_minutes, 'rman_channels_for_incremental_backup': rman_channels_for_incremental_backup, 'rman_files_per_set_for_incremental_backup': rman_files_per_set_for_incremental_backup, 'rman_file_section_size_in_gb_for_incremental_backup': rman_file_section_size_in_gb_for_incremental_backup, 'default_data_diskgroup': default_data_diskgroup, 'redo_diskgroup': redo_diskgroup, 'rman_channels': rman_channels, 'rman_file_section_size_in_gb': rman_file_section_size_in_gb, 'location': location}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=body)
+            return {
+                "error": "Missing required parameter: vdb_id for action export_vdb_to_asm_by_location"
+            }
+        endpoint = f"/vdbs/{vdb_id}/asm-export-by-location"
+        params = build_params(
+            location=location, default_data_diskgroup=default_data_diskgroup
+        )
+        body = {
+            k: v
+            for k, v in {
+                "unique_name": unique_name,
+                "database_name": database_name,
+                "repository_id": repository_id,
+                "environment_user_ref": environment_user_ref,
+                "tde_keystore_password": tde_keystore_password,
+                "tde_keystore_config_type": tde_keystore_config_type,
+                "oracle_instance_name": oracle_instance_name,
+                "instance_number": instance_number,
+                "instances": instances,
+                "mount_base": mount_base,
+                "config_params": config_params,
+                "cdb_id": cdb_id,
+                "parent_tde_keystore_path": parent_tde_keystore_path,
+                "parent_tde_keystore_password": parent_tde_keystore_password,
+                "tde_exported_keyfile_secret": tde_exported_keyfile_secret,
+                "tde_key_identifier": tde_key_identifier,
+                "parent_pdb_tde_keystore_path": parent_pdb_tde_keystore_path,
+                "parent_pdb_tde_keystore_password": parent_pdb_tde_keystore_password,
+                "target_pdb_tde_keystore_password": target_pdb_tde_keystore_password,
+                "crs_database_name": crs_database_name,
+                "recover_database": recover_database,
+                "file_mapping_rules": file_mapping_rules,
+                "enable_cdc": enable_cdc,
+                "recovery_model": recovery_model,
+                "mirroring_state": mirroring_state,
+                "is_incremental_v2p": is_incremental_v2p,
+                "backup_frequency_minutes": backup_frequency_minutes,
+                "rman_channels_for_incremental_backup": rman_channels_for_incremental_backup,
+                "rman_files_per_set_for_incremental_backup": rman_files_per_set_for_incremental_backup,
+                "rman_file_section_size_in_gb_for_incremental_backup": rman_file_section_size_in_gb_for_incremental_backup,
+                "default_data_diskgroup": default_data_diskgroup,
+                "redo_diskgroup": redo_diskgroup,
+                "rman_channels": rman_channels,
+                "rman_file_section_size_in_gb": rman_file_section_size_in_gb,
+                "location": location,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'export_vdb_to_asm_from_bookmark':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "export_vdb_to_asm_from_bookmark":
         if vdb_id is None:
-            return {'error': 'Missing required parameter: vdb_id for action export_vdb_to_asm_from_bookmark'}
-        endpoint = f'/vdbs/{vdb_id}/asm-export-from-bookmark'
+            return {
+                "error": "Missing required parameter: vdb_id for action export_vdb_to_asm_from_bookmark"
+            }
+        endpoint = f"/vdbs/{vdb_id}/asm-export-from-bookmark"
         params = build_params(default_data_diskgroup=default_data_diskgroup)
-        body = {k: v for k, v in {'unique_name': unique_name, 'database_name': database_name, 'repository_id': repository_id, 'environment_user_ref': environment_user_ref, 'tde_keystore_password': tde_keystore_password, 'tde_keystore_config_type': tde_keystore_config_type, 'oracle_instance_name': oracle_instance_name, 'instance_number': instance_number, 'instances': instances, 'mount_base': mount_base, 'config_params': config_params, 'cdb_id': cdb_id, 'parent_tde_keystore_path': parent_tde_keystore_path, 'parent_tde_keystore_password': parent_tde_keystore_password, 'tde_exported_keyfile_secret': tde_exported_keyfile_secret, 'tde_key_identifier': tde_key_identifier, 'parent_pdb_tde_keystore_path': parent_pdb_tde_keystore_path, 'parent_pdb_tde_keystore_password': parent_pdb_tde_keystore_password, 'target_pdb_tde_keystore_password': target_pdb_tde_keystore_password, 'crs_database_name': crs_database_name, 'recover_database': recover_database, 'file_mapping_rules': file_mapping_rules, 'enable_cdc': enable_cdc, 'recovery_model': recovery_model, 'mirroring_state': mirroring_state, 'is_incremental_v2p': is_incremental_v2p, 'backup_frequency_minutes': backup_frequency_minutes, 'rman_channels_for_incremental_backup': rman_channels_for_incremental_backup, 'rman_files_per_set_for_incremental_backup': rman_files_per_set_for_incremental_backup, 'rman_file_section_size_in_gb_for_incremental_backup': rman_file_section_size_in_gb_for_incremental_backup, 'default_data_diskgroup': default_data_diskgroup, 'redo_diskgroup': redo_diskgroup, 'rman_channels': rman_channels, 'rman_file_section_size_in_gb': rman_file_section_size_in_gb, 'bookmark_id': bookmark_id}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "unique_name": unique_name,
+                "database_name": database_name,
+                "repository_id": repository_id,
+                "environment_user_ref": environment_user_ref,
+                "tde_keystore_password": tde_keystore_password,
+                "tde_keystore_config_type": tde_keystore_config_type,
+                "oracle_instance_name": oracle_instance_name,
+                "instance_number": instance_number,
+                "instances": instances,
+                "mount_base": mount_base,
+                "config_params": config_params,
+                "cdb_id": cdb_id,
+                "parent_tde_keystore_path": parent_tde_keystore_path,
+                "parent_tde_keystore_password": parent_tde_keystore_password,
+                "tde_exported_keyfile_secret": tde_exported_keyfile_secret,
+                "tde_key_identifier": tde_key_identifier,
+                "parent_pdb_tde_keystore_path": parent_pdb_tde_keystore_path,
+                "parent_pdb_tde_keystore_password": parent_pdb_tde_keystore_password,
+                "target_pdb_tde_keystore_password": target_pdb_tde_keystore_password,
+                "crs_database_name": crs_database_name,
+                "recover_database": recover_database,
+                "file_mapping_rules": file_mapping_rules,
+                "enable_cdc": enable_cdc,
+                "recovery_model": recovery_model,
+                "mirroring_state": mirroring_state,
+                "is_incremental_v2p": is_incremental_v2p,
+                "backup_frequency_minutes": backup_frequency_minutes,
+                "rman_channels_for_incremental_backup": rman_channels_for_incremental_backup,
+                "rman_files_per_set_for_incremental_backup": rman_files_per_set_for_incremental_backup,
+                "rman_file_section_size_in_gb_for_incremental_backup": rman_file_section_size_in_gb_for_incremental_backup,
+                "default_data_diskgroup": default_data_diskgroup,
+                "redo_diskgroup": redo_diskgroup,
+                "rman_channels": rman_channels,
+                "rman_file_section_size_in_gb": rman_file_section_size_in_gb,
+                "bookmark_id": bookmark_id,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'export_cleanup':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "export_cleanup":
         if vdb_id is None:
-            return {'error': 'Missing required parameter: vdb_id for action export_cleanup'}
-        endpoint = f'/vdbs/{vdb_id}/export_cleanup'
+            return {
+                "error": "Missing required parameter: vdb_id for action export_cleanup"
+            }
+        endpoint = f"/vdbs/{vdb_id}/export_cleanup"
         params = build_params()
-        body = {k: v for k, v in {'cleanup_target_physical_files': cleanup_target_physical_files, 'cleanup_target_container': cleanup_target_container}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "cleanup_target_physical_files": cleanup_target_physical_files,
+                "cleanup_target_container": cleanup_target_container,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'export_finalize':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "export_finalize":
         if vdb_id is None:
-            return {'error': 'Missing required parameter: vdb_id for action export_finalize'}
-        endpoint = f'/vdbs/{vdb_id}/export_finalize'
+            return {
+                "error": "Missing required parameter: vdb_id for action export_finalize"
+            }
+        endpoint = f"/vdbs/{vdb_id}/export_finalize"
         params = build_params()
-        body = {k: v for k, v in {'force': force, 'max_allowed_backups_pending_restore': max_allowed_backups_pending_restore}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "force": force,
+                "max_allowed_backups_pending_restore": max_allowed_backups_pending_restore,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'list_vdb_groups':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "list_vdb_groups":
         params = build_params(limit=limit, cursor=cursor, sort=sort)
-        conf = check_confirmation('GET', '/vdb-groups', action, 'data_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            "/vdb-groups",
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', '/vdb-groups', params=params)
-    elif action == 'search_vdb_groups':
+        return make_api_request("GET", "/vdb-groups", params=params)
+    elif action == "search_vdb_groups":
         params = build_params(limit=limit, cursor=cursor, sort=sort)
-        body = {'filter_expression': filter_expression} if filter_expression else {}
-        conf = check_confirmation('POST', '/vdb-groups/search', action, 'data_tool', confirmed or False, request_params=params, request_body=body)
+        body = {"filter_expression": filter_expression} if filter_expression else {}
+        conf = check_confirmation(
+            "POST",
+            "/vdb-groups/search",
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', '/vdb-groups/search', params=params, json_body=body)
-    elif action == 'get_vdb_group':
+        return make_api_request(
+            "POST", "/vdb-groups/search", params=params, json_body=body
+        )
+    elif action == "get_vdb_group":
         if vdb_group_id is None:
-            return {'error': 'Missing required parameter: vdb_group_id for action get_vdb_group'}
-        endpoint = f'/vdb-groups/{vdb_group_id}'
+            return {
+                "error": "Missing required parameter: vdb_group_id for action get_vdb_group"
+            }
+        endpoint = f"/vdb-groups/{vdb_group_id}"
         params = build_params()
-        conf = check_confirmation('GET', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', endpoint, params=params)
-    elif action == 'create_vdb_group':
+        return make_api_request("GET", endpoint, params=params)
+    elif action == "create_vdb_group":
         params = build_params(name=name)
-        body = {k: v for k, v in {'name': name, 'vdb_ids': vdb_ids, 'vdbs': vdbs, 'tags': tags, 'make_current_account_owner': make_current_account_owner, 'refresh_immediately': refresh_immediately}.items() if v is not None}
-        conf = check_confirmation('POST', '/vdb-groups', action, 'data_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "name": name,
+                "vdb_ids": vdb_ids,
+                "vdbs": vdbs,
+                "tags": tags,
+                "make_current_account_owner": make_current_account_owner,
+                "refresh_immediately": refresh_immediately,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            "/vdb-groups",
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', '/vdb-groups', params=params, json_body=body if body else None)
-    elif action == 'update_vdb_group':
+        return make_api_request(
+            "POST", "/vdb-groups", params=params, json_body=body if body else None
+        )
+    elif action == "update_vdb_group":
         if vdb_group_id is None:
-            return {'error': 'Missing required parameter: vdb_group_id for action update_vdb_group'}
-        endpoint = f'/vdb-groups/{vdb_group_id}'
+            return {
+                "error": "Missing required parameter: vdb_group_id for action update_vdb_group"
+            }
+        endpoint = f"/vdb-groups/{vdb_group_id}"
         params = build_params()
-        body = {k: v for k, v in {'name': name, 'vdb_ids': vdb_ids, 'vdbs': vdbs, 'refresh_immediately': refresh_immediately}.items() if v is not None}
-        conf = check_confirmation('PATCH', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "name": name,
+                "vdb_ids": vdb_ids,
+                "vdbs": vdbs,
+                "refresh_immediately": refresh_immediately,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "PATCH",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('PATCH', endpoint, params=params, json_body=body if body else None)
-    elif action == 'delete_vdb_group':
+        return make_api_request(
+            "PATCH", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "delete_vdb_group":
         if vdb_group_id is None:
-            return {'error': 'Missing required parameter: vdb_group_id for action delete_vdb_group'}
-        endpoint = f'/vdb-groups/{vdb_group_id}'
+            return {
+                "error": "Missing required parameter: vdb_group_id for action delete_vdb_group"
+            }
+        endpoint = f"/vdb-groups/{vdb_group_id}"
         params = build_params()
-        conf = check_confirmation('DELETE', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "DELETE",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('DELETE', endpoint, params=params)
-    elif action == 'provision_vdb_group_from_bookmark':
+        return make_api_request("DELETE", endpoint, params=params)
+    elif action == "provision_vdb_group_from_bookmark":
         params = build_params(name=name, provision_parameters=provision_parameters)
-        body = {k: v for k, v in {'name': name, 'bookmark_id': bookmark_id, 'provision_parameters': provision_parameters, 'tags': tags, 'make_current_account_owner': make_current_account_owner}.items() if v is not None}
-        conf = check_confirmation('POST', '/vdb-groups/provision_from_bookmark', action, 'data_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "name": name,
+                "bookmark_id": bookmark_id,
+                "provision_parameters": provision_parameters,
+                "tags": tags,
+                "make_current_account_owner": make_current_account_owner,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            "/vdb-groups/provision_from_bookmark",
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', '/vdb-groups/provision_from_bookmark', params=params, json_body=body if body else None)
-    elif action == 'refresh_vdb_group':
+        return make_api_request(
+            "POST",
+            "/vdb-groups/provision_from_bookmark",
+            params=params,
+            json_body=body if body else None,
+        )
+    elif action == "refresh_vdb_group":
         if vdb_group_id is None:
-            return {'error': 'Missing required parameter: vdb_group_id for action refresh_vdb_group'}
-        endpoint = f'/vdb-groups/{vdb_group_id}/refresh'
+            return {
+                "error": "Missing required parameter: vdb_group_id for action refresh_vdb_group"
+            }
+        endpoint = f"/vdb-groups/{vdb_group_id}/refresh"
         params = build_params()
-        body = {k: v for k, v in {'bookmark_id': bookmark_id}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=body)
+        body = {k: v for k, v in {"bookmark_id": bookmark_id}.items() if v is not None}
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'refresh_vdb_group_from_bookmark':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "refresh_vdb_group_from_bookmark":
         if vdb_group_id is None:
-            return {'error': 'Missing required parameter: vdb_group_id for action refresh_vdb_group_from_bookmark'}
-        endpoint = f'/vdb-groups/{vdb_group_id}/refresh_from_bookmark'
+            return {
+                "error": "Missing required parameter: vdb_group_id for action refresh_vdb_group_from_bookmark"
+            }
+        endpoint = f"/vdb-groups/{vdb_group_id}/refresh_from_bookmark"
         params = build_params()
-        body = {k: v for k, v in {'bookmark_id': bookmark_id}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=body)
+        body = {k: v for k, v in {"bookmark_id": bookmark_id}.items() if v is not None}
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'refresh_vdb_group_by_snapshot':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "refresh_vdb_group_by_snapshot":
         if vdb_group_id is None:
-            return {'error': 'Missing required parameter: vdb_group_id for action refresh_vdb_group_by_snapshot'}
-        endpoint = f'/vdb-groups/{vdb_group_id}/refresh_by_snapshot'
+            return {
+                "error": "Missing required parameter: vdb_group_id for action refresh_vdb_group_by_snapshot"
+            }
+        endpoint = f"/vdb-groups/{vdb_group_id}/refresh_by_snapshot"
         params = build_params()
-        body = {k: v for k, v in {'vdb_snapshot_mappings': vdb_snapshot_mappings}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {"vdb_snapshot_mappings": vdb_snapshot_mappings}.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'refresh_vdb_group_by_timestamp':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "refresh_vdb_group_by_timestamp":
         if vdb_group_id is None:
-            return {'error': 'Missing required parameter: vdb_group_id for action refresh_vdb_group_by_timestamp'}
-        endpoint = f'/vdb-groups/{vdb_group_id}/refresh_by_timestamp'
+            return {
+                "error": "Missing required parameter: vdb_group_id for action refresh_vdb_group_by_timestamp"
+            }
+        endpoint = f"/vdb-groups/{vdb_group_id}/refresh_by_timestamp"
         params = build_params()
-        body = {k: v for k, v in {'vdb_timestamp_mappings': vdb_timestamp_mappings, 'is_refresh_to_nearest': is_refresh_to_nearest}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "vdb_timestamp_mappings": vdb_timestamp_mappings,
+                "is_refresh_to_nearest": is_refresh_to_nearest,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'rollback_vdb_group':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "rollback_vdb_group":
         if vdb_group_id is None:
-            return {'error': 'Missing required parameter: vdb_group_id for action rollback_vdb_group'}
-        endpoint = f'/vdb-groups/{vdb_group_id}/rollback'
+            return {
+                "error": "Missing required parameter: vdb_group_id for action rollback_vdb_group"
+            }
+        endpoint = f"/vdb-groups/{vdb_group_id}/rollback"
         params = build_params()
-        body = {k: v for k, v in {'bookmark_id': bookmark_id}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=body)
+        body = {k: v for k, v in {"bookmark_id": bookmark_id}.items() if v is not None}
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'lock_vdb_group':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "lock_vdb_group":
         if vdb_group_id is None:
-            return {'error': 'Missing required parameter: vdb_group_id for action lock_vdb_group'}
-        endpoint = f'/vdb-groups/{vdb_group_id}/lock'
+            return {
+                "error": "Missing required parameter: vdb_group_id for action lock_vdb_group"
+            }
+        endpoint = f"/vdb-groups/{vdb_group_id}/lock"
         params = build_params()
-        body = {k: v for k, v in {'account_id': account_id}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=body)
+        body = {k: v for k, v in {"account_id": account_id}.items() if v is not None}
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'unlock_vdb_group':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "unlock_vdb_group":
         if vdb_group_id is None:
-            return {'error': 'Missing required parameter: vdb_group_id for action unlock_vdb_group'}
-        endpoint = f'/vdb-groups/{vdb_group_id}/unlock'
+            return {
+                "error": "Missing required parameter: vdb_group_id for action unlock_vdb_group"
+            }
+        endpoint = f"/vdb-groups/{vdb_group_id}/unlock"
         params = build_params()
-        conf = check_confirmation('POST', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params)
-    elif action == 'start_vdb_group':
+        return make_api_request("POST", endpoint, params=params)
+    elif action == "start_vdb_group":
         if vdb_group_id is None:
-            return {'error': 'Missing required parameter: vdb_group_id for action start_vdb_group'}
-        endpoint = f'/vdb-groups/{vdb_group_id}/start'
+            return {
+                "error": "Missing required parameter: vdb_group_id for action start_vdb_group"
+            }
+        endpoint = f"/vdb-groups/{vdb_group_id}/start"
         params = build_params()
-        body = {k: v for k, v in {'vdb_start_param_mappings': vdb_start_param_mappings}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {"vdb_start_param_mappings": vdb_start_param_mappings}.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'stop_vdb_group':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "stop_vdb_group":
         if vdb_group_id is None:
-            return {'error': 'Missing required parameter: vdb_group_id for action stop_vdb_group'}
-        endpoint = f'/vdb-groups/{vdb_group_id}/stop'
+            return {
+                "error": "Missing required parameter: vdb_group_id for action stop_vdb_group"
+            }
+        endpoint = f"/vdb-groups/{vdb_group_id}/stop"
         params = build_params()
-        body = {k: v for k, v in {'vdb_stop_param_mappings': vdb_stop_param_mappings}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {"vdb_stop_param_mappings": vdb_stop_param_mappings}.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'enable_vdb_group':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "enable_vdb_group":
         if vdb_group_id is None:
-            return {'error': 'Missing required parameter: vdb_group_id for action enable_vdb_group'}
-        endpoint = f'/vdb-groups/{vdb_group_id}/enable'
+            return {
+                "error": "Missing required parameter: vdb_group_id for action enable_vdb_group"
+            }
+        endpoint = f"/vdb-groups/{vdb_group_id}/enable"
         params = build_params()
-        body = {k: v for k, v in {'vdb_enable_param_mappings': vdb_enable_param_mappings}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {"vdb_enable_param_mappings": vdb_enable_param_mappings}.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'disable_vdb_group':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "disable_vdb_group":
         if vdb_group_id is None:
-            return {'error': 'Missing required parameter: vdb_group_id for action disable_vdb_group'}
-        endpoint = f'/vdb-groups/{vdb_group_id}/disable'
+            return {
+                "error": "Missing required parameter: vdb_group_id for action disable_vdb_group"
+            }
+        endpoint = f"/vdb-groups/{vdb_group_id}/disable"
         params = build_params()
-        body = {k: v for k, v in {'vdb_disable_param_mappings': vdb_disable_param_mappings}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "vdb_disable_param_mappings": vdb_disable_param_mappings
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'get_vdb_group_latest_snapshots':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "get_vdb_group_latest_snapshots":
         if vdb_group_id is None:
-            return {'error': 'Missing required parameter: vdb_group_id for action get_vdb_group_latest_snapshots'}
-        endpoint = f'/vdb-groups/{vdb_group_id}/latest-snapshots'
+            return {
+                "error": "Missing required parameter: vdb_group_id for action get_vdb_group_latest_snapshots"
+            }
+        endpoint = f"/vdb-groups/{vdb_group_id}/latest-snapshots"
         params = build_params()
-        conf = check_confirmation('GET', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', endpoint, params=params)
-    elif action == 'get_vdb_group_timestamp_summary':
+        return make_api_request("GET", endpoint, params=params)
+    elif action == "get_vdb_group_timestamp_summary":
         if vdb_group_id is None:
-            return {'error': 'Missing required parameter: vdb_group_id for action get_vdb_group_timestamp_summary'}
-        endpoint = f'/vdb-groups/{vdb_group_id}/timestamp-summary'
+            return {
+                "error": "Missing required parameter: vdb_group_id for action get_vdb_group_timestamp_summary"
+            }
+        endpoint = f"/vdb-groups/{vdb_group_id}/timestamp-summary"
         params = build_params()
-        body = {k: v for k, v in {'timestamp': timestamp, 'vdb_ids': vdb_ids, 'mode': mode}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "timestamp": timestamp,
+                "vdb_ids": vdb_ids,
+                "mode": mode,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'list_vdb_group_bookmarks':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "list_vdb_group_bookmarks":
         if vdb_group_id is None:
-            return {'error': 'Missing required parameter: vdb_group_id for action list_vdb_group_bookmarks'}
-        endpoint = f'/vdb-groups/{vdb_group_id}/bookmarks'
+            return {
+                "error": "Missing required parameter: vdb_group_id for action list_vdb_group_bookmarks"
+            }
+        endpoint = f"/vdb-groups/{vdb_group_id}/bookmarks"
         params = build_params(limit=limit, cursor=cursor, sort=sort)
-        conf = check_confirmation('GET', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', endpoint, params=params)
-    elif action == 'search_vdb_group_bookmarks':
+        return make_api_request("GET", endpoint, params=params)
+    elif action == "search_vdb_group_bookmarks":
         if vdb_group_id is None:
-            return {'error': 'Missing required parameter: vdb_group_id for action search_vdb_group_bookmarks'}
-        endpoint = f'/vdb-groups/{vdb_group_id}/bookmarks/search'
+            return {
+                "error": "Missing required parameter: vdb_group_id for action search_vdb_group_bookmarks"
+            }
+        endpoint = f"/vdb-groups/{vdb_group_id}/bookmarks/search"
         params = build_params(limit=limit, cursor=cursor, sort=sort)
-        body = {'filter_expression': filter_expression} if filter_expression else {}
-        conf = check_confirmation('POST', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=body)
+        body = {"filter_expression": filter_expression} if filter_expression else {}
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body)
-    elif action == 'get_vdb_group_tags':
+        return make_api_request("POST", endpoint, params=params, json_body=body)
+    elif action == "get_vdb_group_tags":
         if vdb_group_id is None:
-            return {'error': 'Missing required parameter: vdb_group_id for action get_vdb_group_tags'}
-        endpoint = f'/vdb-groups/{vdb_group_id}/tags'
+            return {
+                "error": "Missing required parameter: vdb_group_id for action get_vdb_group_tags"
+            }
+        endpoint = f"/vdb-groups/{vdb_group_id}/tags"
         params = build_params()
-        conf = check_confirmation('GET', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', endpoint, params=params)
-    elif action == 'add_vdb_group_tags':
+        return make_api_request("GET", endpoint, params=params)
+    elif action == "add_vdb_group_tags":
         if vdb_group_id is None:
-            return {'error': 'Missing required parameter: vdb_group_id for action add_vdb_group_tags'}
-        endpoint = f'/vdb-groups/{vdb_group_id}/tags'
+            return {
+                "error": "Missing required parameter: vdb_group_id for action add_vdb_group_tags"
+            }
+        endpoint = f"/vdb-groups/{vdb_group_id}/tags"
         params = build_params(tags=tags)
-        body = {k: v for k, v in {'tags': tags}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=body)
+        body = {k: v for k, v in {"tags": tags}.items() if v is not None}
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'list_dsources':
-        params = build_params(limit=limit, cursor=cursor, sort=sort, permission=permission)
-        conf = check_confirmation('GET', '/dsources', action, 'data_tool', confirmed or False, request_params=params, request_body=None)
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "list_dsources":
+        params = build_params(
+            limit=limit, cursor=cursor, sort=sort, permission=permission
+        )
+        conf = check_confirmation(
+            "GET",
+            "/dsources",
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', '/dsources', params=params)
-    elif action == 'search_dsources':
-        params = build_params(limit=limit, cursor=cursor, sort=sort, permission=permission)
-        body = {'filter_expression': filter_expression} if filter_expression else {}
-        conf = check_confirmation('POST', '/dsources/search', action, 'data_tool', confirmed or False, request_params=params, request_body=body)
+        return make_api_request("GET", "/dsources", params=params)
+    elif action == "search_dsources":
+        params = build_params(
+            limit=limit, cursor=cursor, sort=sort, permission=permission
+        )
+        body = {"filter_expression": filter_expression} if filter_expression else {}
+        conf = check_confirmation(
+            "POST",
+            "/dsources/search",
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', '/dsources/search', params=params, json_body=body)
-    elif action == 'get_dsource':
+        return make_api_request(
+            "POST", "/dsources/search", params=params, json_body=body
+        )
+    elif action == "get_dsource":
         if dsource_id is None:
-            return {'error': 'Missing required parameter: dsource_id for action get_dsource'}
-        endpoint = f'/dsources/{dsource_id}'
+            return {
+                "error": "Missing required parameter: dsource_id for action get_dsource"
+            }
+        endpoint = f"/dsources/{dsource_id}"
         params = build_params()
-        conf = check_confirmation('GET', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', endpoint, params=params)
-    elif action == 'delete_dsource':
+        return make_api_request("GET", endpoint, params=params)
+    elif action == "delete_dsource":
         params = build_params()
-        body = {k: v for k, v in {'dsource_id': dsource_id, 'force': force, 'oracle_username': oracle_username, 'oracle_password': oracle_password, 'delete_all_dependent_vdbs': delete_all_dependent_vdbs}.items() if v is not None}
-        conf = check_confirmation('POST', '/dsources/delete', action, 'data_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "dsource_id": dsource_id,
+                "force": force,
+                "oracle_username": oracle_username,
+                "oracle_password": oracle_password,
+                "delete_all_dependent_vdbs": delete_all_dependent_vdbs,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            "/dsources/delete",
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', '/dsources/delete', params=params, json_body=body if body else None)
-    elif action == 'enable_dsource':
+        return make_api_request(
+            "POST", "/dsources/delete", params=params, json_body=body if body else None
+        )
+    elif action == "enable_dsource":
         if dsource_id is None:
-            return {'error': 'Missing required parameter: dsource_id for action enable_dsource'}
-        endpoint = f'/dsources/{dsource_id}/enable'
+            return {
+                "error": "Missing required parameter: dsource_id for action enable_dsource"
+            }
+        endpoint = f"/dsources/{dsource_id}/enable"
         params = build_params()
-        body = {k: v for k, v in {'attempt_start': attempt_start}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v for k, v in {"attempt_start": attempt_start}.items() if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'disable_dsource':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "disable_dsource":
         if dsource_id is None:
-            return {'error': 'Missing required parameter: dsource_id for action disable_dsource'}
-        endpoint = f'/dsources/{dsource_id}/disable'
+            return {
+                "error": "Missing required parameter: dsource_id for action disable_dsource"
+            }
+        endpoint = f"/dsources/{dsource_id}/disable"
         params = build_params()
-        body = {k: v for k, v in {'attempt_cleanup': attempt_cleanup}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {"attempt_cleanup": attempt_cleanup}.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'list_dsource_snapshots':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "list_dsource_snapshots":
         if dsource_id is None:
-            return {'error': 'Missing required parameter: dsource_id for action list_dsource_snapshots'}
-        endpoint = f'/dsources/{dsource_id}/snapshots'
+            return {
+                "error": "Missing required parameter: dsource_id for action list_dsource_snapshots"
+            }
+        endpoint = f"/dsources/{dsource_id}/snapshots"
         params = build_params(limit=limit, cursor=cursor)
-        conf = check_confirmation('GET', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', endpoint, params=params)
-    elif action == 'dsource_create_snapshot':
+        return make_api_request("GET", endpoint, params=params)
+    elif action == "dsource_create_snapshot":
         if dsource_id is None:
-            return {'error': 'Missing required parameter: dsource_id for action dsource_create_snapshot'}
-        endpoint = f'/dsources/{dsource_id}/snapshots'
+            return {
+                "error": "Missing required parameter: dsource_id for action dsource_create_snapshot"
+            }
+        endpoint = f"/dsources/{dsource_id}/snapshots"
         params = build_params()
-        body = {k: v for k, v in {'drop_and_recreate_devices': drop_and_recreate_devices, 'sync_strategy': sync_strategy, 'ase_backup_files': ase_backup_files, 'mssql_backup_uuid': mssql_backup_uuid, 'compression_enabled': compression_enabled, 'availability_group_backup_policy': availability_group_backup_policy, 'do_not_resume': do_not_resume, 'double_sync': double_sync, 'force_full_backup': force_full_backup, 'skip_space_check': skip_space_check, 'files_for_partial_full_backup': files_for_partial_full_backup, 'appdata_parameters': appdata_parameters, 'rman_rate_in_MB': rman_rate_in__m_b}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "drop_and_recreate_devices": drop_and_recreate_devices,
+                "sync_strategy": sync_strategy,
+                "ase_backup_files": ase_backup_files,
+                "mssql_backup_uuid": mssql_backup_uuid,
+                "compression_enabled": compression_enabled,
+                "availability_group_backup_policy": availability_group_backup_policy,
+                "do_not_resume": do_not_resume,
+                "double_sync": double_sync,
+                "force_full_backup": force_full_backup,
+                "skip_space_check": skip_space_check,
+                "files_for_partial_full_backup": files_for_partial_full_backup,
+                "appdata_parameters": appdata_parameters,
+                "rman_rate_in_MB": rman_rate_in__m_b,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'upgrade_dsource':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "upgrade_dsource":
         if dsource_id is None:
-            return {'error': 'Missing required parameter: dsource_id for action upgrade_dsource'}
-        endpoint = f'/dsources/{dsource_id}/upgrade'
+            return {
+                "error": "Missing required parameter: dsource_id for action upgrade_dsource"
+            }
+        endpoint = f"/dsources/{dsource_id}/upgrade"
         params = build_params()
         if not environment_user_id:
             environment_user_id = environment_user_ref or environment_user
-        body = {k: v for k, v in {'repository_id': repository_id, 'environment_user_id': environment_user_id, 'ppt_repository': ppt_repository}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "repository_id": repository_id,
+                "environment_user_id": environment_user_id,
+                "ppt_repository": ppt_repository,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'get_dsource_upgrade_compatible_repositories':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "get_dsource_upgrade_compatible_repositories":
         if dsource_id is None:
-            return {'error': 'Missing required parameter: dsource_id for action get_dsource_upgrade_compatible_repositories'}
-        endpoint = f'/dsources/{dsource_id}/upgrade_compatible_repositories'
+            return {
+                "error": "Missing required parameter: dsource_id for action get_dsource_upgrade_compatible_repositories"
+            }
+        endpoint = f"/dsources/{dsource_id}/upgrade_compatible_repositories"
         params = build_params()
-        conf = check_confirmation('GET', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', endpoint, params=params)
-    elif action == 'get_dsource_deletion_dependencies':
+        return make_api_request("GET", endpoint, params=params)
+    elif action == "get_dsource_deletion_dependencies":
         if dsource_id is None:
-            return {'error': 'Missing required parameter: dsource_id for action get_dsource_deletion_dependencies'}
-        endpoint = f'/dsources/{dsource_id}/deletion-dependencies'
+            return {
+                "error": "Missing required parameter: dsource_id for action get_dsource_deletion_dependencies"
+            }
+        endpoint = f"/dsources/{dsource_id}/deletion-dependencies"
         params = build_params()
-        conf = check_confirmation('GET', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', endpoint, params=params)
-    elif action == 'get_dsource_tags':
+        return make_api_request("GET", endpoint, params=params)
+    elif action == "get_dsource_tags":
         if dsource_id is None:
-            return {'error': 'Missing required parameter: dsource_id for action get_dsource_tags'}
-        endpoint = f'/dsources/{dsource_id}/tags'
+            return {
+                "error": "Missing required parameter: dsource_id for action get_dsource_tags"
+            }
+        endpoint = f"/dsources/{dsource_id}/tags"
         params = build_params()
-        conf = check_confirmation('GET', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', endpoint, params=params)
-    elif action == 'add_dsource_tags':
+        return make_api_request("GET", endpoint, params=params)
+    elif action == "add_dsource_tags":
         if dsource_id is None:
-            return {'error': 'Missing required parameter: dsource_id for action add_dsource_tags'}
-        endpoint = f'/dsources/{dsource_id}/tags'
+            return {
+                "error": "Missing required parameter: dsource_id for action add_dsource_tags"
+            }
+        endpoint = f"/dsources/{dsource_id}/tags"
         params = build_params(tags=tags)
-        body = {k: v for k, v in {'tags': tags}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=body)
+        body = {k: v for k, v in {"tags": tags}.items() if v is not None}
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'delete_dsource_tags':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "delete_dsource_tags":
         if dsource_id is None:
-            return {'error': 'Missing required parameter: dsource_id for action delete_dsource_tags'}
-        endpoint = f'/dsources/{dsource_id}/tags/delete'
+            return {
+                "error": "Missing required parameter: dsource_id for action delete_dsource_tags"
+            }
+        endpoint = f"/dsources/{dsource_id}/tags/delete"
         params = build_params()
-        body = {k: v for k, v in {'key': key, 'value': value, 'tags': tags}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {"key": key, "value": value, "tags": tags}.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'dsource_link_oracle':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "dsource_link_oracle":
         params = build_params()
         if not environment_user_id:
             environment_user_id = environment_user_ref or environment_user
-        body = {k: v for k, v in {'name': name, 'source_id': source_id, 'group_id': group_id, 'description': description, 'log_sync_enabled': log_sync_enabled, 'sync_policy_id': sync_policy_id, 'retention_policy_id': retention_policy_id, 'make_current_account_owner': make_current_account_owner, 'tags': tags, 'ops_pre_sync': ops_pre_sync, 'ops_post_sync': ops_post_sync, 'external_file_path': external_file_path, 'environment_user_id': environment_user_id, 'backup_level_enabled': backup_level_enabled, 'rman_channels': rman_channels, 'files_per_set': files_per_set, 'check_logical': check_logical, 'encrypted_linking_enabled': encrypted_linking_enabled, 'compressed_linking_enabled': compressed_linking_enabled, 'bandwidth_limit': bandwidth_limit, 'number_of_connections': number_of_connections, 'diagnose_no_logging_faults': diagnose_no_logging_faults, 'pre_provisioning_enabled': pre_provisioning_enabled, 'link_now': link_now, 'force_full_backup': force_full_backup, 'double_sync': double_sync, 'rman_rate_in_MB': rman_rate_in__m_b, 'skip_space_check': skip_space_check, 'do_not_resume': do_not_resume, 'files_for_full_backup': files_for_full_backup, 'log_sync_mode': log_sync_mode, 'log_sync_interval': log_sync_interval, 'non_sys_username': non_sys_username, 'non_sys_password': non_sys_password, 'non_sys_vault_username': non_sys_vault_username, 'non_sys_vault': non_sys_vault, 'non_sys_hashicorp_vault_engine': non_sys_hashicorp_vault_engine, 'non_sys_hashicorp_vault_secret_path': non_sys_hashicorp_vault_secret_path, 'non_sys_hashicorp_vault_username_key': non_sys_hashicorp_vault_username_key, 'non_sys_hashicorp_vault_secret_key': non_sys_hashicorp_vault_secret_key, 'non_sys_azure_vault_name': non_sys_azure_vault_name, 'non_sys_azure_vault_username_key': non_sys_azure_vault_username_key, 'non_sys_azure_vault_secret_key': non_sys_azure_vault_secret_key, 'non_sys_cyberark_vault_query_string': non_sys_cyberark_vault_query_string, 'fallback_username': fallback_username, 'fallback_password': fallback_password, 'fallback_vault_username': fallback_vault_username, 'fallback_vault': fallback_vault, 'fallback_hashicorp_vault_engine': fallback_hashicorp_vault_engine, 'fallback_hashicorp_vault_secret_path': fallback_hashicorp_vault_secret_path, 'fallback_hashicorp_vault_username_key': fallback_hashicorp_vault_username_key, 'fallback_hashicorp_vault_secret_key': fallback_hashicorp_vault_secret_key, 'fallback_azure_vault_name': fallback_azure_vault_name, 'fallback_azure_vault_username_key': fallback_azure_vault_username_key, 'fallback_azure_vault_secret_key': fallback_azure_vault_secret_key, 'fallback_cyberark_vault_query_string': fallback_cyberark_vault_query_string, 'ops_pre_log_sync': ops_pre_log_sync}.items() if v is not None}
-        conf = check_confirmation('POST', '/dsources/oracle', action, 'data_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "name": name,
+                "source_id": source_id,
+                "group_id": group_id,
+                "description": description,
+                "log_sync_enabled": log_sync_enabled,
+                "sync_policy_id": sync_policy_id,
+                "retention_policy_id": retention_policy_id,
+                "make_current_account_owner": make_current_account_owner,
+                "tags": tags,
+                "ops_pre_sync": ops_pre_sync,
+                "ops_post_sync": ops_post_sync,
+                "external_file_path": external_file_path,
+                "environment_user_id": environment_user_id,
+                "backup_level_enabled": backup_level_enabled,
+                "rman_channels": rman_channels,
+                "files_per_set": files_per_set,
+                "check_logical": check_logical,
+                "encrypted_linking_enabled": encrypted_linking_enabled,
+                "compressed_linking_enabled": compressed_linking_enabled,
+                "bandwidth_limit": bandwidth_limit,
+                "number_of_connections": number_of_connections,
+                "diagnose_no_logging_faults": diagnose_no_logging_faults,
+                "pre_provisioning_enabled": pre_provisioning_enabled,
+                "link_now": link_now,
+                "force_full_backup": force_full_backup,
+                "double_sync": double_sync,
+                "rman_rate_in_MB": rman_rate_in__m_b,
+                "skip_space_check": skip_space_check,
+                "do_not_resume": do_not_resume,
+                "files_for_full_backup": files_for_full_backup,
+                "log_sync_mode": log_sync_mode,
+                "log_sync_interval": log_sync_interval,
+                "non_sys_username": non_sys_username,
+                "non_sys_password": non_sys_password,
+                "non_sys_vault_username": non_sys_vault_username,
+                "non_sys_vault": non_sys_vault,
+                "non_sys_hashicorp_vault_engine": non_sys_hashicorp_vault_engine,
+                "non_sys_hashicorp_vault_secret_path": non_sys_hashicorp_vault_secret_path,
+                "non_sys_hashicorp_vault_username_key": non_sys_hashicorp_vault_username_key,
+                "non_sys_hashicorp_vault_secret_key": non_sys_hashicorp_vault_secret_key,
+                "non_sys_azure_vault_name": non_sys_azure_vault_name,
+                "non_sys_azure_vault_username_key": non_sys_azure_vault_username_key,
+                "non_sys_azure_vault_secret_key": non_sys_azure_vault_secret_key,
+                "non_sys_cyberark_vault_query_string": non_sys_cyberark_vault_query_string,
+                "fallback_username": fallback_username,
+                "fallback_password": fallback_password,
+                "fallback_vault_username": fallback_vault_username,
+                "fallback_vault": fallback_vault,
+                "fallback_hashicorp_vault_engine": fallback_hashicorp_vault_engine,
+                "fallback_hashicorp_vault_secret_path": fallback_hashicorp_vault_secret_path,
+                "fallback_hashicorp_vault_username_key": fallback_hashicorp_vault_username_key,
+                "fallback_hashicorp_vault_secret_key": fallback_hashicorp_vault_secret_key,
+                "fallback_azure_vault_name": fallback_azure_vault_name,
+                "fallback_azure_vault_username_key": fallback_azure_vault_username_key,
+                "fallback_azure_vault_secret_key": fallback_azure_vault_secret_key,
+                "fallback_cyberark_vault_query_string": fallback_cyberark_vault_query_string,
+                "ops_pre_log_sync": ops_pre_log_sync,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            "/dsources/oracle",
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', '/dsources/oracle', params=params, json_body=body if body else None)
-    elif action == 'dsource_link_oracle_defaults':
+        return make_api_request(
+            "POST", "/dsources/oracle", params=params, json_body=body if body else None
+        )
+    elif action == "dsource_link_oracle_defaults":
         params = build_params()
-        body = {k: v for k, v in {'source_id': source_id}.items() if v is not None}
-        conf = check_confirmation('POST', '/dsources/oracle/defaults', action, 'data_tool', confirmed or False, request_params=params, request_body=body)
+        body = {k: v for k, v in {"source_id": source_id}.items() if v is not None}
+        conf = check_confirmation(
+            "POST",
+            "/dsources/oracle/defaults",
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', '/dsources/oracle/defaults', params=params, json_body=body if body else None)
-    elif action == 'dsource_link_oracle_staging_push':
+        return make_api_request(
+            "POST",
+            "/dsources/oracle/defaults",
+            params=params,
+            json_body=body if body else None,
+        )
+    elif action == "dsource_link_oracle_staging_push":
         params = build_params()
         if not environment_user_id:
             environment_user_id = environment_user_ref or environment_user
-        body = {k: v for k, v in {'name': name, 'source_id': source_id, 'group_id': group_id, 'description': description, 'log_sync_enabled': log_sync_enabled, 'sync_policy_id': sync_policy_id, 'retention_policy_id': retention_policy_id, 'make_current_account_owner': make_current_account_owner, 'tags': tags, 'ops_pre_sync': ops_pre_sync, 'ops_post_sync': ops_post_sync, 'engine_id': engine_id, 'container_type': container_type, 'environment_user_id': environment_user_id, 'repository': repository, 'database_name': database_name, 'database_unique_name': database_unique_name, 'sid': sid, 'mount_base': mount_base, 'custom_env_variables_pairs': custom_env_variables_pairs, 'custom_env_variables_paths': custom_env_variables_paths, 'auto_staging_restart': auto_staging_restart, 'allow_auto_staging_restart_on_host_reboot': allow_auto_staging_restart_on_host_reboot, 'physical_standby': physical_standby, 'validate_snapshot_in_readonly': validate_snapshot_in_readonly, 'validate_by_opening_db_in_read_only_mode': validate_by_opening_db_in_read_only_mode, 'staging_database_templates': staging_database_templates, 'staging_database_config_params': staging_database_config_params, 'staging_container_database_reference': staging_container_database_reference, 'ops_pre_log_sync': ops_pre_log_sync, 'tde_keystore_config_type': tde_keystore_config_type, 'template_id': template_id}.items() if v is not None}
-        conf = check_confirmation('POST', '/dsources/oracle/staging-push', action, 'data_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "name": name,
+                "source_id": source_id,
+                "group_id": group_id,
+                "description": description,
+                "log_sync_enabled": log_sync_enabled,
+                "sync_policy_id": sync_policy_id,
+                "retention_policy_id": retention_policy_id,
+                "make_current_account_owner": make_current_account_owner,
+                "tags": tags,
+                "ops_pre_sync": ops_pre_sync,
+                "ops_post_sync": ops_post_sync,
+                "engine_id": engine_id,
+                "container_type": container_type,
+                "environment_user_id": environment_user_id,
+                "repository": repository,
+                "database_name": database_name,
+                "database_unique_name": database_unique_name,
+                "sid": sid,
+                "mount_base": mount_base,
+                "custom_env_variables_pairs": custom_env_variables_pairs,
+                "custom_env_variables_paths": custom_env_variables_paths,
+                "auto_staging_restart": auto_staging_restart,
+                "allow_auto_staging_restart_on_host_reboot": allow_auto_staging_restart_on_host_reboot,
+                "physical_standby": physical_standby,
+                "validate_snapshot_in_readonly": validate_snapshot_in_readonly,
+                "validate_by_opening_db_in_read_only_mode": validate_by_opening_db_in_read_only_mode,
+                "staging_database_templates": staging_database_templates,
+                "staging_database_config_params": staging_database_config_params,
+                "staging_container_database_reference": staging_container_database_reference,
+                "ops_pre_log_sync": ops_pre_log_sync,
+                "tde_keystore_config_type": tde_keystore_config_type,
+                "template_id": template_id,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            "/dsources/oracle/staging-push",
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', '/dsources/oracle/staging-push', params=params, json_body=body if body else None)
-    elif action == 'dsource_link_oracle_staging_push_defaults':
+        return make_api_request(
+            "POST",
+            "/dsources/oracle/staging-push",
+            params=params,
+            json_body=body if body else None,
+        )
+    elif action == "dsource_link_oracle_staging_push_defaults":
         params = build_params()
-        body = {k: v for k, v in {'environment_id': environment_id, 'container_type': container_type}.items() if v is not None}
-        conf = check_confirmation('POST', '/dsources/oracle/staging-push/defaults', action, 'data_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "environment_id": environment_id,
+                "container_type": container_type,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            "/dsources/oracle/staging-push/defaults",
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', '/dsources/oracle/staging-push/defaults', params=params, json_body=body if body else None)
-    elif action == 'update_oracle_dsource':
+        return make_api_request(
+            "POST",
+            "/dsources/oracle/staging-push/defaults",
+            params=params,
+            json_body=body if body else None,
+        )
+    elif action == "update_oracle_dsource":
         if dsource_id is None:
-            return {'error': 'Missing required parameter: dsource_id for action update_oracle_dsource'}
-        endpoint = f'/dsources/oracle/{dsource_id}'
+            return {
+                "error": "Missing required parameter: dsource_id for action update_oracle_dsource"
+            }
+        endpoint = f"/dsources/oracle/{dsource_id}"
         params = build_params()
         if not environment_user_id:
             environment_user_id = environment_user_ref or environment_user
-        body = {k: v for k, v in {'name': name, 'description': description, 'db_username': db_username, 'db_password': db_password, 'non_sys_username': non_sys_username, 'non_sys_password': non_sys_password, 'validate_db_credentials': validate_db_credentials, 'environment_user_id': environment_user_id, 'backup_level_enabled': backup_level_enabled, 'rman_channels': rman_channels, 'files_per_set': files_per_set, 'check_logical': check_logical, 'encrypted_linking_enabled': encrypted_linking_enabled, 'compressed_linking_enabled': compressed_linking_enabled, 'bandwidth_limit': bandwidth_limit, 'number_of_connections': number_of_connections, 'validate_by_opening_db_in_read_only_mode': validate_by_opening_db_in_read_only_mode, 'pre_provisioning_enabled': pre_provisioning_enabled, 'diagnose_no_logging_faults': diagnose_no_logging_faults, 'rac_max_instance_lag': rac_max_instance_lag, 'allow_auto_staging_restart_on_host_reboot': allow_auto_staging_restart_on_host_reboot, 'physical_standby': physical_standby, 'external_file_path': external_file_path, 'hooks': hooks, 'custom_env_variables_pairs': custom_env_variables_pairs, 'custom_env_variables_paths': custom_env_variables_paths, 'staging_database_config_params': staging_database_config_params, 'template_id': template_id, 'logsync_enabled': logsync_enabled, 'logsync_mode': logsync_mode, 'logsync_interval': logsync_interval, 'repository': repository}.items() if v is not None}
-        conf = check_confirmation('PATCH', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "name": name,
+                "description": description,
+                "db_username": db_username,
+                "db_password": db_password,
+                "non_sys_username": non_sys_username,
+                "non_sys_password": non_sys_password,
+                "validate_db_credentials": validate_db_credentials,
+                "environment_user_id": environment_user_id,
+                "backup_level_enabled": backup_level_enabled,
+                "rman_channels": rman_channels,
+                "files_per_set": files_per_set,
+                "check_logical": check_logical,
+                "encrypted_linking_enabled": encrypted_linking_enabled,
+                "compressed_linking_enabled": compressed_linking_enabled,
+                "bandwidth_limit": bandwidth_limit,
+                "number_of_connections": number_of_connections,
+                "validate_by_opening_db_in_read_only_mode": validate_by_opening_db_in_read_only_mode,
+                "pre_provisioning_enabled": pre_provisioning_enabled,
+                "diagnose_no_logging_faults": diagnose_no_logging_faults,
+                "rac_max_instance_lag": rac_max_instance_lag,
+                "allow_auto_staging_restart_on_host_reboot": allow_auto_staging_restart_on_host_reboot,
+                "physical_standby": physical_standby,
+                "external_file_path": external_file_path,
+                "hooks": hooks,
+                "custom_env_variables_pairs": custom_env_variables_pairs,
+                "custom_env_variables_paths": custom_env_variables_paths,
+                "staging_database_config_params": staging_database_config_params,
+                "template_id": template_id,
+                "logsync_enabled": logsync_enabled,
+                "logsync_mode": logsync_mode,
+                "logsync_interval": logsync_interval,
+                "repository": repository,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "PATCH",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('PATCH', endpoint, params=params, json_body=body if body else None)
-    elif action == 'attach_oracle_dsource':
+        return make_api_request(
+            "PATCH", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "attach_oracle_dsource":
         if dsource_id is None:
-            return {'error': 'Missing required parameter: dsource_id for action attach_oracle_dsource'}
-        endpoint = f'/dsources/oracle/{dsource_id}/attachSource'
+            return {
+                "error": "Missing required parameter: dsource_id for action attach_oracle_dsource"
+            }
+        endpoint = f"/dsources/oracle/{dsource_id}/attachSource"
         params = build_params()
-        body = {k: v for k, v in {'backup_level_enabled': backup_level_enabled, 'bandwidth_limit': bandwidth_limit, 'check_logical': check_logical, 'compressed_linking_enabled': compressed_linking_enabled, 'double_sync': double_sync, 'encrypted_linking_enabled': encrypted_linking_enabled, 'environment_user': environment_user, 'external_file_path': external_file_path, 'files_per_set': files_per_set, 'force': force, 'link_now': link_now, 'number_of_connections': number_of_connections, 'operations': operations, 'oracle_fallback_user': oracle_fallback_user, 'oracle_fallback_credentials': oracle_fallback_credentials, 'rman_channels': rman_channels, 'source_id': source_id}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "backup_level_enabled": backup_level_enabled,
+                "bandwidth_limit": bandwidth_limit,
+                "check_logical": check_logical,
+                "compressed_linking_enabled": compressed_linking_enabled,
+                "double_sync": double_sync,
+                "encrypted_linking_enabled": encrypted_linking_enabled,
+                "environment_user": environment_user,
+                "external_file_path": external_file_path,
+                "files_per_set": files_per_set,
+                "force": force,
+                "link_now": link_now,
+                "number_of_connections": number_of_connections,
+                "operations": operations,
+                "oracle_fallback_user": oracle_fallback_user,
+                "oracle_fallback_credentials": oracle_fallback_credentials,
+                "rman_channels": rman_channels,
+                "source_id": source_id,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'detach_oracle_dsource':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "detach_oracle_dsource":
         if dsource_id is None:
-            return {'error': 'Missing required parameter: dsource_id for action detach_oracle_dsource'}
-        endpoint = f'/dsources/oracle/{dsource_id}/detachSource'
+            return {
+                "error": "Missing required parameter: dsource_id for action detach_oracle_dsource"
+            }
+        endpoint = f"/dsources/oracle/{dsource_id}/detachSource"
         params = build_params()
-        conf = check_confirmation('POST', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params)
-    elif action == 'upgrade_oracle_dsource':
+        return make_api_request("POST", endpoint, params=params)
+    elif action == "upgrade_oracle_dsource":
         if dsource_id is None:
-            return {'error': 'Missing required parameter: dsource_id for action upgrade_oracle_dsource'}
-        endpoint = f'/dsources/oracle/{dsource_id}/upgrade'
+            return {
+                "error": "Missing required parameter: dsource_id for action upgrade_oracle_dsource"
+            }
+        endpoint = f"/dsources/oracle/{dsource_id}/upgrade"
         params = build_params()
         if not environment_user_id:
             environment_user_id = environment_user_ref or environment_user
-        body = {k: v for k, v in {'repository_id': repository_id, 'environment_user_id': environment_user_id}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "repository_id": repository_id,
+                "environment_user_id": environment_user_id,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'dsource_link_ase':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "dsource_link_ase":
         params = build_params()
-        body = {k: v for k, v in {'name': name, 'source_id': source_id, 'group_id': group_id, 'description': description, 'log_sync_enabled': log_sync_enabled, 'sync_policy_id': sync_policy_id, 'retention_policy_id': retention_policy_id, 'make_current_account_owner': make_current_account_owner, 'tags': tags, 'ops_pre_sync': ops_pre_sync, 'ops_post_sync': ops_post_sync, 'external_file_path': external_file_path, 'mount_base': mount_base, 'load_backup_path': load_backup_path, 'backup_server_name': backup_server_name, 'backup_host_user': backup_host_user, 'backup_host': backup_host, 'dump_credentials': dump_credentials, 'source_host_user': source_host_user, 'db_user': db_user, 'db_password': db_password, 'db_vault_username': db_vault_username, 'db_vault': db_vault, 'db_hashicorp_vault_engine': db_hashicorp_vault_engine, 'db_hashicorp_vault_secret_path': db_hashicorp_vault_secret_path, 'db_hashicorp_vault_username_key': db_hashicorp_vault_username_key, 'db_hashicorp_vault_secret_key': db_hashicorp_vault_secret_key, 'db_azure_vault_name': db_azure_vault_name, 'db_azure_vault_username_key': db_azure_vault_username_key, 'db_azure_vault_secret_key': db_azure_vault_secret_key, 'db_cyberark_vault_query_string': db_cyberark_vault_query_string, 'staging_repository': staging_repository, 'staging_host_user': staging_host_user, 'validated_sync_mode': validated_sync_mode, 'dump_history_file_enabled': dump_history_file_enabled, 'drop_and_recreate_devices': drop_and_recreate_devices, 'sync_strategy': sync_strategy, 'ase_backup_files': ase_backup_files, 'pre_validated_sync': pre_validated_sync, 'post_validated_sync': post_validated_sync}.items() if v is not None}
-        conf = check_confirmation('POST', '/dsources/ase', action, 'data_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "name": name,
+                "source_id": source_id,
+                "group_id": group_id,
+                "description": description,
+                "log_sync_enabled": log_sync_enabled,
+                "sync_policy_id": sync_policy_id,
+                "retention_policy_id": retention_policy_id,
+                "make_current_account_owner": make_current_account_owner,
+                "tags": tags,
+                "ops_pre_sync": ops_pre_sync,
+                "ops_post_sync": ops_post_sync,
+                "external_file_path": external_file_path,
+                "mount_base": mount_base,
+                "load_backup_path": load_backup_path,
+                "backup_server_name": backup_server_name,
+                "backup_host_user": backup_host_user,
+                "backup_host": backup_host,
+                "dump_credentials": dump_credentials,
+                "source_host_user": source_host_user,
+                "db_user": db_user,
+                "db_password": db_password,
+                "db_vault_username": db_vault_username,
+                "db_vault": db_vault,
+                "db_hashicorp_vault_engine": db_hashicorp_vault_engine,
+                "db_hashicorp_vault_secret_path": db_hashicorp_vault_secret_path,
+                "db_hashicorp_vault_username_key": db_hashicorp_vault_username_key,
+                "db_hashicorp_vault_secret_key": db_hashicorp_vault_secret_key,
+                "db_azure_vault_name": db_azure_vault_name,
+                "db_azure_vault_username_key": db_azure_vault_username_key,
+                "db_azure_vault_secret_key": db_azure_vault_secret_key,
+                "db_cyberark_vault_query_string": db_cyberark_vault_query_string,
+                "staging_repository": staging_repository,
+                "staging_host_user": staging_host_user,
+                "validated_sync_mode": validated_sync_mode,
+                "dump_history_file_enabled": dump_history_file_enabled,
+                "drop_and_recreate_devices": drop_and_recreate_devices,
+                "sync_strategy": sync_strategy,
+                "ase_backup_files": ase_backup_files,
+                "pre_validated_sync": pre_validated_sync,
+                "post_validated_sync": post_validated_sync,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            "/dsources/ase",
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', '/dsources/ase', params=params, json_body=body if body else None)
-    elif action == 'dsource_link_ase_defaults':
+        return make_api_request(
+            "POST", "/dsources/ase", params=params, json_body=body if body else None
+        )
+    elif action == "dsource_link_ase_defaults":
         params = build_params()
-        body = {k: v for k, v in {'source_id': source_id}.items() if v is not None}
-        conf = check_confirmation('POST', '/dsources/ase/defaults', action, 'data_tool', confirmed or False, request_params=params, request_body=body)
+        body = {k: v for k, v in {"source_id": source_id}.items() if v is not None}
+        conf = check_confirmation(
+            "POST",
+            "/dsources/ase/defaults",
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', '/dsources/ase/defaults', params=params, json_body=body if body else None)
-    elif action == 'update_ase_dsource':
+        return make_api_request(
+            "POST",
+            "/dsources/ase/defaults",
+            params=params,
+            json_body=body if body else None,
+        )
+    elif action == "update_ase_dsource":
         if dsource_id is None:
-            return {'error': 'Missing required parameter: dsource_id for action update_ase_dsource'}
-        endpoint = f'/dsources/ase/{dsource_id}'
+            return {
+                "error": "Missing required parameter: dsource_id for action update_ase_dsource"
+            }
+        endpoint = f"/dsources/ase/{dsource_id}"
         params = build_params()
-        body = {k: v for k, v in {'name': name, 'description': description, 'sync_policy_id': sync_policy_id, 'retention_policy_id': retention_policy_id, 'hooks': hooks}.items() if v is not None}
-        conf = check_confirmation('PATCH', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "name": name,
+                "description": description,
+                "sync_policy_id": sync_policy_id,
+                "retention_policy_id": retention_policy_id,
+                "hooks": hooks,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "PATCH",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('PATCH', endpoint, params=params, json_body=body if body else None)
-    elif action == 'dsource_link_appdata':
+        return make_api_request(
+            "PATCH", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "dsource_link_appdata":
         params = build_params()
-        body = {k: v for k, v in {'name': name, 'source_id': source_id, 'group_id': group_id, 'description': description, 'log_sync_enabled': log_sync_enabled, 'sync_policy_id': sync_policy_id, 'retention_policy_id': retention_policy_id, 'make_current_account_owner': make_current_account_owner, 'tags': tags, 'ops_pre_sync': ops_pre_sync, 'ops_post_sync': ops_post_sync, 'link_type': link_type, 'staging_mount_base': staging_mount_base, 'staging_environment': staging_environment, 'staging_environment_user': staging_environment_user, 'environment_user': environment_user, 'excludes': excludes, 'follow_symlinks': follow_symlinks, 'parameters': parameters, 'sync_parameters': sync_parameters}.items() if v is not None}
-        conf = check_confirmation('POST', '/dsources/appdata', action, 'data_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "name": name,
+                "source_id": source_id,
+                "group_id": group_id,
+                "description": description,
+                "log_sync_enabled": log_sync_enabled,
+                "sync_policy_id": sync_policy_id,
+                "retention_policy_id": retention_policy_id,
+                "make_current_account_owner": make_current_account_owner,
+                "tags": tags,
+                "ops_pre_sync": ops_pre_sync,
+                "ops_post_sync": ops_post_sync,
+                "link_type": link_type,
+                "staging_mount_base": staging_mount_base,
+                "staging_environment": staging_environment,
+                "staging_environment_user": staging_environment_user,
+                "environment_user": environment_user,
+                "excludes": excludes,
+                "follow_symlinks": follow_symlinks,
+                "parameters": parameters,
+                "sync_parameters": sync_parameters,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            "/dsources/appdata",
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', '/dsources/appdata', params=params, json_body=body if body else None)
-    elif action == 'dsource_link_appdata_defaults':
+        return make_api_request(
+            "POST", "/dsources/appdata", params=params, json_body=body if body else None
+        )
+    elif action == "dsource_link_appdata_defaults":
         params = build_params()
-        body = {k: v for k, v in {'source_id': source_id}.items() if v is not None}
-        conf = check_confirmation('POST', '/dsources/appdata/defaults', action, 'data_tool', confirmed or False, request_params=params, request_body=body)
+        body = {k: v for k, v in {"source_id": source_id}.items() if v is not None}
+        conf = check_confirmation(
+            "POST",
+            "/dsources/appdata/defaults",
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', '/dsources/appdata/defaults', params=params, json_body=body if body else None)
-    elif action == 'update_appdata_dsource':
+        return make_api_request(
+            "POST",
+            "/dsources/appdata/defaults",
+            params=params,
+            json_body=body if body else None,
+        )
+    elif action == "update_appdata_dsource":
         if dsource_id is None:
-            return {'error': 'Missing required parameter: dsource_id for action update_appdata_dsource'}
-        endpoint = f'/dsources/appdata/{dsource_id}'
+            return {
+                "error": "Missing required parameter: dsource_id for action update_appdata_dsource"
+            }
+        endpoint = f"/dsources/appdata/{dsource_id}"
         params = build_params()
-        body = {k: v for k, v in {'name': name, 'description': description, 'staging_environment': staging_environment, 'staging_environment_user': staging_environment_user, 'environment_user': environment_user, 'parameters': parameters, 'sync_policy_id': sync_policy_id, 'retention_policy_id': retention_policy_id, 'ops_pre_sync': ops_pre_sync, 'ops_post_sync': ops_post_sync, 'hooks': hooks}.items() if v is not None}
-        conf = check_confirmation('PATCH', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "name": name,
+                "description": description,
+                "staging_environment": staging_environment,
+                "staging_environment_user": staging_environment_user,
+                "environment_user": environment_user,
+                "parameters": parameters,
+                "sync_policy_id": sync_policy_id,
+                "retention_policy_id": retention_policy_id,
+                "ops_pre_sync": ops_pre_sync,
+                "ops_post_sync": ops_post_sync,
+                "hooks": hooks,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "PATCH",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('PATCH', endpoint, params=params, json_body=body if body else None)
-    elif action == 'dsource_link_mssql':
+        return make_api_request(
+            "PATCH", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "dsource_link_mssql":
         params = build_params()
-        body = {k: v for k, v in {'name': name, 'source_id': source_id, 'group_id': group_id, 'description': description, 'log_sync_enabled': log_sync_enabled, 'sync_policy_id': sync_policy_id, 'retention_policy_id': retention_policy_id, 'make_current_account_owner': make_current_account_owner, 'tags': tags, 'ops_pre_sync': ops_pre_sync, 'ops_post_sync': ops_post_sync, 'encryption_key': encryption_key, 'sync_strategy': sync_strategy, 'mssql_backup_uuid': mssql_backup_uuid, 'compression_enabled': compression_enabled, 'availability_group_backup_policy': availability_group_backup_policy, 'source_host_user': source_host_user, 'ppt_repository': ppt_repository, 'ppt_host_user': ppt_host_user, 'staging_pre_script': staging_pre_script, 'staging_post_script': staging_post_script, 'sync_strategy_managed_type': sync_strategy_managed_type, 'mssql_user_environment_reference': mssql_user_environment_reference, 'mssql_user_domain_username': mssql_user_domain_username, 'mssql_user_domain_password': mssql_user_domain_password, 'mssql_user_domain_vault_username': mssql_user_domain_vault_username, 'mssql_user_domain_vault': mssql_user_domain_vault, 'mssql_user_domain_hashicorp_vault_engine': mssql_user_domain_hashicorp_vault_engine, 'mssql_user_domain_hashicorp_vault_secret_path': mssql_user_domain_hashicorp_vault_secret_path, 'mssql_user_domain_hashicorp_vault_username_key': mssql_user_domain_hashicorp_vault_username_key, 'mssql_user_domain_hashicorp_vault_secret_key': mssql_user_domain_hashicorp_vault_secret_key, 'mssql_user_domain_azure_vault_name': mssql_user_domain_azure_vault_name, 'mssql_user_domain_azure_vault_username_key': mssql_user_domain_azure_vault_username_key, 'mssql_user_domain_azure_vault_secret_key': mssql_user_domain_azure_vault_secret_key, 'mssql_user_domain_cyberark_vault_query_string': mssql_user_domain_cyberark_vault_query_string, 'mssql_database_username': mssql_database_username, 'mssql_database_password': mssql_database_password, 'delphix_managed_backup_compression_enabled': delphix_managed_backup_compression_enabled, 'delphix_managed_backup_policy': delphix_managed_backup_policy, 'external_managed_validate_sync_mode': external_managed_validate_sync_mode, 'external_managed_shared_backup_locations': external_managed_shared_backup_locations, 'external_netbackup_config_master_name': external_netbackup_config_master_name, 'external_netbackup_config_source_client_name': external_netbackup_config_source_client_name, 'external_netbackup_config_params': external_netbackup_config_params, 'external_netbackup_config_templates': external_netbackup_config_templates, 'external_commserve_host_name': external_commserve_host_name, 'external_commvault_config_source_client_name': external_commvault_config_source_client_name, 'external_commvault_config_staging_client_name': external_commvault_config_staging_client_name, 'external_commvault_config_params': external_commvault_config_params, 'external_commvault_config_templates': external_commvault_config_templates}.items() if v is not None}
-        conf = check_confirmation('POST', '/dsources/mssql', action, 'data_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "name": name,
+                "source_id": source_id,
+                "group_id": group_id,
+                "description": description,
+                "log_sync_enabled": log_sync_enabled,
+                "sync_policy_id": sync_policy_id,
+                "retention_policy_id": retention_policy_id,
+                "make_current_account_owner": make_current_account_owner,
+                "tags": tags,
+                "ops_pre_sync": ops_pre_sync,
+                "ops_post_sync": ops_post_sync,
+                "encryption_key": encryption_key,
+                "sync_strategy": sync_strategy,
+                "mssql_backup_uuid": mssql_backup_uuid,
+                "compression_enabled": compression_enabled,
+                "availability_group_backup_policy": availability_group_backup_policy,
+                "source_host_user": source_host_user,
+                "ppt_repository": ppt_repository,
+                "ppt_host_user": ppt_host_user,
+                "staging_pre_script": staging_pre_script,
+                "staging_post_script": staging_post_script,
+                "sync_strategy_managed_type": sync_strategy_managed_type,
+                "mssql_user_environment_reference": mssql_user_environment_reference,
+                "mssql_user_domain_username": mssql_user_domain_username,
+                "mssql_user_domain_password": mssql_user_domain_password,
+                "mssql_user_domain_vault_username": mssql_user_domain_vault_username,
+                "mssql_user_domain_vault": mssql_user_domain_vault,
+                "mssql_user_domain_hashicorp_vault_engine": mssql_user_domain_hashicorp_vault_engine,
+                "mssql_user_domain_hashicorp_vault_secret_path": mssql_user_domain_hashicorp_vault_secret_path,
+                "mssql_user_domain_hashicorp_vault_username_key": mssql_user_domain_hashicorp_vault_username_key,
+                "mssql_user_domain_hashicorp_vault_secret_key": mssql_user_domain_hashicorp_vault_secret_key,
+                "mssql_user_domain_azure_vault_name": mssql_user_domain_azure_vault_name,
+                "mssql_user_domain_azure_vault_username_key": mssql_user_domain_azure_vault_username_key,
+                "mssql_user_domain_azure_vault_secret_key": mssql_user_domain_azure_vault_secret_key,
+                "mssql_user_domain_cyberark_vault_query_string": mssql_user_domain_cyberark_vault_query_string,
+                "mssql_database_username": mssql_database_username,
+                "mssql_database_password": mssql_database_password,
+                "delphix_managed_backup_compression_enabled": delphix_managed_backup_compression_enabled,
+                "delphix_managed_backup_policy": delphix_managed_backup_policy,
+                "external_managed_validate_sync_mode": external_managed_validate_sync_mode,
+                "external_managed_shared_backup_locations": external_managed_shared_backup_locations,
+                "external_netbackup_config_master_name": external_netbackup_config_master_name,
+                "external_netbackup_config_source_client_name": external_netbackup_config_source_client_name,
+                "external_netbackup_config_params": external_netbackup_config_params,
+                "external_netbackup_config_templates": external_netbackup_config_templates,
+                "external_commserve_host_name": external_commserve_host_name,
+                "external_commvault_config_source_client_name": external_commvault_config_source_client_name,
+                "external_commvault_config_staging_client_name": external_commvault_config_staging_client_name,
+                "external_commvault_config_params": external_commvault_config_params,
+                "external_commvault_config_templates": external_commvault_config_templates,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            "/dsources/mssql",
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', '/dsources/mssql', params=params, json_body=body if body else None)
-    elif action == 'dsource_link_mssql_defaults':
+        return make_api_request(
+            "POST", "/dsources/mssql", params=params, json_body=body if body else None
+        )
+    elif action == "dsource_link_mssql_defaults":
         params = build_params()
-        body = {k: v for k, v in {'source_id': source_id}.items() if v is not None}
-        conf = check_confirmation('POST', '/dsources/mssql/defaults', action, 'data_tool', confirmed or False, request_params=params, request_body=body)
+        body = {k: v for k, v in {"source_id": source_id}.items() if v is not None}
+        conf = check_confirmation(
+            "POST",
+            "/dsources/mssql/defaults",
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', '/dsources/mssql/defaults', params=params, json_body=body if body else None)
-    elif action == 'dsource_link_mssql_staging_push':
+        return make_api_request(
+            "POST",
+            "/dsources/mssql/defaults",
+            params=params,
+            json_body=body if body else None,
+        )
+    elif action == "dsource_link_mssql_staging_push":
         params = build_params()
-        body = {k: v for k, v in {'name': name, 'source_id': source_id, 'group_id': group_id, 'description': description, 'log_sync_enabled': log_sync_enabled, 'sync_policy_id': sync_policy_id, 'retention_policy_id': retention_policy_id, 'make_current_account_owner': make_current_account_owner, 'tags': tags, 'ops_pre_sync': ops_pre_sync, 'ops_post_sync': ops_post_sync, 'engine_id': engine_id, 'encryption_key': encryption_key, 'ppt_repository': ppt_repository, 'ppt_host_user': ppt_host_user, 'staging_pre_script': staging_pre_script, 'staging_post_script': staging_post_script, 'staging_database_name': staging_database_name, 'db_state': db_state}.items() if v is not None}
-        conf = check_confirmation('POST', '/dsources/mssql/staging-push', action, 'data_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "name": name,
+                "source_id": source_id,
+                "group_id": group_id,
+                "description": description,
+                "log_sync_enabled": log_sync_enabled,
+                "sync_policy_id": sync_policy_id,
+                "retention_policy_id": retention_policy_id,
+                "make_current_account_owner": make_current_account_owner,
+                "tags": tags,
+                "ops_pre_sync": ops_pre_sync,
+                "ops_post_sync": ops_post_sync,
+                "engine_id": engine_id,
+                "encryption_key": encryption_key,
+                "ppt_repository": ppt_repository,
+                "ppt_host_user": ppt_host_user,
+                "staging_pre_script": staging_pre_script,
+                "staging_post_script": staging_post_script,
+                "staging_database_name": staging_database_name,
+                "db_state": db_state,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            "/dsources/mssql/staging-push",
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', '/dsources/mssql/staging-push', params=params, json_body=body if body else None)
-    elif action == 'dsource_link_mssql_staging_push_defaults':
+        return make_api_request(
+            "POST",
+            "/dsources/mssql/staging-push",
+            params=params,
+            json_body=body if body else None,
+        )
+    elif action == "dsource_link_mssql_staging_push_defaults":
         params = build_params()
-        body = {k: v for k, v in {'environment_id': environment_id}.items() if v is not None}
-        conf = check_confirmation('POST', '/dsources/mssql/staging-push/defaults', action, 'data_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v for k, v in {"environment_id": environment_id}.items() if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            "/dsources/mssql/staging-push/defaults",
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', '/dsources/mssql/staging-push/defaults', params=params, json_body=body if body else None)
-    elif action == 'attach_mssql_staging_push_dsource':
+        return make_api_request(
+            "POST",
+            "/dsources/mssql/staging-push/defaults",
+            params=params,
+            json_body=body if body else None,
+        )
+    elif action == "attach_mssql_staging_push_dsource":
         if dsource_id is None:
-            return {'error': 'Missing required parameter: dsource_id for action attach_mssql_staging_push_dsource'}
-        endpoint = f'/dsources/mssql/staging-push/{dsource_id}/attachSource'
-        params = build_params(ppt_repository=ppt_repository, staging_database_name=staging_database_name)
-        body = {k: v for k, v in {'encryption_key': encryption_key, 'ppt_repository': ppt_repository, 'ppt_host_user': ppt_host_user, 'staging_pre_script': staging_pre_script, 'staging_post_script': staging_post_script, 'staging_database_name': staging_database_name, 'db_state': db_state, 'ops_pre_sync': ops_pre_sync, 'ops_post_sync': ops_post_sync}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=body)
+            return {
+                "error": "Missing required parameter: dsource_id for action attach_mssql_staging_push_dsource"
+            }
+        endpoint = f"/dsources/mssql/staging-push/{dsource_id}/attachSource"
+        params = build_params(
+            ppt_repository=ppt_repository, staging_database_name=staging_database_name
+        )
+        body = {
+            k: v
+            for k, v in {
+                "encryption_key": encryption_key,
+                "ppt_repository": ppt_repository,
+                "ppt_host_user": ppt_host_user,
+                "staging_pre_script": staging_pre_script,
+                "staging_post_script": staging_post_script,
+                "staging_database_name": staging_database_name,
+                "db_state": db_state,
+                "ops_pre_sync": ops_pre_sync,
+                "ops_post_sync": ops_post_sync,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'update_mssql_dsource':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "update_mssql_dsource":
         if dsource_id is None:
-            return {'error': 'Missing required parameter: dsource_id for action update_mssql_dsource'}
-        endpoint = f'/dsources/mssql/{dsource_id}'
+            return {
+                "error": "Missing required parameter: dsource_id for action update_mssql_dsource"
+            }
+        endpoint = f"/dsources/mssql/{dsource_id}"
         params = build_params()
-        body = {k: v for k, v in {'name': name, 'logsync_enabled': logsync_enabled, 'encryption_key': encryption_key, 'ppt_repository': ppt_repository, 'ppt_host_user': ppt_host_user, 'sync_strategy_managed_type': sync_strategy_managed_type, 'source_host_user': source_host_user, 'mssql_user_environment_reference': mssql_user_environment_reference, 'mssql_user_domain_username': mssql_user_domain_username, 'mssql_user_domain_password': mssql_user_domain_password, 'mssql_user_domain_vault_username': mssql_user_domain_vault_username, 'mssql_user_domain_vault': mssql_user_domain_vault, 'mssql_user_domain_hashicorp_vault_engine': mssql_user_domain_hashicorp_vault_engine, 'mssql_user_domain_hashicorp_vault_secret_path': mssql_user_domain_hashicorp_vault_secret_path, 'mssql_user_domain_hashicorp_vault_username_key': mssql_user_domain_hashicorp_vault_username_key, 'mssql_user_domain_hashicorp_vault_secret_key': mssql_user_domain_hashicorp_vault_secret_key, 'mssql_user_domain_azure_vault_name': mssql_user_domain_azure_vault_name, 'mssql_user_domain_azure_vault_username_key': mssql_user_domain_azure_vault_username_key, 'mssql_user_domain_azure_vault_secret_key': mssql_user_domain_azure_vault_secret_key, 'mssql_user_domain_cyberark_vault_query_string': mssql_user_domain_cyberark_vault_query_string, 'mssql_database_username': mssql_database_username, 'mssql_database_password': mssql_database_password, 'delphix_managed_backup_compression_enabled': delphix_managed_backup_compression_enabled, 'delphix_managed_backup_policy': delphix_managed_backup_policy, 'external_managed_validate_sync_mode': external_managed_validate_sync_mode, 'external_managed_shared_backup_locations': external_managed_shared_backup_locations, 'disable_netbackup_config': disable_netbackup_config, 'external_netbackup_config_master_name': external_netbackup_config_master_name, 'external_netbackup_config_source_client_name': external_netbackup_config_source_client_name, 'external_netbackup_config_params': external_netbackup_config_params, 'external_netbackup_config_templates': external_netbackup_config_templates, 'disable_commvault_config': disable_commvault_config, 'external_commserve_host_name': external_commserve_host_name, 'external_commvault_config_source_client_name': external_commvault_config_source_client_name, 'external_commvault_config_staging_client_name': external_commvault_config_staging_client_name, 'external_commvault_config_params': external_commvault_config_params, 'external_commvault_config_templates': external_commvault_config_templates, 'hooks': hooks, 'sync_policy_id': sync_policy_id, 'retention_policy_id': retention_policy_id}.items() if v is not None}
-        conf = check_confirmation('PATCH', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "name": name,
+                "logsync_enabled": logsync_enabled,
+                "encryption_key": encryption_key,
+                "ppt_repository": ppt_repository,
+                "ppt_host_user": ppt_host_user,
+                "sync_strategy_managed_type": sync_strategy_managed_type,
+                "source_host_user": source_host_user,
+                "mssql_user_environment_reference": mssql_user_environment_reference,
+                "mssql_user_domain_username": mssql_user_domain_username,
+                "mssql_user_domain_password": mssql_user_domain_password,
+                "mssql_user_domain_vault_username": mssql_user_domain_vault_username,
+                "mssql_user_domain_vault": mssql_user_domain_vault,
+                "mssql_user_domain_hashicorp_vault_engine": mssql_user_domain_hashicorp_vault_engine,
+                "mssql_user_domain_hashicorp_vault_secret_path": mssql_user_domain_hashicorp_vault_secret_path,
+                "mssql_user_domain_hashicorp_vault_username_key": mssql_user_domain_hashicorp_vault_username_key,
+                "mssql_user_domain_hashicorp_vault_secret_key": mssql_user_domain_hashicorp_vault_secret_key,
+                "mssql_user_domain_azure_vault_name": mssql_user_domain_azure_vault_name,
+                "mssql_user_domain_azure_vault_username_key": mssql_user_domain_azure_vault_username_key,
+                "mssql_user_domain_azure_vault_secret_key": mssql_user_domain_azure_vault_secret_key,
+                "mssql_user_domain_cyberark_vault_query_string": mssql_user_domain_cyberark_vault_query_string,
+                "mssql_database_username": mssql_database_username,
+                "mssql_database_password": mssql_database_password,
+                "delphix_managed_backup_compression_enabled": delphix_managed_backup_compression_enabled,
+                "delphix_managed_backup_policy": delphix_managed_backup_policy,
+                "external_managed_validate_sync_mode": external_managed_validate_sync_mode,
+                "external_managed_shared_backup_locations": external_managed_shared_backup_locations,
+                "disable_netbackup_config": disable_netbackup_config,
+                "external_netbackup_config_master_name": external_netbackup_config_master_name,
+                "external_netbackup_config_source_client_name": external_netbackup_config_source_client_name,
+                "external_netbackup_config_params": external_netbackup_config_params,
+                "external_netbackup_config_templates": external_netbackup_config_templates,
+                "disable_commvault_config": disable_commvault_config,
+                "external_commserve_host_name": external_commserve_host_name,
+                "external_commvault_config_source_client_name": external_commvault_config_source_client_name,
+                "external_commvault_config_staging_client_name": external_commvault_config_staging_client_name,
+                "external_commvault_config_params": external_commvault_config_params,
+                "external_commvault_config_templates": external_commvault_config_templates,
+                "hooks": hooks,
+                "sync_policy_id": sync_policy_id,
+                "retention_policy_id": retention_policy_id,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "PATCH",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('PATCH', endpoint, params=params, json_body=body if body else None)
-    elif action == 'attach_mssql_dsource':
+        return make_api_request(
+            "PATCH", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "attach_mssql_dsource":
         if dsource_id is None:
-            return {'error': 'Missing required parameter: dsource_id for action attach_mssql_dsource'}
-        endpoint = f'/dsources/mssql/{dsource_id}/attachSource'
+            return {
+                "error": "Missing required parameter: dsource_id for action attach_mssql_dsource"
+            }
+        endpoint = f"/dsources/mssql/{dsource_id}/attachSource"
         params = build_params(ppt_repository=ppt_repository)
-        body = {k: v for k, v in {'source_id': source_id, 'ppt_repository': ppt_repository, 'sync_strategy_managed_type': sync_strategy_managed_type, 'mssql_user_environment_reference': mssql_user_environment_reference, 'mssql_user_domain_username': mssql_user_domain_username, 'mssql_user_domain_password': mssql_user_domain_password, 'mssql_user_domain_vault_username': mssql_user_domain_vault_username, 'mssql_user_domain_vault': mssql_user_domain_vault, 'mssql_user_domain_hashicorp_vault_engine': mssql_user_domain_hashicorp_vault_engine, 'mssql_user_domain_hashicorp_vault_secret_path': mssql_user_domain_hashicorp_vault_secret_path, 'mssql_user_domain_hashicorp_vault_username_key': mssql_user_domain_hashicorp_vault_username_key, 'mssql_user_domain_hashicorp_vault_secret_key': mssql_user_domain_hashicorp_vault_secret_key, 'mssql_user_domain_azure_vault_name': mssql_user_domain_azure_vault_name, 'mssql_user_domain_azure_vault_username_key': mssql_user_domain_azure_vault_username_key, 'mssql_user_domain_azure_vault_secret_key': mssql_user_domain_azure_vault_secret_key, 'mssql_user_domain_cyberark_vault_query_string': mssql_user_domain_cyberark_vault_query_string, 'mssql_database_username': mssql_database_username, 'mssql_database_password': mssql_database_password, 'delphix_managed_backup_compression_enabled': delphix_managed_backup_compression_enabled, 'delphix_managed_backup_policy': delphix_managed_backup_policy, 'external_managed_validate_sync_mode': external_managed_validate_sync_mode, 'external_managed_shared_backup_locations': external_managed_shared_backup_locations, 'external_netbackup_config_master_name': external_netbackup_config_master_name, 'external_netbackup_config_source_client_name': external_netbackup_config_source_client_name, 'external_netbackup_config_params': external_netbackup_config_params, 'external_netbackup_config_templates': external_netbackup_config_templates, 'external_commserve_host_name': external_commserve_host_name, 'external_commvault_config_source_client_name': external_commvault_config_source_client_name, 'external_commvault_config_staging_client_name': external_commvault_config_staging_client_name, 'external_commvault_config_params': external_commvault_config_params, 'external_commvault_config_templates': external_commvault_config_templates, 'encryption_key': encryption_key, 'source_host_user': source_host_user, 'ppt_host_user': ppt_host_user, 'staging_pre_script': staging_pre_script, 'staging_post_script': staging_post_script, 'ops_pre_sync': ops_pre_sync, 'ops_post_sync': ops_post_sync}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "source_id": source_id,
+                "ppt_repository": ppt_repository,
+                "sync_strategy_managed_type": sync_strategy_managed_type,
+                "mssql_user_environment_reference": mssql_user_environment_reference,
+                "mssql_user_domain_username": mssql_user_domain_username,
+                "mssql_user_domain_password": mssql_user_domain_password,
+                "mssql_user_domain_vault_username": mssql_user_domain_vault_username,
+                "mssql_user_domain_vault": mssql_user_domain_vault,
+                "mssql_user_domain_hashicorp_vault_engine": mssql_user_domain_hashicorp_vault_engine,
+                "mssql_user_domain_hashicorp_vault_secret_path": mssql_user_domain_hashicorp_vault_secret_path,
+                "mssql_user_domain_hashicorp_vault_username_key": mssql_user_domain_hashicorp_vault_username_key,
+                "mssql_user_domain_hashicorp_vault_secret_key": mssql_user_domain_hashicorp_vault_secret_key,
+                "mssql_user_domain_azure_vault_name": mssql_user_domain_azure_vault_name,
+                "mssql_user_domain_azure_vault_username_key": mssql_user_domain_azure_vault_username_key,
+                "mssql_user_domain_azure_vault_secret_key": mssql_user_domain_azure_vault_secret_key,
+                "mssql_user_domain_cyberark_vault_query_string": mssql_user_domain_cyberark_vault_query_string,
+                "mssql_database_username": mssql_database_username,
+                "mssql_database_password": mssql_database_password,
+                "delphix_managed_backup_compression_enabled": delphix_managed_backup_compression_enabled,
+                "delphix_managed_backup_policy": delphix_managed_backup_policy,
+                "external_managed_validate_sync_mode": external_managed_validate_sync_mode,
+                "external_managed_shared_backup_locations": external_managed_shared_backup_locations,
+                "external_netbackup_config_master_name": external_netbackup_config_master_name,
+                "external_netbackup_config_source_client_name": external_netbackup_config_source_client_name,
+                "external_netbackup_config_params": external_netbackup_config_params,
+                "external_netbackup_config_templates": external_netbackup_config_templates,
+                "external_commserve_host_name": external_commserve_host_name,
+                "external_commvault_config_source_client_name": external_commvault_config_source_client_name,
+                "external_commvault_config_staging_client_name": external_commvault_config_staging_client_name,
+                "external_commvault_config_params": external_commvault_config_params,
+                "external_commvault_config_templates": external_commvault_config_templates,
+                "encryption_key": encryption_key,
+                "source_host_user": source_host_user,
+                "ppt_host_user": ppt_host_user,
+                "staging_pre_script": staging_pre_script,
+                "staging_post_script": staging_post_script,
+                "ops_pre_sync": ops_pre_sync,
+                "ops_post_sync": ops_post_sync,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'detach_mssql_dsource':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "detach_mssql_dsource":
         if dsource_id is None:
-            return {'error': 'Missing required parameter: dsource_id for action detach_mssql_dsource'}
-        endpoint = f'/dsources/mssql/{dsource_id}/detachSource'
+            return {
+                "error": "Missing required parameter: dsource_id for action detach_mssql_dsource"
+            }
+        endpoint = f"/dsources/mssql/{dsource_id}/detachSource"
         params = build_params()
-        conf = check_confirmation('POST', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params)
-    elif action == 'export_dsource_by_snapshot':
+        return make_api_request("POST", endpoint, params=params)
+    elif action == "export_dsource_by_snapshot":
         if dsource_id is None:
-            return {'error': 'Missing required parameter: dsource_id for action export_dsource_by_snapshot'}
-        endpoint = f'/dsources/{dsource_id}/export-by-snapshot'
+            return {
+                "error": "Missing required parameter: dsource_id for action export_dsource_by_snapshot"
+            }
+        endpoint = f"/dsources/{dsource_id}/export-by-snapshot"
         params = build_params()
-        body = {k: v for k, v in {'unique_name': unique_name, 'database_name': database_name, 'repository_id': repository_id, 'environment_user_ref': environment_user_ref, 'tde_keystore_password': tde_keystore_password, 'tde_keystore_config_type': tde_keystore_config_type, 'oracle_instance_name': oracle_instance_name, 'instance_number': instance_number, 'instances': instances, 'mount_base': mount_base, 'config_params': config_params, 'cdb_id': cdb_id, 'parent_tde_keystore_path': parent_tde_keystore_path, 'parent_tde_keystore_password': parent_tde_keystore_password, 'tde_exported_keyfile_secret': tde_exported_keyfile_secret, 'tde_key_identifier': tde_key_identifier, 'parent_pdb_tde_keystore_path': parent_pdb_tde_keystore_path, 'parent_pdb_tde_keystore_password': parent_pdb_tde_keystore_password, 'target_pdb_tde_keystore_password': target_pdb_tde_keystore_password, 'crs_database_name': crs_database_name, 'recover_database': recover_database, 'file_mapping_rules': file_mapping_rules, 'enable_cdc': enable_cdc, 'recovery_model': recovery_model, 'mirroring_state': mirroring_state, 'is_incremental_v2p': is_incremental_v2p, 'backup_frequency_minutes': backup_frequency_minutes, 'rman_channels_for_incremental_backup': rman_channels_for_incremental_backup, 'rman_files_per_set_for_incremental_backup': rman_files_per_set_for_incremental_backup, 'rman_file_section_size_in_gb_for_incremental_backup': rman_file_section_size_in_gb_for_incremental_backup, 'targetDirectory': target_directory, 'dataDirectory': data_directory, 'archiveDirectory': archive_directory, 'externalDirectory': external_directory, 'tempDirectory': temp_directory, 'scriptDirectory': script_directory, 'useAbsolutePathForDataFiles': use_absolute_path_for_data_files, 'rman_channels': rman_channels, 'rman_file_section_size_in_gb': rman_file_section_size_in_gb, 'snapshot_id': snapshot_id}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "unique_name": unique_name,
+                "database_name": database_name,
+                "repository_id": repository_id,
+                "environment_user_ref": environment_user_ref,
+                "tde_keystore_password": tde_keystore_password,
+                "tde_keystore_config_type": tde_keystore_config_type,
+                "oracle_instance_name": oracle_instance_name,
+                "instance_number": instance_number,
+                "instances": instances,
+                "mount_base": mount_base,
+                "config_params": config_params,
+                "cdb_id": cdb_id,
+                "parent_tde_keystore_path": parent_tde_keystore_path,
+                "parent_tde_keystore_password": parent_tde_keystore_password,
+                "tde_exported_keyfile_secret": tde_exported_keyfile_secret,
+                "tde_key_identifier": tde_key_identifier,
+                "parent_pdb_tde_keystore_path": parent_pdb_tde_keystore_path,
+                "parent_pdb_tde_keystore_password": parent_pdb_tde_keystore_password,
+                "target_pdb_tde_keystore_password": target_pdb_tde_keystore_password,
+                "crs_database_name": crs_database_name,
+                "recover_database": recover_database,
+                "file_mapping_rules": file_mapping_rules,
+                "enable_cdc": enable_cdc,
+                "recovery_model": recovery_model,
+                "mirroring_state": mirroring_state,
+                "is_incremental_v2p": is_incremental_v2p,
+                "backup_frequency_minutes": backup_frequency_minutes,
+                "rman_channels_for_incremental_backup": rman_channels_for_incremental_backup,
+                "rman_files_per_set_for_incremental_backup": rman_files_per_set_for_incremental_backup,
+                "rman_file_section_size_in_gb_for_incremental_backup": rman_file_section_size_in_gb_for_incremental_backup,
+                "targetDirectory": target_directory,
+                "dataDirectory": data_directory,
+                "archiveDirectory": archive_directory,
+                "externalDirectory": external_directory,
+                "tempDirectory": temp_directory,
+                "scriptDirectory": script_directory,
+                "useAbsolutePathForDataFiles": use_absolute_path_for_data_files,
+                "rman_channels": rman_channels,
+                "rman_file_section_size_in_gb": rman_file_section_size_in_gb,
+                "snapshot_id": snapshot_id,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'export_dsource_by_timestamp':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "export_dsource_by_timestamp":
         if dsource_id is None:
-            return {'error': 'Missing required parameter: dsource_id for action export_dsource_by_timestamp'}
-        endpoint = f'/dsources/{dsource_id}/export-by-timestamp'
+            return {
+                "error": "Missing required parameter: dsource_id for action export_dsource_by_timestamp"
+            }
+        endpoint = f"/dsources/{dsource_id}/export-by-timestamp"
         params = build_params(timestamp=timestamp)
-        body = {k: v for k, v in {'unique_name': unique_name, 'database_name': database_name, 'repository_id': repository_id, 'environment_user_ref': environment_user_ref, 'tde_keystore_password': tde_keystore_password, 'tde_keystore_config_type': tde_keystore_config_type, 'oracle_instance_name': oracle_instance_name, 'instance_number': instance_number, 'instances': instances, 'mount_base': mount_base, 'config_params': config_params, 'cdb_id': cdb_id, 'parent_tde_keystore_path': parent_tde_keystore_path, 'parent_tde_keystore_password': parent_tde_keystore_password, 'tde_exported_keyfile_secret': tde_exported_keyfile_secret, 'tde_key_identifier': tde_key_identifier, 'parent_pdb_tde_keystore_path': parent_pdb_tde_keystore_path, 'parent_pdb_tde_keystore_password': parent_pdb_tde_keystore_password, 'target_pdb_tde_keystore_password': target_pdb_tde_keystore_password, 'crs_database_name': crs_database_name, 'recover_database': recover_database, 'file_mapping_rules': file_mapping_rules, 'enable_cdc': enable_cdc, 'recovery_model': recovery_model, 'mirroring_state': mirroring_state, 'is_incremental_v2p': is_incremental_v2p, 'backup_frequency_minutes': backup_frequency_minutes, 'rman_channels_for_incremental_backup': rman_channels_for_incremental_backup, 'rman_files_per_set_for_incremental_backup': rman_files_per_set_for_incremental_backup, 'rman_file_section_size_in_gb_for_incremental_backup': rman_file_section_size_in_gb_for_incremental_backup, 'targetDirectory': target_directory, 'dataDirectory': data_directory, 'archiveDirectory': archive_directory, 'externalDirectory': external_directory, 'tempDirectory': temp_directory, 'scriptDirectory': script_directory, 'useAbsolutePathForDataFiles': use_absolute_path_for_data_files, 'rman_channels': rman_channels, 'rman_file_section_size_in_gb': rman_file_section_size_in_gb, 'timeflow_id': timeflow_id, 'timestamp': timestamp}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "unique_name": unique_name,
+                "database_name": database_name,
+                "repository_id": repository_id,
+                "environment_user_ref": environment_user_ref,
+                "tde_keystore_password": tde_keystore_password,
+                "tde_keystore_config_type": tde_keystore_config_type,
+                "oracle_instance_name": oracle_instance_name,
+                "instance_number": instance_number,
+                "instances": instances,
+                "mount_base": mount_base,
+                "config_params": config_params,
+                "cdb_id": cdb_id,
+                "parent_tde_keystore_path": parent_tde_keystore_path,
+                "parent_tde_keystore_password": parent_tde_keystore_password,
+                "tde_exported_keyfile_secret": tde_exported_keyfile_secret,
+                "tde_key_identifier": tde_key_identifier,
+                "parent_pdb_tde_keystore_path": parent_pdb_tde_keystore_path,
+                "parent_pdb_tde_keystore_password": parent_pdb_tde_keystore_password,
+                "target_pdb_tde_keystore_password": target_pdb_tde_keystore_password,
+                "crs_database_name": crs_database_name,
+                "recover_database": recover_database,
+                "file_mapping_rules": file_mapping_rules,
+                "enable_cdc": enable_cdc,
+                "recovery_model": recovery_model,
+                "mirroring_state": mirroring_state,
+                "is_incremental_v2p": is_incremental_v2p,
+                "backup_frequency_minutes": backup_frequency_minutes,
+                "rman_channels_for_incremental_backup": rman_channels_for_incremental_backup,
+                "rman_files_per_set_for_incremental_backup": rman_files_per_set_for_incremental_backup,
+                "rman_file_section_size_in_gb_for_incremental_backup": rman_file_section_size_in_gb_for_incremental_backup,
+                "targetDirectory": target_directory,
+                "dataDirectory": data_directory,
+                "archiveDirectory": archive_directory,
+                "externalDirectory": external_directory,
+                "tempDirectory": temp_directory,
+                "scriptDirectory": script_directory,
+                "useAbsolutePathForDataFiles": use_absolute_path_for_data_files,
+                "rman_channels": rman_channels,
+                "rman_file_section_size_in_gb": rman_file_section_size_in_gb,
+                "timeflow_id": timeflow_id,
+                "timestamp": timestamp,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'export_dsource_by_location':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "export_dsource_by_location":
         if dsource_id is None:
-            return {'error': 'Missing required parameter: dsource_id for action export_dsource_by_location'}
-        endpoint = f'/dsources/{dsource_id}/export-by-location'
+            return {
+                "error": "Missing required parameter: dsource_id for action export_dsource_by_location"
+            }
+        endpoint = f"/dsources/{dsource_id}/export-by-location"
         params = build_params(location=location)
-        body = {k: v for k, v in {'unique_name': unique_name, 'database_name': database_name, 'repository_id': repository_id, 'environment_user_ref': environment_user_ref, 'tde_keystore_password': tde_keystore_password, 'tde_keystore_config_type': tde_keystore_config_type, 'oracle_instance_name': oracle_instance_name, 'instance_number': instance_number, 'instances': instances, 'mount_base': mount_base, 'config_params': config_params, 'cdb_id': cdb_id, 'parent_tde_keystore_path': parent_tde_keystore_path, 'parent_tde_keystore_password': parent_tde_keystore_password, 'tde_exported_keyfile_secret': tde_exported_keyfile_secret, 'tde_key_identifier': tde_key_identifier, 'parent_pdb_tde_keystore_path': parent_pdb_tde_keystore_path, 'parent_pdb_tde_keystore_password': parent_pdb_tde_keystore_password, 'target_pdb_tde_keystore_password': target_pdb_tde_keystore_password, 'crs_database_name': crs_database_name, 'recover_database': recover_database, 'file_mapping_rules': file_mapping_rules, 'enable_cdc': enable_cdc, 'recovery_model': recovery_model, 'mirroring_state': mirroring_state, 'is_incremental_v2p': is_incremental_v2p, 'backup_frequency_minutes': backup_frequency_minutes, 'rman_channels_for_incremental_backup': rman_channels_for_incremental_backup, 'rman_files_per_set_for_incremental_backup': rman_files_per_set_for_incremental_backup, 'rman_file_section_size_in_gb_for_incremental_backup': rman_file_section_size_in_gb_for_incremental_backup, 'targetDirectory': target_directory, 'dataDirectory': data_directory, 'archiveDirectory': archive_directory, 'externalDirectory': external_directory, 'tempDirectory': temp_directory, 'scriptDirectory': script_directory, 'useAbsolutePathForDataFiles': use_absolute_path_for_data_files, 'rman_channels': rman_channels, 'rman_file_section_size_in_gb': rman_file_section_size_in_gb, 'location': location}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "unique_name": unique_name,
+                "database_name": database_name,
+                "repository_id": repository_id,
+                "environment_user_ref": environment_user_ref,
+                "tde_keystore_password": tde_keystore_password,
+                "tde_keystore_config_type": tde_keystore_config_type,
+                "oracle_instance_name": oracle_instance_name,
+                "instance_number": instance_number,
+                "instances": instances,
+                "mount_base": mount_base,
+                "config_params": config_params,
+                "cdb_id": cdb_id,
+                "parent_tde_keystore_path": parent_tde_keystore_path,
+                "parent_tde_keystore_password": parent_tde_keystore_password,
+                "tde_exported_keyfile_secret": tde_exported_keyfile_secret,
+                "tde_key_identifier": tde_key_identifier,
+                "parent_pdb_tde_keystore_path": parent_pdb_tde_keystore_path,
+                "parent_pdb_tde_keystore_password": parent_pdb_tde_keystore_password,
+                "target_pdb_tde_keystore_password": target_pdb_tde_keystore_password,
+                "crs_database_name": crs_database_name,
+                "recover_database": recover_database,
+                "file_mapping_rules": file_mapping_rules,
+                "enable_cdc": enable_cdc,
+                "recovery_model": recovery_model,
+                "mirroring_state": mirroring_state,
+                "is_incremental_v2p": is_incremental_v2p,
+                "backup_frequency_minutes": backup_frequency_minutes,
+                "rman_channels_for_incremental_backup": rman_channels_for_incremental_backup,
+                "rman_files_per_set_for_incremental_backup": rman_files_per_set_for_incremental_backup,
+                "rman_file_section_size_in_gb_for_incremental_backup": rman_file_section_size_in_gb_for_incremental_backup,
+                "targetDirectory": target_directory,
+                "dataDirectory": data_directory,
+                "archiveDirectory": archive_directory,
+                "externalDirectory": external_directory,
+                "tempDirectory": temp_directory,
+                "scriptDirectory": script_directory,
+                "useAbsolutePathForDataFiles": use_absolute_path_for_data_files,
+                "rman_channels": rman_channels,
+                "rman_file_section_size_in_gb": rman_file_section_size_in_gb,
+                "location": location,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'export_dsource_from_bookmark':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "export_dsource_from_bookmark":
         if dsource_id is None:
-            return {'error': 'Missing required parameter: dsource_id for action export_dsource_from_bookmark'}
-        endpoint = f'/dsources/{dsource_id}/export-from-bookmark'
+            return {
+                "error": "Missing required parameter: dsource_id for action export_dsource_from_bookmark"
+            }
+        endpoint = f"/dsources/{dsource_id}/export-from-bookmark"
         params = build_params()
-        body = {k: v for k, v in {'unique_name': unique_name, 'database_name': database_name, 'repository_id': repository_id, 'environment_user_ref': environment_user_ref, 'tde_keystore_password': tde_keystore_password, 'tde_keystore_config_type': tde_keystore_config_type, 'oracle_instance_name': oracle_instance_name, 'instance_number': instance_number, 'instances': instances, 'mount_base': mount_base, 'config_params': config_params, 'cdb_id': cdb_id, 'parent_tde_keystore_path': parent_tde_keystore_path, 'parent_tde_keystore_password': parent_tde_keystore_password, 'tde_exported_keyfile_secret': tde_exported_keyfile_secret, 'tde_key_identifier': tde_key_identifier, 'parent_pdb_tde_keystore_path': parent_pdb_tde_keystore_path, 'parent_pdb_tde_keystore_password': parent_pdb_tde_keystore_password, 'target_pdb_tde_keystore_password': target_pdb_tde_keystore_password, 'crs_database_name': crs_database_name, 'recover_database': recover_database, 'file_mapping_rules': file_mapping_rules, 'enable_cdc': enable_cdc, 'recovery_model': recovery_model, 'mirroring_state': mirroring_state, 'is_incremental_v2p': is_incremental_v2p, 'backup_frequency_minutes': backup_frequency_minutes, 'rman_channels_for_incremental_backup': rman_channels_for_incremental_backup, 'rman_files_per_set_for_incremental_backup': rman_files_per_set_for_incremental_backup, 'rman_file_section_size_in_gb_for_incremental_backup': rman_file_section_size_in_gb_for_incremental_backup, 'targetDirectory': target_directory, 'dataDirectory': data_directory, 'archiveDirectory': archive_directory, 'externalDirectory': external_directory, 'tempDirectory': temp_directory, 'scriptDirectory': script_directory, 'useAbsolutePathForDataFiles': use_absolute_path_for_data_files, 'rman_channels': rman_channels, 'rman_file_section_size_in_gb': rman_file_section_size_in_gb, 'bookmark_id': bookmark_id}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "unique_name": unique_name,
+                "database_name": database_name,
+                "repository_id": repository_id,
+                "environment_user_ref": environment_user_ref,
+                "tde_keystore_password": tde_keystore_password,
+                "tde_keystore_config_type": tde_keystore_config_type,
+                "oracle_instance_name": oracle_instance_name,
+                "instance_number": instance_number,
+                "instances": instances,
+                "mount_base": mount_base,
+                "config_params": config_params,
+                "cdb_id": cdb_id,
+                "parent_tde_keystore_path": parent_tde_keystore_path,
+                "parent_tde_keystore_password": parent_tde_keystore_password,
+                "tde_exported_keyfile_secret": tde_exported_keyfile_secret,
+                "tde_key_identifier": tde_key_identifier,
+                "parent_pdb_tde_keystore_path": parent_pdb_tde_keystore_path,
+                "parent_pdb_tde_keystore_password": parent_pdb_tde_keystore_password,
+                "target_pdb_tde_keystore_password": target_pdb_tde_keystore_password,
+                "crs_database_name": crs_database_name,
+                "recover_database": recover_database,
+                "file_mapping_rules": file_mapping_rules,
+                "enable_cdc": enable_cdc,
+                "recovery_model": recovery_model,
+                "mirroring_state": mirroring_state,
+                "is_incremental_v2p": is_incremental_v2p,
+                "backup_frequency_minutes": backup_frequency_minutes,
+                "rman_channels_for_incremental_backup": rman_channels_for_incremental_backup,
+                "rman_files_per_set_for_incremental_backup": rman_files_per_set_for_incremental_backup,
+                "rman_file_section_size_in_gb_for_incremental_backup": rman_file_section_size_in_gb_for_incremental_backup,
+                "targetDirectory": target_directory,
+                "dataDirectory": data_directory,
+                "archiveDirectory": archive_directory,
+                "externalDirectory": external_directory,
+                "tempDirectory": temp_directory,
+                "scriptDirectory": script_directory,
+                "useAbsolutePathForDataFiles": use_absolute_path_for_data_files,
+                "rman_channels": rman_channels,
+                "rman_file_section_size_in_gb": rman_file_section_size_in_gb,
+                "bookmark_id": bookmark_id,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'export_dsource_to_asm_by_snapshot':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "export_dsource_to_asm_by_snapshot":
         if dsource_id is None:
-            return {'error': 'Missing required parameter: dsource_id for action export_dsource_to_asm_by_snapshot'}
-        endpoint = f'/dsources/{dsource_id}/asm-export-by-snapshot'
+            return {
+                "error": "Missing required parameter: dsource_id for action export_dsource_to_asm_by_snapshot"
+            }
+        endpoint = f"/dsources/{dsource_id}/asm-export-by-snapshot"
         params = build_params(default_data_diskgroup=default_data_diskgroup)
-        body = {k: v for k, v in {'unique_name': unique_name, 'database_name': database_name, 'repository_id': repository_id, 'environment_user_ref': environment_user_ref, 'tde_keystore_password': tde_keystore_password, 'tde_keystore_config_type': tde_keystore_config_type, 'oracle_instance_name': oracle_instance_name, 'instance_number': instance_number, 'instances': instances, 'mount_base': mount_base, 'config_params': config_params, 'cdb_id': cdb_id, 'parent_tde_keystore_path': parent_tde_keystore_path, 'parent_tde_keystore_password': parent_tde_keystore_password, 'tde_exported_keyfile_secret': tde_exported_keyfile_secret, 'tde_key_identifier': tde_key_identifier, 'parent_pdb_tde_keystore_path': parent_pdb_tde_keystore_path, 'parent_pdb_tde_keystore_password': parent_pdb_tde_keystore_password, 'target_pdb_tde_keystore_password': target_pdb_tde_keystore_password, 'crs_database_name': crs_database_name, 'recover_database': recover_database, 'file_mapping_rules': file_mapping_rules, 'enable_cdc': enable_cdc, 'recovery_model': recovery_model, 'mirroring_state': mirroring_state, 'is_incremental_v2p': is_incremental_v2p, 'backup_frequency_minutes': backup_frequency_minutes, 'rman_channels_for_incremental_backup': rman_channels_for_incremental_backup, 'rman_files_per_set_for_incremental_backup': rman_files_per_set_for_incremental_backup, 'rman_file_section_size_in_gb_for_incremental_backup': rman_file_section_size_in_gb_for_incremental_backup, 'default_data_diskgroup': default_data_diskgroup, 'redo_diskgroup': redo_diskgroup, 'rman_channels': rman_channels, 'rman_file_section_size_in_gb': rman_file_section_size_in_gb, 'snapshot_id': snapshot_id}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "unique_name": unique_name,
+                "database_name": database_name,
+                "repository_id": repository_id,
+                "environment_user_ref": environment_user_ref,
+                "tde_keystore_password": tde_keystore_password,
+                "tde_keystore_config_type": tde_keystore_config_type,
+                "oracle_instance_name": oracle_instance_name,
+                "instance_number": instance_number,
+                "instances": instances,
+                "mount_base": mount_base,
+                "config_params": config_params,
+                "cdb_id": cdb_id,
+                "parent_tde_keystore_path": parent_tde_keystore_path,
+                "parent_tde_keystore_password": parent_tde_keystore_password,
+                "tde_exported_keyfile_secret": tde_exported_keyfile_secret,
+                "tde_key_identifier": tde_key_identifier,
+                "parent_pdb_tde_keystore_path": parent_pdb_tde_keystore_path,
+                "parent_pdb_tde_keystore_password": parent_pdb_tde_keystore_password,
+                "target_pdb_tde_keystore_password": target_pdb_tde_keystore_password,
+                "crs_database_name": crs_database_name,
+                "recover_database": recover_database,
+                "file_mapping_rules": file_mapping_rules,
+                "enable_cdc": enable_cdc,
+                "recovery_model": recovery_model,
+                "mirroring_state": mirroring_state,
+                "is_incremental_v2p": is_incremental_v2p,
+                "backup_frequency_minutes": backup_frequency_minutes,
+                "rman_channels_for_incremental_backup": rman_channels_for_incremental_backup,
+                "rman_files_per_set_for_incremental_backup": rman_files_per_set_for_incremental_backup,
+                "rman_file_section_size_in_gb_for_incremental_backup": rman_file_section_size_in_gb_for_incremental_backup,
+                "default_data_diskgroup": default_data_diskgroup,
+                "redo_diskgroup": redo_diskgroup,
+                "rman_channels": rman_channels,
+                "rman_file_section_size_in_gb": rman_file_section_size_in_gb,
+                "snapshot_id": snapshot_id,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'export_dsource_to_asm_by_timestamp':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "export_dsource_to_asm_by_timestamp":
         if dsource_id is None:
-            return {'error': 'Missing required parameter: dsource_id for action export_dsource_to_asm_by_timestamp'}
-        endpoint = f'/dsources/{dsource_id}/asm-export-by-timestamp'
-        params = build_params(timestamp=timestamp, default_data_diskgroup=default_data_diskgroup)
-        body = {k: v for k, v in {'unique_name': unique_name, 'database_name': database_name, 'repository_id': repository_id, 'environment_user_ref': environment_user_ref, 'tde_keystore_password': tde_keystore_password, 'tde_keystore_config_type': tde_keystore_config_type, 'oracle_instance_name': oracle_instance_name, 'instance_number': instance_number, 'instances': instances, 'mount_base': mount_base, 'config_params': config_params, 'cdb_id': cdb_id, 'parent_tde_keystore_path': parent_tde_keystore_path, 'parent_tde_keystore_password': parent_tde_keystore_password, 'tde_exported_keyfile_secret': tde_exported_keyfile_secret, 'tde_key_identifier': tde_key_identifier, 'parent_pdb_tde_keystore_path': parent_pdb_tde_keystore_path, 'parent_pdb_tde_keystore_password': parent_pdb_tde_keystore_password, 'target_pdb_tde_keystore_password': target_pdb_tde_keystore_password, 'crs_database_name': crs_database_name, 'recover_database': recover_database, 'file_mapping_rules': file_mapping_rules, 'enable_cdc': enable_cdc, 'recovery_model': recovery_model, 'mirroring_state': mirroring_state, 'is_incremental_v2p': is_incremental_v2p, 'backup_frequency_minutes': backup_frequency_minutes, 'rman_channels_for_incremental_backup': rman_channels_for_incremental_backup, 'rman_files_per_set_for_incremental_backup': rman_files_per_set_for_incremental_backup, 'rman_file_section_size_in_gb_for_incremental_backup': rman_file_section_size_in_gb_for_incremental_backup, 'default_data_diskgroup': default_data_diskgroup, 'redo_diskgroup': redo_diskgroup, 'rman_channels': rman_channels, 'rman_file_section_size_in_gb': rman_file_section_size_in_gb, 'timeflow_id': timeflow_id, 'timestamp': timestamp}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=body)
+            return {
+                "error": "Missing required parameter: dsource_id for action export_dsource_to_asm_by_timestamp"
+            }
+        endpoint = f"/dsources/{dsource_id}/asm-export-by-timestamp"
+        params = build_params(
+            timestamp=timestamp, default_data_diskgroup=default_data_diskgroup
+        )
+        body = {
+            k: v
+            for k, v in {
+                "unique_name": unique_name,
+                "database_name": database_name,
+                "repository_id": repository_id,
+                "environment_user_ref": environment_user_ref,
+                "tde_keystore_password": tde_keystore_password,
+                "tde_keystore_config_type": tde_keystore_config_type,
+                "oracle_instance_name": oracle_instance_name,
+                "instance_number": instance_number,
+                "instances": instances,
+                "mount_base": mount_base,
+                "config_params": config_params,
+                "cdb_id": cdb_id,
+                "parent_tde_keystore_path": parent_tde_keystore_path,
+                "parent_tde_keystore_password": parent_tde_keystore_password,
+                "tde_exported_keyfile_secret": tde_exported_keyfile_secret,
+                "tde_key_identifier": tde_key_identifier,
+                "parent_pdb_tde_keystore_path": parent_pdb_tde_keystore_path,
+                "parent_pdb_tde_keystore_password": parent_pdb_tde_keystore_password,
+                "target_pdb_tde_keystore_password": target_pdb_tde_keystore_password,
+                "crs_database_name": crs_database_name,
+                "recover_database": recover_database,
+                "file_mapping_rules": file_mapping_rules,
+                "enable_cdc": enable_cdc,
+                "recovery_model": recovery_model,
+                "mirroring_state": mirroring_state,
+                "is_incremental_v2p": is_incremental_v2p,
+                "backup_frequency_minutes": backup_frequency_minutes,
+                "rman_channels_for_incremental_backup": rman_channels_for_incremental_backup,
+                "rman_files_per_set_for_incremental_backup": rman_files_per_set_for_incremental_backup,
+                "rman_file_section_size_in_gb_for_incremental_backup": rman_file_section_size_in_gb_for_incremental_backup,
+                "default_data_diskgroup": default_data_diskgroup,
+                "redo_diskgroup": redo_diskgroup,
+                "rman_channels": rman_channels,
+                "rman_file_section_size_in_gb": rman_file_section_size_in_gb,
+                "timeflow_id": timeflow_id,
+                "timestamp": timestamp,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'export_dsource_to_asm_by_location':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "export_dsource_to_asm_by_location":
         if dsource_id is None:
-            return {'error': 'Missing required parameter: dsource_id for action export_dsource_to_asm_by_location'}
-        endpoint = f'/dsources/{dsource_id}/asm-export-by-location'
-        params = build_params(location=location, default_data_diskgroup=default_data_diskgroup)
-        body = {k: v for k, v in {'unique_name': unique_name, 'database_name': database_name, 'repository_id': repository_id, 'environment_user_ref': environment_user_ref, 'tde_keystore_password': tde_keystore_password, 'tde_keystore_config_type': tde_keystore_config_type, 'oracle_instance_name': oracle_instance_name, 'instance_number': instance_number, 'instances': instances, 'mount_base': mount_base, 'config_params': config_params, 'cdb_id': cdb_id, 'parent_tde_keystore_path': parent_tde_keystore_path, 'parent_tde_keystore_password': parent_tde_keystore_password, 'tde_exported_keyfile_secret': tde_exported_keyfile_secret, 'tde_key_identifier': tde_key_identifier, 'parent_pdb_tde_keystore_path': parent_pdb_tde_keystore_path, 'parent_pdb_tde_keystore_password': parent_pdb_tde_keystore_password, 'target_pdb_tde_keystore_password': target_pdb_tde_keystore_password, 'crs_database_name': crs_database_name, 'recover_database': recover_database, 'file_mapping_rules': file_mapping_rules, 'enable_cdc': enable_cdc, 'recovery_model': recovery_model, 'mirroring_state': mirroring_state, 'is_incremental_v2p': is_incremental_v2p, 'backup_frequency_minutes': backup_frequency_minutes, 'rman_channels_for_incremental_backup': rman_channels_for_incremental_backup, 'rman_files_per_set_for_incremental_backup': rman_files_per_set_for_incremental_backup, 'rman_file_section_size_in_gb_for_incremental_backup': rman_file_section_size_in_gb_for_incremental_backup, 'default_data_diskgroup': default_data_diskgroup, 'redo_diskgroup': redo_diskgroup, 'rman_channels': rman_channels, 'rman_file_section_size_in_gb': rman_file_section_size_in_gb, 'location': location}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=body)
+            return {
+                "error": "Missing required parameter: dsource_id for action export_dsource_to_asm_by_location"
+            }
+        endpoint = f"/dsources/{dsource_id}/asm-export-by-location"
+        params = build_params(
+            location=location, default_data_diskgroup=default_data_diskgroup
+        )
+        body = {
+            k: v
+            for k, v in {
+                "unique_name": unique_name,
+                "database_name": database_name,
+                "repository_id": repository_id,
+                "environment_user_ref": environment_user_ref,
+                "tde_keystore_password": tde_keystore_password,
+                "tde_keystore_config_type": tde_keystore_config_type,
+                "oracle_instance_name": oracle_instance_name,
+                "instance_number": instance_number,
+                "instances": instances,
+                "mount_base": mount_base,
+                "config_params": config_params,
+                "cdb_id": cdb_id,
+                "parent_tde_keystore_path": parent_tde_keystore_path,
+                "parent_tde_keystore_password": parent_tde_keystore_password,
+                "tde_exported_keyfile_secret": tde_exported_keyfile_secret,
+                "tde_key_identifier": tde_key_identifier,
+                "parent_pdb_tde_keystore_path": parent_pdb_tde_keystore_path,
+                "parent_pdb_tde_keystore_password": parent_pdb_tde_keystore_password,
+                "target_pdb_tde_keystore_password": target_pdb_tde_keystore_password,
+                "crs_database_name": crs_database_name,
+                "recover_database": recover_database,
+                "file_mapping_rules": file_mapping_rules,
+                "enable_cdc": enable_cdc,
+                "recovery_model": recovery_model,
+                "mirroring_state": mirroring_state,
+                "is_incremental_v2p": is_incremental_v2p,
+                "backup_frequency_minutes": backup_frequency_minutes,
+                "rman_channels_for_incremental_backup": rman_channels_for_incremental_backup,
+                "rman_files_per_set_for_incremental_backup": rman_files_per_set_for_incremental_backup,
+                "rman_file_section_size_in_gb_for_incremental_backup": rman_file_section_size_in_gb_for_incremental_backup,
+                "default_data_diskgroup": default_data_diskgroup,
+                "redo_diskgroup": redo_diskgroup,
+                "rman_channels": rman_channels,
+                "rman_file_section_size_in_gb": rman_file_section_size_in_gb,
+                "location": location,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'export_dsource_to_asm_from_bookmark':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "export_dsource_to_asm_from_bookmark":
         if dsource_id is None:
-            return {'error': 'Missing required parameter: dsource_id for action export_dsource_to_asm_from_bookmark'}
-        endpoint = f'/dsources/{dsource_id}/asm-export-from-bookmark'
+            return {
+                "error": "Missing required parameter: dsource_id for action export_dsource_to_asm_from_bookmark"
+            }
+        endpoint = f"/dsources/{dsource_id}/asm-export-from-bookmark"
         params = build_params(default_data_diskgroup=default_data_diskgroup)
-        body = {k: v for k, v in {'unique_name': unique_name, 'database_name': database_name, 'repository_id': repository_id, 'environment_user_ref': environment_user_ref, 'tde_keystore_password': tde_keystore_password, 'tde_keystore_config_type': tde_keystore_config_type, 'oracle_instance_name': oracle_instance_name, 'instance_number': instance_number, 'instances': instances, 'mount_base': mount_base, 'config_params': config_params, 'cdb_id': cdb_id, 'parent_tde_keystore_path': parent_tde_keystore_path, 'parent_tde_keystore_password': parent_tde_keystore_password, 'tde_exported_keyfile_secret': tde_exported_keyfile_secret, 'tde_key_identifier': tde_key_identifier, 'parent_pdb_tde_keystore_path': parent_pdb_tde_keystore_path, 'parent_pdb_tde_keystore_password': parent_pdb_tde_keystore_password, 'target_pdb_tde_keystore_password': target_pdb_tde_keystore_password, 'crs_database_name': crs_database_name, 'recover_database': recover_database, 'file_mapping_rules': file_mapping_rules, 'enable_cdc': enable_cdc, 'recovery_model': recovery_model, 'mirroring_state': mirroring_state, 'is_incremental_v2p': is_incremental_v2p, 'backup_frequency_minutes': backup_frequency_minutes, 'rman_channels_for_incremental_backup': rman_channels_for_incremental_backup, 'rman_files_per_set_for_incremental_backup': rman_files_per_set_for_incremental_backup, 'rman_file_section_size_in_gb_for_incremental_backup': rman_file_section_size_in_gb_for_incremental_backup, 'default_data_diskgroup': default_data_diskgroup, 'redo_diskgroup': redo_diskgroup, 'rman_channels': rman_channels, 'rman_file_section_size_in_gb': rman_file_section_size_in_gb, 'bookmark_id': bookmark_id}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'data_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "unique_name": unique_name,
+                "database_name": database_name,
+                "repository_id": repository_id,
+                "environment_user_ref": environment_user_ref,
+                "tde_keystore_password": tde_keystore_password,
+                "tde_keystore_config_type": tde_keystore_config_type,
+                "oracle_instance_name": oracle_instance_name,
+                "instance_number": instance_number,
+                "instances": instances,
+                "mount_base": mount_base,
+                "config_params": config_params,
+                "cdb_id": cdb_id,
+                "parent_tde_keystore_path": parent_tde_keystore_path,
+                "parent_tde_keystore_password": parent_tde_keystore_password,
+                "tde_exported_keyfile_secret": tde_exported_keyfile_secret,
+                "tde_key_identifier": tde_key_identifier,
+                "parent_pdb_tde_keystore_path": parent_pdb_tde_keystore_path,
+                "parent_pdb_tde_keystore_password": parent_pdb_tde_keystore_password,
+                "target_pdb_tde_keystore_password": target_pdb_tde_keystore_password,
+                "crs_database_name": crs_database_name,
+                "recover_database": recover_database,
+                "file_mapping_rules": file_mapping_rules,
+                "enable_cdc": enable_cdc,
+                "recovery_model": recovery_model,
+                "mirroring_state": mirroring_state,
+                "is_incremental_v2p": is_incremental_v2p,
+                "backup_frequency_minutes": backup_frequency_minutes,
+                "rman_channels_for_incremental_backup": rman_channels_for_incremental_backup,
+                "rman_files_per_set_for_incremental_backup": rman_files_per_set_for_incremental_backup,
+                "rman_file_section_size_in_gb_for_incremental_backup": rman_file_section_size_in_gb_for_incremental_backup,
+                "default_data_diskgroup": default_data_diskgroup,
+                "redo_diskgroup": redo_diskgroup,
+                "rman_channels": rman_channels,
+                "rman_file_section_size_in_gb": rman_file_section_size_in_gb,
+                "bookmark_id": bookmark_id,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "data_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
     else:
-        return {'error': f'Unknown action: {action}. Valid actions: list_vdbs, search_vdbs, get_vdb, update_vdb, provision_by_timestamp, provision_by_timestamp_defaults, provision_by_snapshot, provision_by_snapshot_defaults, provision_from_bookmark, provision_from_bookmark_defaults, provision_by_location, provision_by_location_defaults, provision_empty_vdb, delete_vdb, start_vdb, stop_vdb, enable_vdb, disable_vdb, refresh_vdb_by_timestamp, refresh_vdb_by_snapshot, refresh_vdb_from_bookmark, refresh_vdb_by_location, undo_vdb_refresh, rollback_vdb_by_timestamp, rollback_vdb_by_snapshot, rollback_vdb_from_bookmark, switch_vdb_timeflow, lock_vdb, unlock_vdb, migrate_vdb, get_migrate_compatible_repositories, upgrade_vdb, upgrade_oracle_vdb, get_upgrade_compatible_repositories, list_vdb_snapshots, snapshot_vdb, list_vdb_bookmarks, search_vdb_bookmarks, get_vdb_deletion_dependencies, verify_vdb_jdbc_connection, get_vdb_tags, add_vdb_tags, export_vdb_in_place, export_vdb_asm_in_place, export_vdb_by_snapshot, export_vdb_by_timestamp, export_vdb_by_location, export_vdb_from_bookmark, export_vdb_to_asm_by_snapshot, export_vdb_to_asm_by_timestamp, export_vdb_to_asm_by_location, export_vdb_to_asm_from_bookmark, export_cleanup, export_finalize, list_vdb_groups, search_vdb_groups, get_vdb_group, create_vdb_group, update_vdb_group, delete_vdb_group, provision_vdb_group_from_bookmark, refresh_vdb_group, refresh_vdb_group_from_bookmark, refresh_vdb_group_by_snapshot, refresh_vdb_group_by_timestamp, rollback_vdb_group, lock_vdb_group, unlock_vdb_group, start_vdb_group, stop_vdb_group, enable_vdb_group, disable_vdb_group, get_vdb_group_latest_snapshots, get_vdb_group_timestamp_summary, list_vdb_group_bookmarks, search_vdb_group_bookmarks, get_vdb_group_tags, add_vdb_group_tags, list_dsources, search_dsources, get_dsource, delete_dsource, enable_dsource, disable_dsource, list_dsource_snapshots, dsource_create_snapshot, upgrade_dsource, get_dsource_upgrade_compatible_repositories, get_dsource_deletion_dependencies, get_dsource_tags, add_dsource_tags, delete_dsource_tags, dsource_link_oracle, dsource_link_oracle_defaults, dsource_link_oracle_staging_push, dsource_link_oracle_staging_push_defaults, update_oracle_dsource, attach_oracle_dsource, detach_oracle_dsource, upgrade_oracle_dsource, dsource_link_ase, dsource_link_ase_defaults, update_ase_dsource, dsource_link_appdata, dsource_link_appdata_defaults, update_appdata_dsource, dsource_link_mssql, dsource_link_mssql_defaults, dsource_link_mssql_staging_push, dsource_link_mssql_staging_push_defaults, attach_mssql_staging_push_dsource, update_mssql_dsource, attach_mssql_dsource, detach_mssql_dsource, export_dsource_by_snapshot, export_dsource_by_timestamp, export_dsource_by_location, export_dsource_from_bookmark, export_dsource_to_asm_by_snapshot, export_dsource_to_asm_by_timestamp, export_dsource_to_asm_by_location, export_dsource_to_asm_from_bookmark'}
+        return {
+            "error": f"Unknown action: {action}. Valid actions: list_vdbs, search_vdbs, get_vdb, update_vdb, provision_by_timestamp, provision_by_timestamp_defaults, provision_by_snapshot, provision_by_snapshot_defaults, provision_from_bookmark, provision_from_bookmark_defaults, provision_by_location, provision_by_location_defaults, provision_empty_vdb, delete_vdb, start_vdb, stop_vdb, enable_vdb, disable_vdb, refresh_vdb_by_timestamp, refresh_vdb_by_snapshot, refresh_vdb_from_bookmark, refresh_vdb_by_location, undo_vdb_refresh, rollback_vdb_by_timestamp, rollback_vdb_by_snapshot, rollback_vdb_from_bookmark, switch_vdb_timeflow, lock_vdb, unlock_vdb, migrate_vdb, get_migrate_compatible_repositories, upgrade_vdb, upgrade_oracle_vdb, get_upgrade_compatible_repositories, list_vdb_snapshots, snapshot_vdb, list_vdb_bookmarks, search_vdb_bookmarks, get_vdb_deletion_dependencies, verify_vdb_jdbc_connection, get_vdb_tags, add_vdb_tags, export_vdb_in_place, export_vdb_asm_in_place, export_vdb_by_snapshot, export_vdb_by_timestamp, export_vdb_by_location, export_vdb_from_bookmark, export_vdb_to_asm_by_snapshot, export_vdb_to_asm_by_timestamp, export_vdb_to_asm_by_location, export_vdb_to_asm_from_bookmark, export_cleanup, export_finalize, list_vdb_groups, search_vdb_groups, get_vdb_group, create_vdb_group, update_vdb_group, delete_vdb_group, provision_vdb_group_from_bookmark, refresh_vdb_group, refresh_vdb_group_from_bookmark, refresh_vdb_group_by_snapshot, refresh_vdb_group_by_timestamp, rollback_vdb_group, lock_vdb_group, unlock_vdb_group, start_vdb_group, stop_vdb_group, enable_vdb_group, disable_vdb_group, get_vdb_group_latest_snapshots, get_vdb_group_timestamp_summary, list_vdb_group_bookmarks, search_vdb_group_bookmarks, get_vdb_group_tags, add_vdb_group_tags, list_dsources, search_dsources, get_dsource, delete_dsource, enable_dsource, disable_dsource, list_dsource_snapshots, dsource_create_snapshot, upgrade_dsource, get_dsource_upgrade_compatible_repositories, get_dsource_deletion_dependencies, get_dsource_tags, add_dsource_tags, delete_dsource_tags, dsource_link_oracle, dsource_link_oracle_defaults, dsource_link_oracle_staging_push, dsource_link_oracle_staging_push_defaults, update_oracle_dsource, attach_oracle_dsource, detach_oracle_dsource, upgrade_oracle_dsource, dsource_link_ase, dsource_link_ase_defaults, update_ase_dsource, dsource_link_appdata, dsource_link_appdata_defaults, update_appdata_dsource, dsource_link_mssql, dsource_link_mssql_defaults, dsource_link_mssql_staging_push, dsource_link_mssql_staging_push_defaults, attach_mssql_staging_push_dsource, update_mssql_dsource, attach_mssql_dsource, detach_mssql_dsource, export_dsource_by_snapshot, export_dsource_by_timestamp, export_dsource_by_location, export_dsource_from_bookmark, export_dsource_to_asm_by_snapshot, export_dsource_to_asm_by_timestamp, export_dsource_to_asm_by_location, export_dsource_to_asm_from_bookmark"
+        }
+
 
 @log_tool_execution
 def snapshot_bookmark_tool(
@@ -3858,13 +7182,13 @@ def snapshot_bookmark_tool(
 ) -> Dict[str, Any]:
     """
     Unified tool for SNAPSHOT BOOKMARK operations.
-    
+
     This tool supports 19 actions: search_snapshots, get_snapshot, update_snapshot, delete_snapshot, unset_snapshot_expiration, get_snapshot_timeflow_range, get_runtime, get_snapshot_tags, add_snapshot_tags, delete_snapshot_tags, search_bookmarks, get_bookmark, create_bookmark, update_bookmark, delete_bookmark, get_bookmark_vdb_groups, get_bookmark_tags, add_bookmark_tags, delete_bookmark_tags
-    
+
     ======================================================================
     ACTION REFERENCE
     ======================================================================
-    
+
     ACTION: search_snapshots
     ----------------------------------------
     Summary: Search snapshots.
@@ -3872,7 +7196,7 @@ def snapshot_bookmark_tool(
     Endpoint: /snapshots/search
     Required Parameters: limit, cursor, sort
     Key Parameters (provide as applicable): filter_expression
-    
+
     Filterable Fields:
         - id: The Snapshot ID.
         - engine_id: The id of the engine the snapshot belongs to.
@@ -3909,26 +7233,26 @@ def snapshot_bookmark_tool(
         - mssql_incremental_export_source_snapshot: True if this snapshot belongs to Incremental VDB and can ...
         - oracle_from_physical_standby_vdb: True if this snapshot was taken of a standby database.
         - oracle_redo_log_size_in_bytes: Online redo log size in bytes when this snapshot was taken.
-        - tags: 
-    
+        - tags:
+
     Filter Syntax:
         Operators: EQ, NE, GT, GE, LT, LE, CONTAINS, IN, NOT_IN
         Combine: AND, OR
         Example: "name CONTAINS 'prod' AND status EQ 'RUNNING'"
-    
+
     Example:
         >>> snapshot_bookmark_tool(action='search_snapshots', limit=..., cursor=..., sort=..., filter_expression="name CONTAINS 'test'")
-    
+
     ACTION: get_snapshot
     ----------------------------------------
     Summary: Get a Snapshot by ID.
     Method: GET
     Endpoint: /snapshots/{snapshotId}
     Required Parameters: snapshot_id
-    
+
     Example:
         >>> snapshot_bookmark_tool(action='get_snapshot', snapshot_id='example-snapshot-123')
-    
+
     ACTION: update_snapshot
     ----------------------------------------
     Summary: Update values of a Snapshot.
@@ -3936,10 +7260,10 @@ def snapshot_bookmark_tool(
     Endpoint: /snapshots/{snapshotId}
     Required Parameters: snapshot_id
     Key Parameters (provide as applicable): expiration, retain_forever
-    
+
     Example:
         >>> snapshot_bookmark_tool(action='update_snapshot', snapshot_id='example-snapshot-123', expiration=..., retain_forever=...)
-    
+
     ACTION: delete_snapshot
     ----------------------------------------
     Summary: Delete a Snapshot.
@@ -3947,60 +7271,60 @@ def snapshot_bookmark_tool(
     Endpoint: /snapshots/{snapshotId}/delete
     Required Parameters: snapshot_id
     Key Parameters (provide as applicable): delete_all_dependencies
-    
+
     Example:
         >>> snapshot_bookmark_tool(action='delete_snapshot', snapshot_id='example-snapshot-123', delete_all_dependencies=...)
-    
+
     ACTION: unset_snapshot_expiration
     ----------------------------------------
     Summary: Unset a Snapshot's expiration, removing expiration and retain_forever values for the snapshot.
     Method: POST
     Endpoint: /snapshots/{snapshotId}/unset_expiration
     Required Parameters: snapshot_id
-    
+
     Example:
         >>> snapshot_bookmark_tool(action='unset_snapshot_expiration', snapshot_id='example-snapshot-123')
-    
+
     ACTION: get_snapshot_timeflow_range
     ----------------------------------------
     Summary: Return the provisionable timeflow range based on a specific snapshot.
     Method: GET
     Endpoint: /snapshots/{snapshotId}/timeflow_range
     Required Parameters: snapshot_id
-    
+
     Example:
         >>> snapshot_bookmark_tool(action='get_snapshot_timeflow_range', snapshot_id='example-snapshot-123')
-    
+
     ACTION: get_runtime
     ----------------------------------------
     Summary: Get a runtime object of a snapshot by id
     Method: GET
     Endpoint: /snapshots/{snapshotId}/runtime
     Required Parameters: snapshot_id
-    
+
     Example:
         >>> snapshot_bookmark_tool(action='get_runtime', snapshot_id='example-snapshot-123')
-    
+
     ACTION: get_snapshot_tags
     ----------------------------------------
     Summary: Get tags for a Snapshot.
     Method: GET
     Endpoint: /snapshots/{snapshotId}/tags
     Required Parameters: snapshot_id
-    
+
     Example:
         >>> snapshot_bookmark_tool(action='get_snapshot_tags', snapshot_id='example-snapshot-123')
-    
+
     ACTION: add_snapshot_tags
     ----------------------------------------
     Summary: Create tags for a Snapshot.
     Method: POST
     Endpoint: /snapshots/{snapshotId}/tags
     Required Parameters: snapshot_id, tags
-    
+
     Example:
         >>> snapshot_bookmark_tool(action='add_snapshot_tags', snapshot_id='example-snapshot-123', tags=...)
-    
+
     ACTION: delete_snapshot_tags
     ----------------------------------------
     Summary: Delete tags for a Snapshot.
@@ -4008,10 +7332,10 @@ def snapshot_bookmark_tool(
     Endpoint: /snapshots/{snapshotId}/tags/delete
     Required Parameters: snapshot_id
     Key Parameters (provide as applicable): tags, key, value
-    
+
     Example:
         >>> snapshot_bookmark_tool(action='delete_snapshot_tags', snapshot_id='example-snapshot-123', tags=..., key=..., value=...)
-    
+
     ACTION: search_bookmarks
     ----------------------------------------
     Summary: Search for bookmarks.
@@ -4019,7 +7343,7 @@ def snapshot_bookmark_tool(
     Endpoint: /bookmarks/search
     Required Parameters: limit, cursor, sort
     Key Parameters (provide as applicable): filter_expression
-    
+
     Filterable Fields:
         - id: The Bookmark object entity ID.
         - name: The user-defined name of this bookmark.
@@ -4054,25 +7378,25 @@ def snapshot_bookmark_tool(
         - primary_bookmark_expiration: The expiration for the primary bookmark.
         - replicas: The list of replicas replicated from this object.
         - tags: The tags to be created for this Bookmark.
-    
+
     Filter Syntax:
         Operators: EQ, NE, GT, GE, LT, LE, CONTAINS, IN, NOT_IN
         Combine: AND, OR
         Example: "name CONTAINS 'prod' AND status EQ 'RUNNING'"
-    
+
     Example:
         >>> snapshot_bookmark_tool(action='search_bookmarks', limit=..., cursor=..., sort=..., filter_expression="name CONTAINS 'test'")
-    
+
     ACTION: get_bookmark
     ----------------------------------------
     Summary: Get a bookmark by ID.
     Method: GET
     Endpoint: /bookmarks/{bookmarkId}
     Required Parameters: bookmark_id
-    
+
     Example:
         >>> snapshot_bookmark_tool(action='get_bookmark', bookmark_id='example-bookmark-123')
-    
+
     ACTION: create_bookmark
     ----------------------------------------
     Summary: Create a bookmark at the current time.
@@ -4080,10 +7404,10 @@ def snapshot_bookmark_tool(
     Endpoint: /bookmarks
     Required Parameters: name
     Key Parameters (provide as applicable): expiration, retain_forever, tags, vdb_ids, vdb_group_id, snapshot_ids, timeflow_ids, timestamp, timestamp_in_database_timezone, location, paas_snapshot_ids, paas_database_ids, paas_instance_ids, retention, bookmark_type, make_current_account_owner, inherit_parent_vdb_tags, inherit_parent_tags
-    
+
     Example:
         >>> snapshot_bookmark_tool(action='create_bookmark', expiration=..., retain_forever=..., tags=..., name=..., vdb_ids=..., vdb_group_id='example-vdb_group-123', snapshot_ids=..., timeflow_ids=..., timestamp=..., timestamp_in_database_timezone=..., location=..., paas_snapshot_ids=..., paas_database_ids=..., paas_instance_ids=..., retention=..., bookmark_type=..., make_current_account_owner=..., inherit_parent_vdb_tags=..., inherit_parent_tags=...)
-    
+
     ACTION: update_bookmark
     ----------------------------------------
     Summary: Update a bookmark
@@ -4091,50 +7415,50 @@ def snapshot_bookmark_tool(
     Endpoint: /bookmarks/{bookmarkId}
     Required Parameters: bookmark_id
     Key Parameters (provide as applicable): expiration, retain_forever, name, bookmark_type
-    
+
     Example:
         >>> snapshot_bookmark_tool(action='update_bookmark', expiration=..., retain_forever=..., bookmark_id='example-bookmark-123', name=..., bookmark_type=...)
-    
+
     ACTION: delete_bookmark
     ----------------------------------------
     Summary: Delete a bookmark.
     Method: DELETE
     Endpoint: /bookmarks/{bookmarkId}
     Required Parameters: bookmark_id
-    
+
     Example:
         >>> snapshot_bookmark_tool(action='delete_bookmark', bookmark_id='example-bookmark-123')
-    
+
     ACTION: get_bookmark_vdb_groups
     ----------------------------------------
     Summary: List VDB Groups compatible with this bookmark.
     Method: GET
     Endpoint: /bookmarks/{bookmarkId}/vdb-groups
     Required Parameters: limit, cursor, sort, bookmark_id
-    
+
     Example:
         >>> snapshot_bookmark_tool(action='get_bookmark_vdb_groups', limit=..., cursor=..., sort=..., bookmark_id='example-bookmark-123')
-    
+
     ACTION: get_bookmark_tags
     ----------------------------------------
     Summary: Get tags for a Bookmark.
     Method: GET
     Endpoint: /bookmarks/{bookmarkId}/tags
     Required Parameters: bookmark_id
-    
+
     Example:
         >>> snapshot_bookmark_tool(action='get_bookmark_tags', bookmark_id='example-bookmark-123')
-    
+
     ACTION: add_bookmark_tags
     ----------------------------------------
     Summary: Create tags for a Bookmark.
     Method: POST
     Endpoint: /bookmarks/{bookmarkId}/tags
     Required Parameters: tags, bookmark_id
-    
+
     Example:
         >>> snapshot_bookmark_tool(action='add_bookmark_tags', tags=..., bookmark_id='example-bookmark-123')
-    
+
     ACTION: delete_bookmark_tags
     ----------------------------------------
     Summary: Delete tags for a Bookmark.
@@ -4142,17 +7466,17 @@ def snapshot_bookmark_tool(
     Endpoint: /bookmarks/{bookmarkId}/tags/delete
     Required Parameters: bookmark_id
     Key Parameters (provide as applicable): tags, key, value
-    
+
     Example:
         >>> snapshot_bookmark_tool(action='delete_bookmark_tags', tags=..., key=..., value=..., bookmark_id='example-bookmark-123')
-    
+
     ======================================================================
     PARAMETERS
     ======================================================================
-    
+
     Args:
         action (str): The operation to perform. One of: search_snapshots, get_snapshot, update_snapshot, delete_snapshot, unset_snapshot_expiration, get_snapshot_timeflow_range, get_runtime, get_snapshot_tags, add_snapshot_tags, delete_snapshot_tags, search_bookmarks, get_bookmark, create_bookmark, update_bookmark, delete_bookmark, get_bookmark_vdb_groups, get_bookmark_tags, add_bookmark_tags, delete_bookmark_tags
-    
+
       -- General parameters (all database types) --
         bookmark_id (str): The unique identifier for the bookmark.
             [Required for: get_bookmark, update_bookmark, delete_bookmark, get_bookmark_vdb_groups, get_bookmark_tags, add_bookmark_tags, delete_bookmark_tags]
@@ -4210,188 +7534,447 @@ def snapshot_bookmark_tool(
             [Optional for all actions]
         vdb_ids (list): The IDs of the VDBs to create the Bookmark on. This parameter is mutually exc...
             [Optional for all actions]
-    
+
     Returns:
         Dict[str, Any]: The API response containing operation results
-    
+
     Raises:
         Returns error dict if required parameters are missing for the action
     """
     # Route to appropriate API based on action
-    if action == 'search_snapshots':
+    if action == "search_snapshots":
         params = build_params(limit=limit, cursor=cursor, sort=sort)
-        body = {'filter_expression': filter_expression} if filter_expression else {}
-        conf = check_confirmation('POST', '/snapshots/search', action, 'snapshot_bookmark_tool', confirmed or False, request_params=params, request_body=body)
+        body = {"filter_expression": filter_expression} if filter_expression else {}
+        conf = check_confirmation(
+            "POST",
+            "/snapshots/search",
+            action,
+            "snapshot_bookmark_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', '/snapshots/search', params=params, json_body=body)
-    elif action == 'get_snapshot':
+        return make_api_request(
+            "POST", "/snapshots/search", params=params, json_body=body
+        )
+    elif action == "get_snapshot":
         if snapshot_id is None:
-            return {'error': 'Missing required parameter: snapshot_id for action get_snapshot'}
-        endpoint = f'/snapshots/{snapshot_id}'
+            return {
+                "error": "Missing required parameter: snapshot_id for action get_snapshot"
+            }
+        endpoint = f"/snapshots/{snapshot_id}"
         params = build_params()
-        conf = check_confirmation('GET', endpoint, action, 'snapshot_bookmark_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            endpoint,
+            action,
+            "snapshot_bookmark_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', endpoint, params=params)
-    elif action == 'update_snapshot':
+        return make_api_request("GET", endpoint, params=params)
+    elif action == "update_snapshot":
         if snapshot_id is None:
-            return {'error': 'Missing required parameter: snapshot_id for action update_snapshot'}
-        endpoint = f'/snapshots/{snapshot_id}'
+            return {
+                "error": "Missing required parameter: snapshot_id for action update_snapshot"
+            }
+        endpoint = f"/snapshots/{snapshot_id}"
         params = build_params()
-        body = {k: v for k, v in {'expiration': expiration, 'retain_forever': retain_forever}.items() if v is not None}
-        conf = check_confirmation('PATCH', endpoint, action, 'snapshot_bookmark_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "expiration": expiration,
+                "retain_forever": retain_forever,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "PATCH",
+            endpoint,
+            action,
+            "snapshot_bookmark_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('PATCH', endpoint, params=params, json_body=body if body else None)
-    elif action == 'delete_snapshot':
+        return make_api_request(
+            "PATCH", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "delete_snapshot":
         if snapshot_id is None:
-            return {'error': 'Missing required parameter: snapshot_id for action delete_snapshot'}
-        endpoint = f'/snapshots/{snapshot_id}/delete'
+            return {
+                "error": "Missing required parameter: snapshot_id for action delete_snapshot"
+            }
+        endpoint = f"/snapshots/{snapshot_id}/delete"
         params = build_params()
-        body = {k: v for k, v in {'delete_all_dependencies': delete_all_dependencies}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'snapshot_bookmark_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {"delete_all_dependencies": delete_all_dependencies}.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "snapshot_bookmark_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'unset_snapshot_expiration':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "unset_snapshot_expiration":
         if snapshot_id is None:
-            return {'error': 'Missing required parameter: snapshot_id for action unset_snapshot_expiration'}
-        endpoint = f'/snapshots/{snapshot_id}/unset_expiration'
+            return {
+                "error": "Missing required parameter: snapshot_id for action unset_snapshot_expiration"
+            }
+        endpoint = f"/snapshots/{snapshot_id}/unset_expiration"
         params = build_params()
-        conf = check_confirmation('POST', endpoint, action, 'snapshot_bookmark_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "snapshot_bookmark_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params)
-    elif action == 'get_snapshot_timeflow_range':
+        return make_api_request("POST", endpoint, params=params)
+    elif action == "get_snapshot_timeflow_range":
         if snapshot_id is None:
-            return {'error': 'Missing required parameter: snapshot_id for action get_snapshot_timeflow_range'}
-        endpoint = f'/snapshots/{snapshot_id}/timeflow_range'
+            return {
+                "error": "Missing required parameter: snapshot_id for action get_snapshot_timeflow_range"
+            }
+        endpoint = f"/snapshots/{snapshot_id}/timeflow_range"
         params = build_params()
-        conf = check_confirmation('GET', endpoint, action, 'snapshot_bookmark_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            endpoint,
+            action,
+            "snapshot_bookmark_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', endpoint, params=params)
-    elif action == 'get_runtime':
+        return make_api_request("GET", endpoint, params=params)
+    elif action == "get_runtime":
         if snapshot_id is None:
-            return {'error': 'Missing required parameter: snapshot_id for action get_runtime'}
-        endpoint = f'/snapshots/{snapshot_id}/runtime'
+            return {
+                "error": "Missing required parameter: snapshot_id for action get_runtime"
+            }
+        endpoint = f"/snapshots/{snapshot_id}/runtime"
         params = build_params()
-        conf = check_confirmation('GET', endpoint, action, 'snapshot_bookmark_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            endpoint,
+            action,
+            "snapshot_bookmark_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', endpoint, params=params)
-    elif action == 'get_snapshot_tags':
+        return make_api_request("GET", endpoint, params=params)
+    elif action == "get_snapshot_tags":
         if snapshot_id is None:
-            return {'error': 'Missing required parameter: snapshot_id for action get_snapshot_tags'}
-        endpoint = f'/snapshots/{snapshot_id}/tags'
+            return {
+                "error": "Missing required parameter: snapshot_id for action get_snapshot_tags"
+            }
+        endpoint = f"/snapshots/{snapshot_id}/tags"
         params = build_params()
-        conf = check_confirmation('GET', endpoint, action, 'snapshot_bookmark_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            endpoint,
+            action,
+            "snapshot_bookmark_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', endpoint, params=params)
-    elif action == 'add_snapshot_tags':
+        return make_api_request("GET", endpoint, params=params)
+    elif action == "add_snapshot_tags":
         if snapshot_id is None:
-            return {'error': 'Missing required parameter: snapshot_id for action add_snapshot_tags'}
-        endpoint = f'/snapshots/{snapshot_id}/tags'
+            return {
+                "error": "Missing required parameter: snapshot_id for action add_snapshot_tags"
+            }
+        endpoint = f"/snapshots/{snapshot_id}/tags"
         params = build_params(tags=tags)
-        body = {k: v for k, v in {'tags': tags}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'snapshot_bookmark_tool', confirmed or False, request_params=params, request_body=body)
+        body = {k: v for k, v in {"tags": tags}.items() if v is not None}
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "snapshot_bookmark_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'delete_snapshot_tags':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "delete_snapshot_tags":
         if snapshot_id is None:
-            return {'error': 'Missing required parameter: snapshot_id for action delete_snapshot_tags'}
-        endpoint = f'/snapshots/{snapshot_id}/tags/delete'
+            return {
+                "error": "Missing required parameter: snapshot_id for action delete_snapshot_tags"
+            }
+        endpoint = f"/snapshots/{snapshot_id}/tags/delete"
         params = build_params()
-        body = {k: v for k, v in {'key': key, 'value': value, 'tags': tags}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'snapshot_bookmark_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {"key": key, "value": value, "tags": tags}.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "snapshot_bookmark_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'search_bookmarks':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "search_bookmarks":
         params = build_params(limit=limit, cursor=cursor, sort=sort)
-        body = {'filter_expression': filter_expression} if filter_expression else {}
-        conf = check_confirmation('POST', '/bookmarks/search', action, 'snapshot_bookmark_tool', confirmed or False, request_params=params, request_body=body)
+        body = {"filter_expression": filter_expression} if filter_expression else {}
+        conf = check_confirmation(
+            "POST",
+            "/bookmarks/search",
+            action,
+            "snapshot_bookmark_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', '/bookmarks/search', params=params, json_body=body)
-    elif action == 'get_bookmark':
+        return make_api_request(
+            "POST", "/bookmarks/search", params=params, json_body=body
+        )
+    elif action == "get_bookmark":
         if bookmark_id is None:
-            return {'error': 'Missing required parameter: bookmark_id for action get_bookmark'}
-        endpoint = f'/bookmarks/{bookmark_id}'
+            return {
+                "error": "Missing required parameter: bookmark_id for action get_bookmark"
+            }
+        endpoint = f"/bookmarks/{bookmark_id}"
         params = build_params()
-        conf = check_confirmation('GET', endpoint, action, 'snapshot_bookmark_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            endpoint,
+            action,
+            "snapshot_bookmark_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', endpoint, params=params)
-    elif action == 'create_bookmark':
+        return make_api_request("GET", endpoint, params=params)
+    elif action == "create_bookmark":
         params = build_params(name=name)
-        body = {k: v for k, v in {'name': name, 'vdb_ids': vdb_ids, 'vdb_group_id': vdb_group_id, 'snapshot_ids': snapshot_ids, 'timeflow_ids': timeflow_ids, 'timestamp': timestamp, 'timestamp_in_database_timezone': timestamp_in_database_timezone, 'location': location, 'paas_snapshot_ids': paas_snapshot_ids, 'paas_database_ids': paas_database_ids, 'paas_instance_ids': paas_instance_ids, 'retention': retention, 'expiration': expiration, 'retain_forever': retain_forever, 'tags': tags, 'bookmark_type': bookmark_type, 'make_current_account_owner': make_current_account_owner, 'inherit_parent_vdb_tags': inherit_parent_vdb_tags, 'inherit_parent_tags': inherit_parent_tags}.items() if v is not None}
-        conf = check_confirmation('POST', '/bookmarks', action, 'snapshot_bookmark_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "name": name,
+                "vdb_ids": vdb_ids,
+                "vdb_group_id": vdb_group_id,
+                "snapshot_ids": snapshot_ids,
+                "timeflow_ids": timeflow_ids,
+                "timestamp": timestamp,
+                "timestamp_in_database_timezone": timestamp_in_database_timezone,
+                "location": location,
+                "paas_snapshot_ids": paas_snapshot_ids,
+                "paas_database_ids": paas_database_ids,
+                "paas_instance_ids": paas_instance_ids,
+                "retention": retention,
+                "expiration": expiration,
+                "retain_forever": retain_forever,
+                "tags": tags,
+                "bookmark_type": bookmark_type,
+                "make_current_account_owner": make_current_account_owner,
+                "inherit_parent_vdb_tags": inherit_parent_vdb_tags,
+                "inherit_parent_tags": inherit_parent_tags,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            "/bookmarks",
+            action,
+            "snapshot_bookmark_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', '/bookmarks', params=params, json_body=body if body else None)
-    elif action == 'update_bookmark':
+        return make_api_request(
+            "POST", "/bookmarks", params=params, json_body=body if body else None
+        )
+    elif action == "update_bookmark":
         if bookmark_id is None:
-            return {'error': 'Missing required parameter: bookmark_id for action update_bookmark'}
-        endpoint = f'/bookmarks/{bookmark_id}'
+            return {
+                "error": "Missing required parameter: bookmark_id for action update_bookmark"
+            }
+        endpoint = f"/bookmarks/{bookmark_id}"
         params = build_params()
-        body = {k: v for k, v in {'name': name, 'expiration': expiration, 'retain_forever': retain_forever, 'bookmark_type': bookmark_type}.items() if v is not None}
-        conf = check_confirmation('PATCH', endpoint, action, 'snapshot_bookmark_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "name": name,
+                "expiration": expiration,
+                "retain_forever": retain_forever,
+                "bookmark_type": bookmark_type,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "PATCH",
+            endpoint,
+            action,
+            "snapshot_bookmark_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('PATCH', endpoint, params=params, json_body=body if body else None)
-    elif action == 'delete_bookmark':
+        return make_api_request(
+            "PATCH", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "delete_bookmark":
         if bookmark_id is None:
-            return {'error': 'Missing required parameter: bookmark_id for action delete_bookmark'}
-        endpoint = f'/bookmarks/{bookmark_id}'
+            return {
+                "error": "Missing required parameter: bookmark_id for action delete_bookmark"
+            }
+        endpoint = f"/bookmarks/{bookmark_id}"
         params = build_params()
-        conf = check_confirmation('DELETE', endpoint, action, 'snapshot_bookmark_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "DELETE",
+            endpoint,
+            action,
+            "snapshot_bookmark_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('DELETE', endpoint, params=params)
-    elif action == 'get_bookmark_vdb_groups':
+        return make_api_request("DELETE", endpoint, params=params)
+    elif action == "get_bookmark_vdb_groups":
         if bookmark_id is None:
-            return {'error': 'Missing required parameter: bookmark_id for action get_bookmark_vdb_groups'}
-        endpoint = f'/bookmarks/{bookmark_id}/vdb-groups'
+            return {
+                "error": "Missing required parameter: bookmark_id for action get_bookmark_vdb_groups"
+            }
+        endpoint = f"/bookmarks/{bookmark_id}/vdb-groups"
         params = build_params(limit=limit, cursor=cursor, sort=sort)
-        conf = check_confirmation('GET', endpoint, action, 'snapshot_bookmark_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            endpoint,
+            action,
+            "snapshot_bookmark_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', endpoint, params=params)
-    elif action == 'get_bookmark_tags':
+        return make_api_request("GET", endpoint, params=params)
+    elif action == "get_bookmark_tags":
         if bookmark_id is None:
-            return {'error': 'Missing required parameter: bookmark_id for action get_bookmark_tags'}
-        endpoint = f'/bookmarks/{bookmark_id}/tags'
+            return {
+                "error": "Missing required parameter: bookmark_id for action get_bookmark_tags"
+            }
+        endpoint = f"/bookmarks/{bookmark_id}/tags"
         params = build_params()
-        conf = check_confirmation('GET', endpoint, action, 'snapshot_bookmark_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            endpoint,
+            action,
+            "snapshot_bookmark_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', endpoint, params=params)
-    elif action == 'add_bookmark_tags':
+        return make_api_request("GET", endpoint, params=params)
+    elif action == "add_bookmark_tags":
         if bookmark_id is None:
-            return {'error': 'Missing required parameter: bookmark_id for action add_bookmark_tags'}
-        endpoint = f'/bookmarks/{bookmark_id}/tags'
+            return {
+                "error": "Missing required parameter: bookmark_id for action add_bookmark_tags"
+            }
+        endpoint = f"/bookmarks/{bookmark_id}/tags"
         params = build_params(tags=tags)
-        body = {k: v for k, v in {'tags': tags}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'snapshot_bookmark_tool', confirmed or False, request_params=params, request_body=body)
+        body = {k: v for k, v in {"tags": tags}.items() if v is not None}
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "snapshot_bookmark_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'delete_bookmark_tags':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "delete_bookmark_tags":
         if bookmark_id is None:
-            return {'error': 'Missing required parameter: bookmark_id for action delete_bookmark_tags'}
-        endpoint = f'/bookmarks/{bookmark_id}/tags/delete'
+            return {
+                "error": "Missing required parameter: bookmark_id for action delete_bookmark_tags"
+            }
+        endpoint = f"/bookmarks/{bookmark_id}/tags/delete"
         params = build_params()
-        body = {k: v for k, v in {'key': key, 'value': value, 'tags': tags}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'snapshot_bookmark_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {"key": key, "value": value, "tags": tags}.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "snapshot_bookmark_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
     else:
-        return {'error': f'Unknown action: {action}. Valid actions: search_snapshots, get_snapshot, update_snapshot, delete_snapshot, unset_snapshot_expiration, get_snapshot_timeflow_range, get_runtime, get_snapshot_tags, add_snapshot_tags, delete_snapshot_tags, search_bookmarks, get_bookmark, create_bookmark, update_bookmark, delete_bookmark, get_bookmark_vdb_groups, get_bookmark_tags, add_bookmark_tags, delete_bookmark_tags'}
+        return {
+            "error": f"Unknown action: {action}. Valid actions: search_snapshots, get_snapshot, update_snapshot, delete_snapshot, unset_snapshot_expiration, get_snapshot_timeflow_range, get_runtime, get_snapshot_tags, add_snapshot_tags, delete_snapshot_tags, search_bookmarks, get_bookmark, create_bookmark, update_bookmark, delete_bookmark, get_bookmark_vdb_groups, get_bookmark_tags, add_bookmark_tags, delete_bookmark_tags"
+        }
+
 
 @log_tool_execution
 def data_connection_tool(
@@ -4409,13 +7992,13 @@ def data_connection_tool(
 ) -> Dict[str, Any]:
     """
     Unified tool for DATA CONNECTION operations.
-    
+
     This tool supports 6 actions: search, get, update, get_tags, add_tags, delete_tags
-    
+
     ======================================================================
     ACTION REFERENCE
     ======================================================================
-    
+
     ACTION: search
     ----------------------------------------
     Summary: Search for data connections.
@@ -4423,7 +8006,7 @@ def data_connection_tool(
     Endpoint: /data-connections/search
     Required Parameters: limit, cursor, sort
     Key Parameters (provide as applicable): filter_expression
-    
+
     Filterable Fields:
         - id: ID of the data connection.
         - name: Name of the data connection.
@@ -4438,25 +8021,25 @@ def data_connection_tool(
         - custom_driver_name: The name of the custom JDBC driver.
         - path: The path to the FILE data on the remote host.
         - size: The size of the data connection in bytes. This is equival...
-    
+
     Filter Syntax:
         Operators: EQ, NE, GT, GE, LT, LE, CONTAINS, IN, NOT_IN
         Combine: AND, OR
         Example: "name CONTAINS 'prod' AND status EQ 'RUNNING'"
-    
+
     Example:
         >>> data_connection_tool(action='search', limit=..., cursor=..., sort=..., filter_expression="name CONTAINS 'test'")
-    
+
     ACTION: get
     ----------------------------------------
     Summary: Get a data connection by id.
     Method: GET
     Endpoint: /data-connections/{dataConnectionId}
     Required Parameters: data_connection_id
-    
+
     Example:
         >>> data_connection_tool(action='get', data_connection_id='example-data_connection-123')
-    
+
     ACTION: update
     ----------------------------------------
     Summary: Update a data connection.
@@ -4464,30 +8047,30 @@ def data_connection_tool(
     Endpoint: /data-connections/{dataConnectionId}
     Required Parameters: data_connection_id
     Key Parameters (provide as applicable): name
-    
+
     Example:
         >>> data_connection_tool(action='update', data_connection_id='example-data_connection-123', name=...)
-    
+
     ACTION: get_tags
     ----------------------------------------
     Summary: Get tags for a data connection.
     Method: GET
     Endpoint: /data-connections/{dataConnectionId}/tags
     Required Parameters: data_connection_id
-    
+
     Example:
         >>> data_connection_tool(action='get_tags', data_connection_id='example-data_connection-123')
-    
+
     ACTION: add_tags
     ----------------------------------------
     Summary: Create tags for a data connection.
     Method: POST
     Endpoint: /data-connections/{dataConnectionId}/tags
     Required Parameters: data_connection_id, tags
-    
+
     Example:
         >>> data_connection_tool(action='add_tags', data_connection_id='example-data_connection-123', tags=...)
-    
+
     ACTION: delete_tags
     ----------------------------------------
     Summary: Delete tags for a data connection.
@@ -4495,17 +8078,17 @@ def data_connection_tool(
     Endpoint: /data-connections/{dataConnectionId}/tags/delete
     Required Parameters: data_connection_id
     Key Parameters (provide as applicable): tags, key, value
-    
+
     Example:
         >>> data_connection_tool(action='delete_tags', data_connection_id='example-data_connection-123', tags=..., key=..., value=...)
-    
+
     ======================================================================
     PARAMETERS
     ======================================================================
-    
+
     Args:
         action (str): The operation to perform. One of: search, get, update, get_tags, add_tags, delete_tags
-    
+
       -- General parameters (all database types) --
         cursor (str): Cursor to fetch the next or previous page of results. The value of this prope...
             [Required for: search]
@@ -4525,71 +8108,144 @@ def data_connection_tool(
             [Required for: add_tags]
         value (str): Value of the tag
             [Optional for all actions]
-    
+
     Returns:
         Dict[str, Any]: The API response containing operation results
-    
+
     Raises:
         Returns error dict if required parameters are missing for the action
     """
     # Route to appropriate API based on action
-    if action == 'search':
+    if action == "search":
         params = build_params(limit=limit, cursor=cursor, sort=sort)
-        body = {'filter_expression': filter_expression} if filter_expression else {}
-        conf = check_confirmation('POST', '/data-connections/search', action, 'data_connection_tool', confirmed or False, request_params=params, request_body=body)
+        body = {"filter_expression": filter_expression} if filter_expression else {}
+        conf = check_confirmation(
+            "POST",
+            "/data-connections/search",
+            action,
+            "data_connection_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', '/data-connections/search', params=params, json_body=body)
-    elif action == 'get':
+        return make_api_request(
+            "POST", "/data-connections/search", params=params, json_body=body
+        )
+    elif action == "get":
         if data_connection_id is None:
-            return {'error': 'Missing required parameter: data_connection_id for action get'}
-        endpoint = f'/data-connections/{data_connection_id}'
+            return {
+                "error": "Missing required parameter: data_connection_id for action get"
+            }
+        endpoint = f"/data-connections/{data_connection_id}"
         params = build_params()
-        conf = check_confirmation('GET', endpoint, action, 'data_connection_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            endpoint,
+            action,
+            "data_connection_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', endpoint, params=params)
-    elif action == 'update':
+        return make_api_request("GET", endpoint, params=params)
+    elif action == "update":
         if data_connection_id is None:
-            return {'error': 'Missing required parameter: data_connection_id for action update'}
-        endpoint = f'/data-connections/{data_connection_id}'
+            return {
+                "error": "Missing required parameter: data_connection_id for action update"
+            }
+        endpoint = f"/data-connections/{data_connection_id}"
         params = build_params()
-        body = {k: v for k, v in {'name': name}.items() if v is not None}
-        conf = check_confirmation('PATCH', endpoint, action, 'data_connection_tool', confirmed or False, request_params=params, request_body=body)
+        body = {k: v for k, v in {"name": name}.items() if v is not None}
+        conf = check_confirmation(
+            "PATCH",
+            endpoint,
+            action,
+            "data_connection_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('PATCH', endpoint, params=params, json_body=body if body else None)
-    elif action == 'get_tags':
+        return make_api_request(
+            "PATCH", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "get_tags":
         if data_connection_id is None:
-            return {'error': 'Missing required parameter: data_connection_id for action get_tags'}
-        endpoint = f'/data-connections/{data_connection_id}/tags'
+            return {
+                "error": "Missing required parameter: data_connection_id for action get_tags"
+            }
+        endpoint = f"/data-connections/{data_connection_id}/tags"
         params = build_params()
-        conf = check_confirmation('GET', endpoint, action, 'data_connection_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            endpoint,
+            action,
+            "data_connection_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', endpoint, params=params)
-    elif action == 'add_tags':
+        return make_api_request("GET", endpoint, params=params)
+    elif action == "add_tags":
         if data_connection_id is None:
-            return {'error': 'Missing required parameter: data_connection_id for action add_tags'}
-        endpoint = f'/data-connections/{data_connection_id}/tags'
+            return {
+                "error": "Missing required parameter: data_connection_id for action add_tags"
+            }
+        endpoint = f"/data-connections/{data_connection_id}/tags"
         params = build_params(tags=tags)
-        body = {k: v for k, v in {'tags': tags}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'data_connection_tool', confirmed or False, request_params=params, request_body=body)
+        body = {k: v for k, v in {"tags": tags}.items() if v is not None}
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "data_connection_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'delete_tags':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "delete_tags":
         if data_connection_id is None:
-            return {'error': 'Missing required parameter: data_connection_id for action delete_tags'}
-        endpoint = f'/data-connections/{data_connection_id}/tags/delete'
+            return {
+                "error": "Missing required parameter: data_connection_id for action delete_tags"
+            }
+        endpoint = f"/data-connections/{data_connection_id}/tags/delete"
         params = build_params()
-        body = {k: v for k, v in {'key': key, 'value': value, 'tags': tags}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'data_connection_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {"key": key, "value": value, "tags": tags}.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "data_connection_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
     else:
-        return {'error': f'Unknown action: {action}. Valid actions: search, get, update, get_tags, add_tags, delete_tags'}
+        return {
+            "error": f"Unknown action: {action}. Valid actions: search, get, update, get_tags, add_tags, delete_tags"
+        }
+
 
 @log_tool_execution
 def timeflow_tool(
@@ -4628,23 +8284,23 @@ def timeflow_tool(
 ) -> Dict[str, Any]:
     """
     Unified tool for TIMEFLOW operations.
-    
+
     This tool supports 10 actions: list, search, get, update, delete, get_snapshot_day_range, repair, get_tags, add_tags, delete_tags
-    
+
     ======================================================================
     ACTION REFERENCE
     ======================================================================
-    
+
     ACTION: list
     ----------------------------------------
     Summary: Retrieve the list of timeflows.
     Method: GET
     Endpoint: /timeflows
     Required Parameters: limit, cursor, sort
-    
+
     Example:
         >>> timeflow_tool(action='list', limit=..., cursor=..., sort=...)
-    
+
     ACTION: search
     ----------------------------------------
     Summary: Search timeflows.
@@ -4652,7 +8308,7 @@ def timeflow_tool(
     Endpoint: /timeflows/search
     Required Parameters: limit, cursor, sort
     Key Parameters (provide as applicable): filter_expression
-    
+
     Filterable Fields:
         - id: The Timeflow ID.
         - engine_id: The ID of the engine the timeflow belongs to.
@@ -4679,26 +8335,26 @@ def timeflow_tool(
         - is_active: Whether this timeflow is currently active or not.
         - creation_timestamp: The time when the timeflow was created.
         - activation_timestamp: The time when this timeflow became active.
-        - tags: 
-    
+        - tags:
+
     Filter Syntax:
         Operators: EQ, NE, GT, GE, LT, LE, CONTAINS, IN, NOT_IN
         Combine: AND, OR
         Example: "name CONTAINS 'prod' AND status EQ 'RUNNING'"
-    
+
     Example:
         >>> timeflow_tool(action='search', limit=..., cursor=..., sort=..., filter_expression="name CONTAINS 'test'")
-    
+
     ACTION: get
     ----------------------------------------
     Summary: Get a Timeflow by ID.
     Method: GET
     Endpoint: /timeflows/{timeflowId}
     Required Parameters: timeflow_id
-    
+
     Example:
         >>> timeflow_tool(action='get', timeflow_id='example-timeflow-123')
-    
+
     ACTION: update
     ----------------------------------------
     Summary: Update values of a timeflow.
@@ -4706,30 +8362,30 @@ def timeflow_tool(
     Endpoint: /timeflows/{timeflowId}
     Required Parameters: timeflow_id
     Key Parameters (provide as applicable): name
-    
+
     Example:
         >>> timeflow_tool(action='update', timeflow_id='example-timeflow-123', name=...)
-    
+
     ACTION: delete
     ----------------------------------------
     Summary: Delete a timeflow.
     Method: DELETE
     Endpoint: /timeflows/{timeflowId}
     Required Parameters: timeflow_id
-    
+
     Example:
         >>> timeflow_tool(action='delete', timeflow_id='example-timeflow-123')
-    
+
     ACTION: get_snapshot_day_range
     ----------------------------------------
     Summary: Returns the count of TimeFlow snapshots of the Timeflow aggregated by day.
     Method: GET
     Endpoint: /timeflows/{timeflowId}/timeflowSnapshotDayRange
     Required Parameters: timeflow_id
-    
+
     Example:
         >>> timeflow_tool(action='get_snapshot_day_range', timeflow_id='example-timeflow-123')
-    
+
     ACTION: repair
     ----------------------------------------
     Summary: Repair a Timeflow.
@@ -4737,30 +8393,30 @@ def timeflow_tool(
     Endpoint: /timeflows/{timeflowId}/repair
     Required Parameters: timeflow_id, host, username, directory, start_location, end_location
     Key Parameters (provide as applicable): port, use_engine_public_key, password, key_pair_private_key, key_pair_public_key, vault_id, hashicorp_vault_engine, hashicorp_vault_secret_path, hashicorp_vault_username_key, hashicorp_vault_secret_key, azure_vault_name, azure_vault_username_key, azure_vault_secret_key, cyberark_vault_query_string, use_kerberos_authentication, ssh_verification_strategy
-    
+
     Example:
         >>> timeflow_tool(action='repair', timeflow_id='example-timeflow-123', host=..., port=..., username=..., directory=..., start_location=..., end_location=..., use_engine_public_key=..., password=..., key_pair_private_key=..., key_pair_public_key=..., vault_id='example-vault-123', hashicorp_vault_engine=..., hashicorp_vault_secret_path=..., hashicorp_vault_username_key=..., hashicorp_vault_secret_key=..., azure_vault_name=..., azure_vault_username_key=..., azure_vault_secret_key=..., cyberark_vault_query_string=..., use_kerberos_authentication=..., ssh_verification_strategy=...)
-    
+
     ACTION: get_tags
     ----------------------------------------
     Summary: Get tags for a Timeflow.
     Method: GET
     Endpoint: /timeflows/{timeflowId}/tags
     Required Parameters: timeflow_id
-    
+
     Example:
         >>> timeflow_tool(action='get_tags', timeflow_id='example-timeflow-123')
-    
+
     ACTION: add_tags
     ----------------------------------------
     Summary: Create tags for a Timeflow.
     Method: POST
     Endpoint: /timeflows/{timeflowId}/tags
     Required Parameters: timeflow_id, tags
-    
+
     Example:
         >>> timeflow_tool(action='add_tags', timeflow_id='example-timeflow-123', tags=...)
-    
+
     ACTION: delete_tags
     ----------------------------------------
     Summary: Delete tags for a Timeflow.
@@ -4768,17 +8424,17 @@ def timeflow_tool(
     Endpoint: /timeflows/{timeflowId}/tags/delete
     Required Parameters: timeflow_id
     Key Parameters (provide as applicable): tags, key, value
-    
+
     Example:
         >>> timeflow_tool(action='delete_tags', timeflow_id='example-timeflow-123', tags=..., key=..., value=...)
-    
+
     ======================================================================
     PARAMETERS
     ======================================================================
-    
+
     Args:
         action (str): The operation to perform. One of: list, search, get, update, delete, get_snapshot_day_range, repair, get_tags, add_tags, delete_tags
-    
+
       -- General parameters (all database types) --
         azure_vault_name (str): Azure key vault name (ORACLE, ASE and MSSQL_DOMAIN_USER only).
             [Optional for all actions]
@@ -4840,120 +8496,262 @@ def timeflow_tool(
             [Optional for all actions]
         vault_id (str): The DCT id or name of the vault from which to read the host credentials.
             [Optional for all actions]
-    
+
     Returns:
         Dict[str, Any]: The API response containing operation results
-    
+
     Raises:
         Returns error dict if required parameters are missing for the action
     """
     # Route to appropriate API based on action
-    if action == 'list':
+    if action == "list":
         params = build_params(limit=limit, cursor=cursor, sort=sort)
-        conf = check_confirmation('GET', '/timeflows', action, 'timeflow_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            "/timeflows",
+            action,
+            "timeflow_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', '/timeflows', params=params)
-    elif action == 'search':
+        return make_api_request("GET", "/timeflows", params=params)
+    elif action == "search":
         params = build_params(limit=limit, cursor=cursor, sort=sort)
-        body = {'filter_expression': filter_expression} if filter_expression else {}
-        conf = check_confirmation('POST', '/timeflows/search', action, 'timeflow_tool', confirmed or False, request_params=params, request_body=body)
+        body = {"filter_expression": filter_expression} if filter_expression else {}
+        conf = check_confirmation(
+            "POST",
+            "/timeflows/search",
+            action,
+            "timeflow_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', '/timeflows/search', params=params, json_body=body)
-    elif action == 'get':
+        return make_api_request(
+            "POST", "/timeflows/search", params=params, json_body=body
+        )
+    elif action == "get":
         if timeflow_id is None:
-            return {'error': 'Missing required parameter: timeflow_id for action get'}
-        endpoint = f'/timeflows/{timeflow_id}'
+            return {"error": "Missing required parameter: timeflow_id for action get"}
+        endpoint = f"/timeflows/{timeflow_id}"
         params = build_params()
-        conf = check_confirmation('GET', endpoint, action, 'timeflow_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            endpoint,
+            action,
+            "timeflow_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', endpoint, params=params)
-    elif action == 'update':
+        return make_api_request("GET", endpoint, params=params)
+    elif action == "update":
         if timeflow_id is None:
-            return {'error': 'Missing required parameter: timeflow_id for action update'}
-        endpoint = f'/timeflows/{timeflow_id}'
+            return {
+                "error": "Missing required parameter: timeflow_id for action update"
+            }
+        endpoint = f"/timeflows/{timeflow_id}"
         params = build_params()
-        body = {k: v for k, v in {'name': name}.items() if v is not None}
-        conf = check_confirmation('PATCH', endpoint, action, 'timeflow_tool', confirmed or False, request_params=params, request_body=body)
+        body = {k: v for k, v in {"name": name}.items() if v is not None}
+        conf = check_confirmation(
+            "PATCH",
+            endpoint,
+            action,
+            "timeflow_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('PATCH', endpoint, params=params, json_body=body if body else None)
-    elif action == 'delete':
+        return make_api_request(
+            "PATCH", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "delete":
         if timeflow_id is None:
-            return {'error': 'Missing required parameter: timeflow_id for action delete'}
-        endpoint = f'/timeflows/{timeflow_id}'
+            return {
+                "error": "Missing required parameter: timeflow_id for action delete"
+            }
+        endpoint = f"/timeflows/{timeflow_id}"
         params = build_params()
-        conf = check_confirmation('DELETE', endpoint, action, 'timeflow_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "DELETE",
+            endpoint,
+            action,
+            "timeflow_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('DELETE', endpoint, params=params)
-    elif action == 'get_snapshot_day_range':
+        return make_api_request("DELETE", endpoint, params=params)
+    elif action == "get_snapshot_day_range":
         if timeflow_id is None:
-            return {'error': 'Missing required parameter: timeflow_id for action get_snapshot_day_range'}
-        endpoint = f'/timeflows/{timeflow_id}/timeflowSnapshotDayRange'
+            return {
+                "error": "Missing required parameter: timeflow_id for action get_snapshot_day_range"
+            }
+        endpoint = f"/timeflows/{timeflow_id}/timeflowSnapshotDayRange"
         params = build_params()
-        conf = check_confirmation('GET', endpoint, action, 'timeflow_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            endpoint,
+            action,
+            "timeflow_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', endpoint, params=params)
-    elif action == 'repair':
+        return make_api_request("GET", endpoint, params=params)
+    elif action == "repair":
         if timeflow_id is None:
-            return {'error': 'Missing required parameter: timeflow_id for action repair'}
-        endpoint = f'/timeflows/{timeflow_id}/repair'
-        params = build_params(host=host, username=username, directory=directory, start_location=start_location, end_location=end_location)
-        body = {k: v for k, v in {'host': host, 'port': port, 'username': username, 'directory': directory, 'start_location': start_location, 'end_location': end_location, 'use_engine_public_key': use_engine_public_key, 'password': password, 'key_pair_private_key': key_pair_private_key, 'key_pair_public_key': key_pair_public_key, 'vault_id': vault_id, 'hashicorp_vault_engine': hashicorp_vault_engine, 'hashicorp_vault_secret_path': hashicorp_vault_secret_path, 'hashicorp_vault_username_key': hashicorp_vault_username_key, 'hashicorp_vault_secret_key': hashicorp_vault_secret_key, 'azure_vault_name': azure_vault_name, 'azure_vault_username_key': azure_vault_username_key, 'azure_vault_secret_key': azure_vault_secret_key, 'cyberark_vault_query_string': cyberark_vault_query_string, 'use_kerberos_authentication': use_kerberos_authentication, 'sshVerificationStrategy': ssh_verification_strategy}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'timeflow_tool', confirmed or False, request_params=params, request_body=body)
+            return {
+                "error": "Missing required parameter: timeflow_id for action repair"
+            }
+        endpoint = f"/timeflows/{timeflow_id}/repair"
+        params = build_params(
+            host=host,
+            username=username,
+            directory=directory,
+            start_location=start_location,
+            end_location=end_location,
+        )
+        body = {
+            k: v
+            for k, v in {
+                "host": host,
+                "port": port,
+                "username": username,
+                "directory": directory,
+                "start_location": start_location,
+                "end_location": end_location,
+                "use_engine_public_key": use_engine_public_key,
+                "password": password,
+                "key_pair_private_key": key_pair_private_key,
+                "key_pair_public_key": key_pair_public_key,
+                "vault_id": vault_id,
+                "hashicorp_vault_engine": hashicorp_vault_engine,
+                "hashicorp_vault_secret_path": hashicorp_vault_secret_path,
+                "hashicorp_vault_username_key": hashicorp_vault_username_key,
+                "hashicorp_vault_secret_key": hashicorp_vault_secret_key,
+                "azure_vault_name": azure_vault_name,
+                "azure_vault_username_key": azure_vault_username_key,
+                "azure_vault_secret_key": azure_vault_secret_key,
+                "cyberark_vault_query_string": cyberark_vault_query_string,
+                "use_kerberos_authentication": use_kerberos_authentication,
+                "sshVerificationStrategy": ssh_verification_strategy,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "timeflow_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'get_tags':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "get_tags":
         if timeflow_id is None:
-            return {'error': 'Missing required parameter: timeflow_id for action get_tags'}
-        endpoint = f'/timeflows/{timeflow_id}/tags'
+            return {
+                "error": "Missing required parameter: timeflow_id for action get_tags"
+            }
+        endpoint = f"/timeflows/{timeflow_id}/tags"
         params = build_params()
-        conf = check_confirmation('GET', endpoint, action, 'timeflow_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            endpoint,
+            action,
+            "timeflow_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', endpoint, params=params)
-    elif action == 'add_tags':
+        return make_api_request("GET", endpoint, params=params)
+    elif action == "add_tags":
         if timeflow_id is None:
-            return {'error': 'Missing required parameter: timeflow_id for action add_tags'}
-        endpoint = f'/timeflows/{timeflow_id}/tags'
+            return {
+                "error": "Missing required parameter: timeflow_id for action add_tags"
+            }
+        endpoint = f"/timeflows/{timeflow_id}/tags"
         params = build_params(tags=tags)
-        body = {k: v for k, v in {'tags': tags}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'timeflow_tool', confirmed or False, request_params=params, request_body=body)
+        body = {k: v for k, v in {"tags": tags}.items() if v is not None}
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "timeflow_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'delete_tags':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "delete_tags":
         if timeflow_id is None:
-            return {'error': 'Missing required parameter: timeflow_id for action delete_tags'}
-        endpoint = f'/timeflows/{timeflow_id}/tags/delete'
+            return {
+                "error": "Missing required parameter: timeflow_id for action delete_tags"
+            }
+        endpoint = f"/timeflows/{timeflow_id}/tags/delete"
         params = build_params()
-        body = {k: v for k, v in {'key': key, 'value': value, 'tags': tags}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'timeflow_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {"key": key, "value": value, "tags": tags}.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "timeflow_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
     else:
-        return {'error': f'Unknown action: {action}. Valid actions: list, search, get, update, delete, get_snapshot_day_range, repair, get_tags, add_tags, delete_tags'}
+        return {
+            "error": f"Unknown action: {action}. Valid actions: list, search, get, update, delete, get_snapshot_day_range, repair, get_tags, add_tags, delete_tags"
+        }
 
 
 def register_tools(app, dct_client):
     global client
     client = dct_client
-    logger.info(f'Registering tools for dataset_endpoints...')
+    logger.info("Registering tools for dataset_endpoints...")
     try:
-        logger.info(f'  Registering tool function: data_tool')
+        logger.info("  Registering tool function: data_tool")
         app.add_tool(data_tool, name="data_tool")
-        logger.info(f'  Registering tool function: snapshot_bookmark_tool')
+        logger.info("  Registering tool function: snapshot_bookmark_tool")
         app.add_tool(snapshot_bookmark_tool, name="snapshot_bookmark_tool")
-        logger.info(f'  Registering tool function: data_connection_tool')
+        logger.info("  Registering tool function: data_connection_tool")
         app.add_tool(data_connection_tool, name="data_connection_tool")
-        logger.info(f'  Registering tool function: timeflow_tool')
+        logger.info("  Registering tool function: timeflow_tool")
         app.add_tool(timeflow_tool, name="timeflow_tool")
     except Exception as e:
-        logger.error(f'Error registering tools for dataset_endpoints: {e}')
-    logger.info(f'Tools registration finished for dataset_endpoints.')
+        logger.error(f"Error registering tools for dataset_endpoints: {e}")
+    logger.info("Tools registration finished for dataset_endpoints.")

--- a/src/dct_mcp_server/tools/engine_endpoints_tool.py
+++ b/src/dct_mcp_server/tools/engine_endpoints_tool.py
@@ -1,7 +1,6 @@
-from mcp.server.fastmcp import FastMCP
-from typing import Dict,Any,Optional
+from typing import Dict, Any, Optional
 from dct_mcp_server.core.decorators import log_tool_execution
-from dct_mcp_server.config import get_confirmation_for_operation, requires_confirmation
+from dct_mcp_server.config import get_confirmation_for_operation
 import asyncio
 import logging
 import threading
@@ -29,7 +28,16 @@ logger = logging.getLogger(__name__)
 #       }
 # =============================================================================
 
-def check_confirmation(method: str, api_path: str, action: str, tool_name: str, confirmed: bool = False, request_params: Optional[Dict[str, Any]] = None, request_body: Optional[Dict[str, Any]] = None) -> Optional[Dict[str, Any]]:
+
+def check_confirmation(
+    method: str,
+    api_path: str,
+    action: str,
+    tool_name: str,
+    confirmed: bool = False,
+    request_params: Optional[Dict[str, Any]] = None,
+    request_body: Optional[Dict[str, Any]] = None,
+) -> Optional[Dict[str, Any]]:
     """Check if operation requires confirmation. Returns confirmation response or None if confirmed/not needed."""
     confirmation = get_confirmation_for_operation(method, api_path)
     if confirmation["level"] != "none" and not confirmed:
@@ -41,7 +49,11 @@ def check_confirmation(method: str, api_path: str, action: str, tool_name: str, 
             review.update(request_params)
         if request_body:
             review.update(request_body)
-        is_review_critical = action.startswith("provision_") or action.startswith("dsource_link_") or action == "dsource_create_snapshot"
+        is_review_critical = (
+            action.startswith("provision_")
+            or action.startswith("dsource_link_")
+            or action == "dsource_create_snapshot"
+        )
         instructions = (
             "STOP: You MUST display the confirmation_message to the user and wait for their EXPLICIT "
             "approval before re-calling with confirmed=True. Do NOT proceed without user consent."
@@ -56,7 +68,9 @@ def check_confirmation(method: str, api_path: str, action: str, tool_name: str, 
         return {
             "status": "confirmation_required",
             "confirmation_level": confirmation["level"],
-            "confirmation_message": confirmation.get("message", "Please confirm this operation."),
+            "confirmation_message": confirmation.get(
+                "message", "Please confirm this operation."
+            ),
             "action": action,
             "tool": tool_name,
             "api_path": api_path,
@@ -66,8 +80,10 @@ def check_confirmation(method: str, api_path: str, action: str, tool_name: str, 
         }
     return None
 
+
 def async_to_sync(async_func):
     """Utility decorator to convert async functions to sync with proper event loop handling."""
+
     @wraps(async_func)
     def wrapper(*args, **kwargs):
         try:
@@ -76,12 +92,14 @@ def async_to_sync(async_func):
                 # Create a task and run it synchronously
                 result = None
                 exception = None
+
                 def run_in_thread():
                     nonlocal result, exception
                     try:
                         result = asyncio.run(async_func(*args, **kwargs))
                     except Exception as e:
                         exception = e
+
                 thread = threading.Thread(target=run_in_thread)
                 thread.start()
                 thread.join()
@@ -92,18 +110,28 @@ def async_to_sync(async_func):
                 return loop.run_until_complete(async_func(*args, **kwargs))
         except RuntimeError:
             return asyncio.run(async_func(*args, **kwargs))
+
     return wrapper
 
-def make_api_request(method: str, endpoint: str, params: dict = None, json_body: dict = None):
+
+def make_api_request(
+    method: str, endpoint: str, params: dict = None, json_body: dict = None
+):
     """Utility function to make API requests with consistent parameter handling."""
+
     @async_to_sync
     async def _make_request():
-        return await client.make_request(method, endpoint, params=params or {}, json=json_body)
+        return await client.make_request(
+            method, endpoint, params=params or {}, json=json_body
+        )
+
     return _make_request()
+
 
 def build_params(**kwargs):
     """Build parameters dictionary excluding None and empty string values."""
-    return {k: v for k, v in kwargs.items() if v is not None and v != ''}
+    return {k: v for k, v in kwargs.items() if v is not None and v != ""}
+
 
 @log_tool_execution
 def engine_tool(
@@ -162,424 +190,616 @@ def engine_tool(
     confirmed: Optional[bool] = None,
 ) -> Dict[str, Any]:
     """
-    Unified tool for ENGINE operations.
-    
-    This tool supports 11 actions: search, get, update, get_tags, add_tags, delete_tags, register, unregister, get_auto_tagging, get_compliance_settings, search_compliance_settings
-    
-    ======================================================================
-    ACTION REFERENCE
-    ======================================================================
-    
-    ACTION: search
-    ----------------------------------------
-    Summary: Search for engines.
-    Method: POST
-    Endpoint: /management/engines/search
-    Required Parameters: limit, cursor, sort
-    Key Parameters (provide as applicable): filter_expression
-    
-    Filterable Fields:
-        - id: The Engine object entity ID.
-        - uuid: The unique identifier generated by this engine.
-        - type: The type of this engine.
-        - version: The engine version.
-        - name: The name of this engine.
-        - ssh_public_key: The ssh public key of this engine.
-        - hostname: The hostname of this engine.
-        - cpu_core_count: The total number of CPU cores on this engine.
-        - memory_size: The total amount of memory on this engine, in bytes.
-        - data_storage_capacity: The total amount of storage allocated for engine objects ...
-        - data_storage_used: The amount of storage used by engine objects and system m...
-        - insecure_ssl: Allow connections to the engine over HTTPs without valida...
-        - unsafe_ssl_hostname_check: Ignore validation of the name associated to the TLS certi...
-        - status: the status of the engine
+        Unified tool for ENGINE operations.
 
-        - connection_status: The status of the connection to the engine. Deprecated; u...
-        - engine_connection_status: The state of the connection to the engine.
-        - connection_status_details: If set, details about the status of the connection to the...
-        - engine_connection_status_details: If set, details about the state of the connection to the ...
-        - username: The virtualization domain admin username.
-        - password: The virtualization domain admin password.
-        - masking_username: The masking admin username.
-        - masking_password: The masking admin password.
-        - hashicorp_vault_username_command_args: Arguments to pass to the Vault CLI tool to retrieve the v...
-        - hashicorp_vault_masking_username_command_args: Arguments to pass to the Vault CLI tool to retrieve the m...
-        - hashicorp_vault_password_command_args: Arguments to pass to the Vault CLI tool to retrieve the v...
-        - hashicorp_vault_masking_password_command_args: Arguments to pass to the Vault CLI tool to retrieve the m...
-        - masking_hashicorp_vault_id: Reference to the Hashicorp vault to use to retrieve maski...
-        - hashicorp_vault_id: Reference to the Hashicorp vault to use to retrieve virtu...
-        - tags: The tags to be created for this engine.
-        - masking_memory_used: The current amount of memory used by running masking jobs...
-        - masking_allocated_memory: The maximum amount of memory available for running maskin...
-        - masking_jobs_running: The number of masking jobs currently running.
-        - masking_max_concurrent_jobs: The maximum number of masking jobs that can be running at...
-        - masking_available_cores: The number of CPU cores available to the masking engine.
-        - hyperscale_instance_ids: List of Hyperscale Instances that this engine is connecte...
-        - hyperscale_truststore_filename: File name of a truststore which can be used to validate t...
-        - hyperscale_truststore_password: Password to read the truststore as expected by associated...
-        - using_object_storage: true if the engine is using an object store (like AWS S3)...
-        - using_continuous_vault: true if the engine is using an object store (like AWS S3)...
-        - platform: The infrastructure or environment where the engine is dep...
-        - storage_cache_bytes: Total number of bytes of storage reserved for storage cache
-        - priority_cache_max_bytes: Total number of bytes of storage available for VDB priori...
-        - priority_cache_used_bytes: Total number of bytes of storage allocated to existing pr...
-    
-    Filter Syntax:
-        Operators: EQ, NE, GT, GE, LT, LE, CONTAINS, IN, NOT_IN
-        Combine: AND, OR
-        Example: "name CONTAINS 'prod' AND status EQ 'RUNNING'"
-    
-    Example:
-        >>> engine_tool(action='search', limit=..., cursor=..., sort=..., filter_expression="name CONTAINS 'test'")
-    
-    ACTION: get
-    ----------------------------------------
-    Summary: Returns a registered engine by ID.
-    Method: GET
-    Endpoint: /management/engines/{engineId}
-    Required Parameters: engine_id
-    
-    Example:
-        >>> engine_tool(action='get', engine_id='example-engine-123')
-    
-    ACTION: update
-    ----------------------------------------
-    Summary: Update a registered engine.
-    Method: PATCH
-    Endpoint: /management/engines/{engineId}
-    Required Parameters: engine_id
-    Key Parameters (provide as applicable): id, uuid, type, version, name, ssh_public_key, hostname, cpu_core_count, memory_size, data_storage_capacity, data_storage_used, insecure_ssl, unsafe_ssl_hostname_check, status, connection_status, engine_connection_status, connection_status_details, engine_connection_status_details, username, password, masking_username, masking_password, hashicorp_vault_username_command_args, hashicorp_vault_masking_username_command_args, hashicorp_vault_password_command_args, hashicorp_vault_masking_password_command_args, masking_hashicorp_vault_id, hashicorp_vault_id, tags, masking_memory_used, masking_allocated_memory, masking_jobs_running, masking_max_concurrent_jobs, masking_available_cores, hyperscale_instance_ids, hyperscale_truststore_filename, hyperscale_truststore_password, using_object_storage, using_continuous_vault, platform, storage_cache_bytes, priority_cache_max_bytes, priority_cache_used_bytes
-    
-    Example:
-        >>> engine_tool(action='update', engine_id='example-engine-123', id=..., uuid=..., type=..., version=..., name=..., ssh_public_key=..., hostname=..., cpu_core_count=..., memory_size=..., data_storage_capacity=..., data_storage_used=..., insecure_ssl=..., unsafe_ssl_hostname_check=..., status=..., connection_status=..., engine_connection_status=..., connection_status_details=..., engine_connection_status_details=..., username=..., password=..., masking_username=..., masking_password=..., hashicorp_vault_username_command_args=..., hashicorp_vault_masking_username_command_args=..., hashicorp_vault_password_command_args=..., hashicorp_vault_masking_password_command_args=..., masking_hashicorp_vault_id='example-masking_hashicorp_vault-123', hashicorp_vault_id='example-hashicorp_vault-123', tags=..., masking_memory_used=..., masking_allocated_memory=..., masking_jobs_running=..., masking_max_concurrent_jobs=..., masking_available_cores=..., hyperscale_instance_ids=..., hyperscale_truststore_filename=..., hyperscale_truststore_password=..., using_object_storage=..., using_continuous_vault=..., platform=..., storage_cache_bytes=..., priority_cache_max_bytes=..., priority_cache_used_bytes=...)
-    
-    ACTION: get_tags
-    ----------------------------------------
-    Summary: Get tags for a Engine.
-    Method: GET
-    Endpoint: /management/engines/{engineId}/tags
-    Required Parameters: engine_id
-    
-    Example:
-        >>> engine_tool(action='get_tags', engine_id='example-engine-123')
-    
-    ACTION: add_tags
-    ----------------------------------------
-    Summary: Create tags for an Engine.
-    Method: POST
-    Endpoint: /management/engines/{engineId}/tags
-    Required Parameters: engine_id, tags
-    
-    Example:
-        >>> engine_tool(action='add_tags', engine_id='example-engine-123', tags=...)
-    
-    ACTION: delete_tags
-    ----------------------------------------
-    Summary: Delete tags for an Engine.
-    Method: POST
-    Endpoint: /management/engines/{engineId}/tags/delete
-    Required Parameters: engine_id
-    Key Parameters (provide as applicable): tags, key, value
-    
-    Example:
-        >>> engine_tool(action='delete_tags', engine_id='example-engine-123', tags=..., key=..., value=...)
-    
-    ACTION: register
-    ----------------------------------------
-    Summary: Register an engine.
-    Method: POST
-    Endpoint: /management/engines
-    Required Parameters: name, hostname
-    Key Parameters (provide as applicable): insecure_ssl, unsafe_ssl_hostname_check, username, password, masking_username, masking_password, hashicorp_vault_username_command_args, hashicorp_vault_masking_username_command_args, hashicorp_vault_password_command_args, hashicorp_vault_masking_password_command_args, masking_hashicorp_vault_id, hashicorp_vault_id, tags, auto_tagging_config
-    
-    Example:
-        >>> engine_tool(action='register', name=..., hostname=..., insecure_ssl=..., unsafe_ssl_hostname_check=..., username=..., password=..., masking_username=..., masking_password=..., hashicorp_vault_username_command_args=..., hashicorp_vault_masking_username_command_args=..., hashicorp_vault_password_command_args=..., hashicorp_vault_masking_password_command_args=..., masking_hashicorp_vault_id='example-masking_hashicorp_vault-123', hashicorp_vault_id='example-hashicorp_vault-123', tags=..., auto_tagging_config=...)
-    
-    ACTION: unregister
-    ----------------------------------------
-    Summary: Unregister an engine.
-    Method: DELETE
-    Endpoint: /management/engines/{engineId}
-    Required Parameters: engine_id
-    
-    Example:
-        >>> engine_tool(action='unregister', engine_id='example-engine-123')
-    
-    ACTION: get_auto_tagging
-    ----------------------------------------
-    Summary: Returns the engine's auto tagging configuration.
-    Method: GET
-    Endpoint: /management/engines/{engineId}/auto-tagging
-    Required Parameters: engine_id
-    
-    Example:
-        >>> engine_tool(action='get_auto_tagging', engine_id='example-engine-123')
-    
-    ACTION: get_compliance_settings
-    ----------------------------------------
-    Summary: Returns a compliance engine's application settings.
-    Method: GET
-    Endpoint: /management/engines/{engineId}/compliance-application-settings
-    Required Parameters: limit, cursor, sort, engine_id
-    
-    Example:
-        >>> engine_tool(action='get_compliance_settings', limit=..., cursor=..., sort=..., engine_id='example-engine-123')
-    
-    ACTION: search_compliance_settings
-    ----------------------------------------
-    Summary: Search a compliance engine's application settings.
-    Method: POST
-    Endpoint: /management/engines/{engineId}/compliance-application-settings/search
-    Required Parameters: limit, cursor, sort, engine_id
-    Key Parameters (provide as applicable): filter_expression
-    
-    Filterable Fields:
-        - id: The ID of the application setting.
-        - group: The group of the application setting.
-        - name: The name of the application setting.
-        - value: The value of the application setting.
-        - value_type: The type of the value of the application setting.
-    
-    Filter Syntax:
-        Operators: EQ, NE, GT, GE, LT, LE, CONTAINS, IN, NOT_IN
-        Combine: AND, OR
-        Example: "name CONTAINS 'prod' AND status EQ 'RUNNING'"
-    
-    Example:
-        >>> engine_tool(action='search_compliance_settings', limit=..., cursor=..., sort=..., filter_expression="name CONTAINS 'test'", engine_id='example-engine-123')
-    
-    ======================================================================
-    PARAMETERS
-    ======================================================================
-    
-    Args:
-        action (str): The operation to perform. One of: search, get, update, get_tags, add_tags, delete_tags, register, unregister, get_auto_tagging, get_compliance_settings, search_compliance_settings
-    
-      -- General parameters (all database types) --
-        auto_tagging_config (dict): Configuration settings for auto tagging. (Pass as JSON object)
-            [Optional for all actions]
-        connection_status (str): The status of the connection to the engine. Deprecated; use "engine_connectio...
-            [Optional for all actions]
-        connection_status_details (str): If set, details about the status of the connection to the engine. Deprecated;...
-            [Optional for all actions]
-        cpu_core_count (int): The total number of CPU cores on this engine.
-            [Optional for all actions]
-        cursor (str): Cursor to fetch the next or previous page of results. The value of this prope...
-            [Required for: search, get_compliance_settings, search_compliance_settings]
-        data_storage_capacity (int): The total amount of storage allocated for engine objects and system metadata,...
-            [Optional for all actions]
-        data_storage_used (int): The amount of storage used by engine objects and system metadata, in bytes.
-            [Optional for all actions]
-        engine_connection_status (str): The state of the connection to the engine. Valid values: ONLINE, CONNECTION_E...
-            [Optional for all actions]
-        engine_connection_status_details (str): If set, details about the state of the connection to the engine.
-            [Optional for all actions]
-        engine_id (str): The unique identifier for the engine.
-            [Required for: get, update, get_tags, add_tags, delete_tags, unregister, get_auto_tagging, get_compliance_settings, search_compliance_settings]
-        filter_expression (str): Request body parameter
-            [Optional for all actions]
-        hashicorp_vault_id (int): Reference to the Hashicorp vault to use to retrieve virtualization engine cre...
-            [Optional for all actions]
-        hashicorp_vault_masking_password_command_args (list): Arguments to pass to the Vault CLI tool to retrieve the masking password for ...
-            [Optional for all actions]
-        hashicorp_vault_masking_username_command_args (list): Arguments to pass to the Vault CLI tool to retrieve the masking username for ...
-            [Optional for all actions]
-        hashicorp_vault_password_command_args (list): Arguments to pass to the Vault CLI tool to retrieve the virtualization passwo...
-            [Optional for all actions]
-        hashicorp_vault_username_command_args (list): Arguments to pass to the Vault CLI tool to retrieve the virtualization userna...
-            [Optional for all actions]
-        hostname (str): The hostname of this engine.
-            [Required for: register]
-        hyperscale_instance_ids (list): List of Hyperscale Instances that this engine is connected to. (Pass as JSON ...
-            [Optional for all actions]
-        hyperscale_truststore_filename (str): File name of a truststore which can be used to validate the TLS certificate o...
-            [Optional for all actions]
-        hyperscale_truststore_password (str): Password to read the truststore as expected by associated hyperscale instances.
+        This tool supports 11 actions: search, get, update, get_tags, add_tags, delete_tags, register, unregister, get_auto_tagging, get_compliance_settings, search_compliance_settings
 
-            [Optional for all actions]
-        id (str): The Engine object entity ID.
-            [Optional for all actions]
-        insecure_ssl (bool): Allow connections to the engine over HTTPs without validating the TLS certifi...
-            [Optional for all actions]
-        key (str): Key of the tag
-            [Optional for all actions]
-        limit (int): Maximum number of objects to return per query. The value must be between 1 an...
-            [Required for: search, get_compliance_settings, search_compliance_settings]
-        masking_allocated_memory (int): The maximum amount of memory available for running masking jobs in bytes.
-            [Optional for all actions]
-        masking_available_cores (int): The number of CPU cores available to the masking engine.
-            [Optional for all actions]
-        masking_hashicorp_vault_id (int): Reference to the Hashicorp vault to use to retrieve masking engine credentials.
-            [Optional for all actions]
-        masking_jobs_running (int): The number of masking jobs currently running.
-            [Optional for all actions]
-        masking_max_concurrent_jobs (int): The maximum number of masking jobs that can be running at the same time.
-            [Optional for all actions]
-        masking_memory_used (int): The current amount of memory used by running masking jobs in bytes.
-            [Optional for all actions]
-        masking_password (str): The masking admin password.
-            [Optional for all actions]
-        masking_username (str): The masking admin username.
-            [Optional for all actions]
-        memory_size (int): The total amount of memory on this engine, in bytes.
-            [Optional for all actions]
-        name (str): The name of this engine.
-            [Required for: register]
-        password (str): The virtualization domain admin password.
-            [Optional for all actions]
-        platform (str): The infrastructure or environment where the engine is deployed or built, incl...
-            [Optional for all actions]
-        priority_cache_max_bytes (int): Total number of bytes of storage available for VDB priority caching
-            [Optional for all actions]
-        priority_cache_used_bytes (int): Total number of bytes of storage allocated to existing priority cache enabled...
-            [Optional for all actions]
-        sort (str): The field to sort results by. A property name with a prepended '-' signifies ...
-            [Required for: search, get_compliance_settings, search_compliance_settings]
-        ssh_public_key (str): The ssh public key of this engine.
-            [Optional for all actions]
-        status (str): the status of the engine
- Valid values: CREATED, DELETING.
-            [Optional for all actions]
-        storage_cache_bytes (int): Total number of bytes of storage reserved for storage cache
-            [Optional for all actions]
-        tags (list): The tags to be created for this engine. (Pass as JSON array)
-            [Required for: add_tags]
-        type (str): The type of this engine. Valid values: VIRTUALIZATION, MASKING, BOTH, UNSET.
-            [Optional for all actions]
-        unsafe_ssl_hostname_check (bool): Ignore validation of the name associated to the TLS certificate when connecti...
-            [Optional for all actions]
-        username (str): The virtualization domain admin username.
-            [Optional for all actions]
-        using_continuous_vault (bool): true if the engine is using an object store (like AWS S3) to store data |
-fal...
-            [Optional for all actions]
-        using_object_storage (bool): true if the engine is using an object store (like AWS S3) to store data |
-fal...
-            [Optional for all actions]
-        uuid (str): The unique identifier generated by this engine.
-            [Optional for all actions]
-        value (str): Value of the tag
-            [Optional for all actions]
-        version (str): The engine version.
-            [Optional for all actions]
-    
-    Returns:
-        Dict[str, Any]: The API response containing operation results
-    
-    Raises:
-        Returns error dict if required parameters are missing for the action
+        ======================================================================
+        ACTION REFERENCE
+        ======================================================================
+
+        ACTION: search
+        ----------------------------------------
+        Summary: Search for engines.
+        Method: POST
+        Endpoint: /management/engines/search
+        Required Parameters: limit, cursor, sort
+        Key Parameters (provide as applicable): filter_expression
+
+        Filterable Fields:
+            - id: The Engine object entity ID.
+            - uuid: The unique identifier generated by this engine.
+            - type: The type of this engine.
+            - version: The engine version.
+            - name: The name of this engine.
+            - ssh_public_key: The ssh public key of this engine.
+            - hostname: The hostname of this engine.
+            - cpu_core_count: The total number of CPU cores on this engine.
+            - memory_size: The total amount of memory on this engine, in bytes.
+            - data_storage_capacity: The total amount of storage allocated for engine objects ...
+            - data_storage_used: The amount of storage used by engine objects and system m...
+            - insecure_ssl: Allow connections to the engine over HTTPs without valida...
+            - unsafe_ssl_hostname_check: Ignore validation of the name associated to the TLS certi...
+            - status: the status of the engine
+
+            - connection_status: The status of the connection to the engine. Deprecated; u...
+            - engine_connection_status: The state of the connection to the engine.
+            - connection_status_details: If set, details about the status of the connection to the...
+            - engine_connection_status_details: If set, details about the state of the connection to the ...
+            - username: The virtualization domain admin username.
+            - password: The virtualization domain admin password.
+            - masking_username: The masking admin username.
+            - masking_password: The masking admin password.
+            - hashicorp_vault_username_command_args: Arguments to pass to the Vault CLI tool to retrieve the v...
+            - hashicorp_vault_masking_username_command_args: Arguments to pass to the Vault CLI tool to retrieve the m...
+            - hashicorp_vault_password_command_args: Arguments to pass to the Vault CLI tool to retrieve the v...
+            - hashicorp_vault_masking_password_command_args: Arguments to pass to the Vault CLI tool to retrieve the m...
+            - masking_hashicorp_vault_id: Reference to the Hashicorp vault to use to retrieve maski...
+            - hashicorp_vault_id: Reference to the Hashicorp vault to use to retrieve virtu...
+            - tags: The tags to be created for this engine.
+            - masking_memory_used: The current amount of memory used by running masking jobs...
+            - masking_allocated_memory: The maximum amount of memory available for running maskin...
+            - masking_jobs_running: The number of masking jobs currently running.
+            - masking_max_concurrent_jobs: The maximum number of masking jobs that can be running at...
+            - masking_available_cores: The number of CPU cores available to the masking engine.
+            - hyperscale_instance_ids: List of Hyperscale Instances that this engine is connecte...
+            - hyperscale_truststore_filename: File name of a truststore which can be used to validate t...
+            - hyperscale_truststore_password: Password to read the truststore as expected by associated...
+            - using_object_storage: true if the engine is using an object store (like AWS S3)...
+            - using_continuous_vault: true if the engine is using an object store (like AWS S3)...
+            - platform: The infrastructure or environment where the engine is dep...
+            - storage_cache_bytes: Total number of bytes of storage reserved for storage cache
+            - priority_cache_max_bytes: Total number of bytes of storage available for VDB priori...
+            - priority_cache_used_bytes: Total number of bytes of storage allocated to existing pr...
+
+        Filter Syntax:
+            Operators: EQ, NE, GT, GE, LT, LE, CONTAINS, IN, NOT_IN
+            Combine: AND, OR
+            Example: "name CONTAINS 'prod' AND status EQ 'RUNNING'"
+
+        Example:
+            >>> engine_tool(action='search', limit=..., cursor=..., sort=..., filter_expression="name CONTAINS 'test'")
+
+        ACTION: get
+        ----------------------------------------
+        Summary: Returns a registered engine by ID.
+        Method: GET
+        Endpoint: /management/engines/{engineId}
+        Required Parameters: engine_id
+
+        Example:
+            >>> engine_tool(action='get', engine_id='example-engine-123')
+
+        ACTION: update
+        ----------------------------------------
+        Summary: Update a registered engine.
+        Method: PATCH
+        Endpoint: /management/engines/{engineId}
+        Required Parameters: engine_id
+        Key Parameters (provide as applicable): id, uuid, type, version, name, ssh_public_key, hostname, cpu_core_count, memory_size, data_storage_capacity, data_storage_used, insecure_ssl, unsafe_ssl_hostname_check, status, connection_status, engine_connection_status, connection_status_details, engine_connection_status_details, username, password, masking_username, masking_password, hashicorp_vault_username_command_args, hashicorp_vault_masking_username_command_args, hashicorp_vault_password_command_args, hashicorp_vault_masking_password_command_args, masking_hashicorp_vault_id, hashicorp_vault_id, tags, masking_memory_used, masking_allocated_memory, masking_jobs_running, masking_max_concurrent_jobs, masking_available_cores, hyperscale_instance_ids, hyperscale_truststore_filename, hyperscale_truststore_password, using_object_storage, using_continuous_vault, platform, storage_cache_bytes, priority_cache_max_bytes, priority_cache_used_bytes
+
+        Example:
+            >>> engine_tool(action='update', engine_id='example-engine-123', id=..., uuid=..., type=..., version=..., name=..., ssh_public_key=..., hostname=..., cpu_core_count=..., memory_size=..., data_storage_capacity=..., data_storage_used=..., insecure_ssl=..., unsafe_ssl_hostname_check=..., status=..., connection_status=..., engine_connection_status=..., connection_status_details=..., engine_connection_status_details=..., username=..., password=..., masking_username=..., masking_password=..., hashicorp_vault_username_command_args=..., hashicorp_vault_masking_username_command_args=..., hashicorp_vault_password_command_args=..., hashicorp_vault_masking_password_command_args=..., masking_hashicorp_vault_id='example-masking_hashicorp_vault-123', hashicorp_vault_id='example-hashicorp_vault-123', tags=..., masking_memory_used=..., masking_allocated_memory=..., masking_jobs_running=..., masking_max_concurrent_jobs=..., masking_available_cores=..., hyperscale_instance_ids=..., hyperscale_truststore_filename=..., hyperscale_truststore_password=..., using_object_storage=..., using_continuous_vault=..., platform=..., storage_cache_bytes=..., priority_cache_max_bytes=..., priority_cache_used_bytes=...)
+
+        ACTION: get_tags
+        ----------------------------------------
+        Summary: Get tags for a Engine.
+        Method: GET
+        Endpoint: /management/engines/{engineId}/tags
+        Required Parameters: engine_id
+
+        Example:
+            >>> engine_tool(action='get_tags', engine_id='example-engine-123')
+
+        ACTION: add_tags
+        ----------------------------------------
+        Summary: Create tags for an Engine.
+        Method: POST
+        Endpoint: /management/engines/{engineId}/tags
+        Required Parameters: engine_id, tags
+
+        Example:
+            >>> engine_tool(action='add_tags', engine_id='example-engine-123', tags=...)
+
+        ACTION: delete_tags
+        ----------------------------------------
+        Summary: Delete tags for an Engine.
+        Method: POST
+        Endpoint: /management/engines/{engineId}/tags/delete
+        Required Parameters: engine_id
+        Key Parameters (provide as applicable): tags, key, value
+
+        Example:
+            >>> engine_tool(action='delete_tags', engine_id='example-engine-123', tags=..., key=..., value=...)
+
+        ACTION: register
+        ----------------------------------------
+        Summary: Register an engine.
+        Method: POST
+        Endpoint: /management/engines
+        Required Parameters: name, hostname
+        Key Parameters (provide as applicable): insecure_ssl, unsafe_ssl_hostname_check, username, password, masking_username, masking_password, hashicorp_vault_username_command_args, hashicorp_vault_masking_username_command_args, hashicorp_vault_password_command_args, hashicorp_vault_masking_password_command_args, masking_hashicorp_vault_id, hashicorp_vault_id, tags, auto_tagging_config
+
+        Example:
+            >>> engine_tool(action='register', name=..., hostname=..., insecure_ssl=..., unsafe_ssl_hostname_check=..., username=..., password=..., masking_username=..., masking_password=..., hashicorp_vault_username_command_args=..., hashicorp_vault_masking_username_command_args=..., hashicorp_vault_password_command_args=..., hashicorp_vault_masking_password_command_args=..., masking_hashicorp_vault_id='example-masking_hashicorp_vault-123', hashicorp_vault_id='example-hashicorp_vault-123', tags=..., auto_tagging_config=...)
+
+        ACTION: unregister
+        ----------------------------------------
+        Summary: Unregister an engine.
+        Method: DELETE
+        Endpoint: /management/engines/{engineId}
+        Required Parameters: engine_id
+
+        Example:
+            >>> engine_tool(action='unregister', engine_id='example-engine-123')
+
+        ACTION: get_auto_tagging
+        ----------------------------------------
+        Summary: Returns the engine's auto tagging configuration.
+        Method: GET
+        Endpoint: /management/engines/{engineId}/auto-tagging
+        Required Parameters: engine_id
+
+        Example:
+            >>> engine_tool(action='get_auto_tagging', engine_id='example-engine-123')
+
+        ACTION: get_compliance_settings
+        ----------------------------------------
+        Summary: Returns a compliance engine's application settings.
+        Method: GET
+        Endpoint: /management/engines/{engineId}/compliance-application-settings
+        Required Parameters: limit, cursor, sort, engine_id
+
+        Example:
+            >>> engine_tool(action='get_compliance_settings', limit=..., cursor=..., sort=..., engine_id='example-engine-123')
+
+        ACTION: search_compliance_settings
+        ----------------------------------------
+        Summary: Search a compliance engine's application settings.
+        Method: POST
+        Endpoint: /management/engines/{engineId}/compliance-application-settings/search
+        Required Parameters: limit, cursor, sort, engine_id
+        Key Parameters (provide as applicable): filter_expression
+
+        Filterable Fields:
+            - id: The ID of the application setting.
+            - group: The group of the application setting.
+            - name: The name of the application setting.
+            - value: The value of the application setting.
+            - value_type: The type of the value of the application setting.
+
+        Filter Syntax:
+            Operators: EQ, NE, GT, GE, LT, LE, CONTAINS, IN, NOT_IN
+            Combine: AND, OR
+            Example: "name CONTAINS 'prod' AND status EQ 'RUNNING'"
+
+        Example:
+            >>> engine_tool(action='search_compliance_settings', limit=..., cursor=..., sort=..., filter_expression="name CONTAINS 'test'", engine_id='example-engine-123')
+
+        ======================================================================
+        PARAMETERS
+        ======================================================================
+
+        Args:
+            action (str): The operation to perform. One of: search, get, update, get_tags, add_tags, delete_tags, register, unregister, get_auto_tagging, get_compliance_settings, search_compliance_settings
+
+          -- General parameters (all database types) --
+            auto_tagging_config (dict): Configuration settings for auto tagging. (Pass as JSON object)
+                [Optional for all actions]
+            connection_status (str): The status of the connection to the engine. Deprecated; use "engine_connectio...
+                [Optional for all actions]
+            connection_status_details (str): If set, details about the status of the connection to the engine. Deprecated;...
+                [Optional for all actions]
+            cpu_core_count (int): The total number of CPU cores on this engine.
+                [Optional for all actions]
+            cursor (str): Cursor to fetch the next or previous page of results. The value of this prope...
+                [Required for: search, get_compliance_settings, search_compliance_settings]
+            data_storage_capacity (int): The total amount of storage allocated for engine objects and system metadata,...
+                [Optional for all actions]
+            data_storage_used (int): The amount of storage used by engine objects and system metadata, in bytes.
+                [Optional for all actions]
+            engine_connection_status (str): The state of the connection to the engine. Valid values: ONLINE, CONNECTION_E...
+                [Optional for all actions]
+            engine_connection_status_details (str): If set, details about the state of the connection to the engine.
+                [Optional for all actions]
+            engine_id (str): The unique identifier for the engine.
+                [Required for: get, update, get_tags, add_tags, delete_tags, unregister, get_auto_tagging, get_compliance_settings, search_compliance_settings]
+            filter_expression (str): Request body parameter
+                [Optional for all actions]
+            hashicorp_vault_id (int): Reference to the Hashicorp vault to use to retrieve virtualization engine cre...
+                [Optional for all actions]
+            hashicorp_vault_masking_password_command_args (list): Arguments to pass to the Vault CLI tool to retrieve the masking password for ...
+                [Optional for all actions]
+            hashicorp_vault_masking_username_command_args (list): Arguments to pass to the Vault CLI tool to retrieve the masking username for ...
+                [Optional for all actions]
+            hashicorp_vault_password_command_args (list): Arguments to pass to the Vault CLI tool to retrieve the virtualization passwo...
+                [Optional for all actions]
+            hashicorp_vault_username_command_args (list): Arguments to pass to the Vault CLI tool to retrieve the virtualization userna...
+                [Optional for all actions]
+            hostname (str): The hostname of this engine.
+                [Required for: register]
+            hyperscale_instance_ids (list): List of Hyperscale Instances that this engine is connected to. (Pass as JSON ...
+                [Optional for all actions]
+            hyperscale_truststore_filename (str): File name of a truststore which can be used to validate the TLS certificate o...
+                [Optional for all actions]
+            hyperscale_truststore_password (str): Password to read the truststore as expected by associated hyperscale instances.
+
+                [Optional for all actions]
+            id (str): The Engine object entity ID.
+                [Optional for all actions]
+            insecure_ssl (bool): Allow connections to the engine over HTTPs without validating the TLS certifi...
+                [Optional for all actions]
+            key (str): Key of the tag
+                [Optional for all actions]
+            limit (int): Maximum number of objects to return per query. The value must be between 1 an...
+                [Required for: search, get_compliance_settings, search_compliance_settings]
+            masking_allocated_memory (int): The maximum amount of memory available for running masking jobs in bytes.
+                [Optional for all actions]
+            masking_available_cores (int): The number of CPU cores available to the masking engine.
+                [Optional for all actions]
+            masking_hashicorp_vault_id (int): Reference to the Hashicorp vault to use to retrieve masking engine credentials.
+                [Optional for all actions]
+            masking_jobs_running (int): The number of masking jobs currently running.
+                [Optional for all actions]
+            masking_max_concurrent_jobs (int): The maximum number of masking jobs that can be running at the same time.
+                [Optional for all actions]
+            masking_memory_used (int): The current amount of memory used by running masking jobs in bytes.
+                [Optional for all actions]
+            masking_password (str): The masking admin password.
+                [Optional for all actions]
+            masking_username (str): The masking admin username.
+                [Optional for all actions]
+            memory_size (int): The total amount of memory on this engine, in bytes.
+                [Optional for all actions]
+            name (str): The name of this engine.
+                [Required for: register]
+            password (str): The virtualization domain admin password.
+                [Optional for all actions]
+            platform (str): The infrastructure or environment where the engine is deployed or built, incl...
+                [Optional for all actions]
+            priority_cache_max_bytes (int): Total number of bytes of storage available for VDB priority caching
+                [Optional for all actions]
+            priority_cache_used_bytes (int): Total number of bytes of storage allocated to existing priority cache enabled...
+                [Optional for all actions]
+            sort (str): The field to sort results by. A property name with a prepended '-' signifies ...
+                [Required for: search, get_compliance_settings, search_compliance_settings]
+            ssh_public_key (str): The ssh public key of this engine.
+                [Optional for all actions]
+            status (str): the status of the engine
+     Valid values: CREATED, DELETING.
+                [Optional for all actions]
+            storage_cache_bytes (int): Total number of bytes of storage reserved for storage cache
+                [Optional for all actions]
+            tags (list): The tags to be created for this engine. (Pass as JSON array)
+                [Required for: add_tags]
+            type (str): The type of this engine. Valid values: VIRTUALIZATION, MASKING, BOTH, UNSET.
+                [Optional for all actions]
+            unsafe_ssl_hostname_check (bool): Ignore validation of the name associated to the TLS certificate when connecti...
+                [Optional for all actions]
+            username (str): The virtualization domain admin username.
+                [Optional for all actions]
+            using_continuous_vault (bool): true if the engine is using an object store (like AWS S3) to store data |
+    fal...
+                [Optional for all actions]
+            using_object_storage (bool): true if the engine is using an object store (like AWS S3) to store data |
+    fal...
+                [Optional for all actions]
+            uuid (str): The unique identifier generated by this engine.
+                [Optional for all actions]
+            value (str): Value of the tag
+                [Optional for all actions]
+            version (str): The engine version.
+                [Optional for all actions]
+
+        Returns:
+            Dict[str, Any]: The API response containing operation results
+
+        Raises:
+            Returns error dict if required parameters are missing for the action
     """
     # Route to appropriate API based on action
-    if action == 'search':
+    if action == "search":
         params = build_params(limit=limit, cursor=cursor, sort=sort)
-        body = {'filter_expression': filter_expression} if filter_expression else {}
-        conf = check_confirmation('POST', '/management/engines/search', action, 'engine_tool', confirmed or False, request_params=params, request_body=body)
+        body = {"filter_expression": filter_expression} if filter_expression else {}
+        conf = check_confirmation(
+            "POST",
+            "/management/engines/search",
+            action,
+            "engine_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', '/management/engines/search', params=params, json_body=body)
-    elif action == 'get':
+        return make_api_request(
+            "POST", "/management/engines/search", params=params, json_body=body
+        )
+    elif action == "get":
         if engine_id is None:
-            return {'error': 'Missing required parameter: engine_id for action get'}
-        endpoint = f'/management/engines/{engine_id}'
+            return {"error": "Missing required parameter: engine_id for action get"}
+        endpoint = f"/management/engines/{engine_id}"
         params = build_params()
-        conf = check_confirmation('GET', endpoint, action, 'engine_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            endpoint,
+            action,
+            "engine_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', endpoint, params=params)
-    elif action == 'update':
+        return make_api_request("GET", endpoint, params=params)
+    elif action == "update":
         if engine_id is None:
-            return {'error': 'Missing required parameter: engine_id for action update'}
-        endpoint = f'/management/engines/{engine_id}'
+            return {"error": "Missing required parameter: engine_id for action update"}
+        endpoint = f"/management/engines/{engine_id}"
         params = build_params()
-        body = {k: v for k, v in {'id': id, 'uuid': uuid, 'type': type, 'version': version, 'name': name, 'ssh_public_key': ssh_public_key, 'hostname': hostname, 'cpu_core_count': cpu_core_count, 'memory_size': memory_size, 'data_storage_capacity': data_storage_capacity, 'data_storage_used': data_storage_used, 'insecure_ssl': insecure_ssl, 'unsafe_ssl_hostname_check': unsafe_ssl_hostname_check, 'status': status, 'connection_status': connection_status, 'engine_connection_status': engine_connection_status, 'connection_status_details': connection_status_details, 'engine_connection_status_details': engine_connection_status_details, 'username': username, 'password': password, 'masking_username': masking_username, 'masking_password': masking_password, 'hashicorp_vault_username_command_args': hashicorp_vault_username_command_args, 'hashicorp_vault_masking_username_command_args': hashicorp_vault_masking_username_command_args, 'hashicorp_vault_password_command_args': hashicorp_vault_password_command_args, 'hashicorp_vault_masking_password_command_args': hashicorp_vault_masking_password_command_args, 'masking_hashicorp_vault_id': masking_hashicorp_vault_id, 'hashicorp_vault_id': hashicorp_vault_id, 'tags': tags, 'masking_memory_used': masking_memory_used, 'masking_allocated_memory': masking_allocated_memory, 'masking_jobs_running': masking_jobs_running, 'masking_max_concurrent_jobs': masking_max_concurrent_jobs, 'masking_available_cores': masking_available_cores, 'hyperscale_instance_ids': hyperscale_instance_ids, 'hyperscale_truststore_filename': hyperscale_truststore_filename, 'hyperscale_truststore_password': hyperscale_truststore_password, 'using_object_storage': using_object_storage, 'using_continuous_vault': using_continuous_vault, 'platform': platform, 'storage_cache_bytes': storage_cache_bytes, 'priority_cache_max_bytes': priority_cache_max_bytes, 'priority_cache_used_bytes': priority_cache_used_bytes}.items() if v is not None}
-        conf = check_confirmation('PATCH', endpoint, action, 'engine_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "id": id,
+                "uuid": uuid,
+                "type": type,
+                "version": version,
+                "name": name,
+                "ssh_public_key": ssh_public_key,
+                "hostname": hostname,
+                "cpu_core_count": cpu_core_count,
+                "memory_size": memory_size,
+                "data_storage_capacity": data_storage_capacity,
+                "data_storage_used": data_storage_used,
+                "insecure_ssl": insecure_ssl,
+                "unsafe_ssl_hostname_check": unsafe_ssl_hostname_check,
+                "status": status,
+                "connection_status": connection_status,
+                "engine_connection_status": engine_connection_status,
+                "connection_status_details": connection_status_details,
+                "engine_connection_status_details": engine_connection_status_details,
+                "username": username,
+                "password": password,
+                "masking_username": masking_username,
+                "masking_password": masking_password,
+                "hashicorp_vault_username_command_args": hashicorp_vault_username_command_args,
+                "hashicorp_vault_masking_username_command_args": hashicorp_vault_masking_username_command_args,
+                "hashicorp_vault_password_command_args": hashicorp_vault_password_command_args,
+                "hashicorp_vault_masking_password_command_args": hashicorp_vault_masking_password_command_args,
+                "masking_hashicorp_vault_id": masking_hashicorp_vault_id,
+                "hashicorp_vault_id": hashicorp_vault_id,
+                "tags": tags,
+                "masking_memory_used": masking_memory_used,
+                "masking_allocated_memory": masking_allocated_memory,
+                "masking_jobs_running": masking_jobs_running,
+                "masking_max_concurrent_jobs": masking_max_concurrent_jobs,
+                "masking_available_cores": masking_available_cores,
+                "hyperscale_instance_ids": hyperscale_instance_ids,
+                "hyperscale_truststore_filename": hyperscale_truststore_filename,
+                "hyperscale_truststore_password": hyperscale_truststore_password,
+                "using_object_storage": using_object_storage,
+                "using_continuous_vault": using_continuous_vault,
+                "platform": platform,
+                "storage_cache_bytes": storage_cache_bytes,
+                "priority_cache_max_bytes": priority_cache_max_bytes,
+                "priority_cache_used_bytes": priority_cache_used_bytes,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "PATCH",
+            endpoint,
+            action,
+            "engine_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('PATCH', endpoint, params=params, json_body=body if body else None)
-    elif action == 'get_tags':
+        return make_api_request(
+            "PATCH", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "get_tags":
         if engine_id is None:
-            return {'error': 'Missing required parameter: engine_id for action get_tags'}
-        endpoint = f'/management/engines/{engine_id}/tags'
+            return {
+                "error": "Missing required parameter: engine_id for action get_tags"
+            }
+        endpoint = f"/management/engines/{engine_id}/tags"
         params = build_params()
-        conf = check_confirmation('GET', endpoint, action, 'engine_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            endpoint,
+            action,
+            "engine_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', endpoint, params=params)
-    elif action == 'add_tags':
+        return make_api_request("GET", endpoint, params=params)
+    elif action == "add_tags":
         if engine_id is None:
-            return {'error': 'Missing required parameter: engine_id for action add_tags'}
-        endpoint = f'/management/engines/{engine_id}/tags'
+            return {
+                "error": "Missing required parameter: engine_id for action add_tags"
+            }
+        endpoint = f"/management/engines/{engine_id}/tags"
         params = build_params(tags=tags)
-        body = {k: v for k, v in {'tags': tags}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'engine_tool', confirmed or False, request_params=params, request_body=body)
+        body = {k: v for k, v in {"tags": tags}.items() if v is not None}
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "engine_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'delete_tags':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "delete_tags":
         if engine_id is None:
-            return {'error': 'Missing required parameter: engine_id for action delete_tags'}
-        endpoint = f'/management/engines/{engine_id}/tags/delete'
+            return {
+                "error": "Missing required parameter: engine_id for action delete_tags"
+            }
+        endpoint = f"/management/engines/{engine_id}/tags/delete"
         params = build_params()
-        body = {k: v for k, v in {'key': key, 'value': value, 'tags': tags}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'engine_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {"key": key, "value": value, "tags": tags}.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "engine_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'register':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "register":
         params = build_params(name=name, hostname=hostname)
-        body = {k: v for k, v in {'name': name, 'hostname': hostname, 'username': username, 'password': password, 'masking_username': masking_username, 'masking_password': masking_password, 'hashicorp_vault_username_command_args': hashicorp_vault_username_command_args, 'hashicorp_vault_masking_username_command_args': hashicorp_vault_masking_username_command_args, 'hashicorp_vault_password_command_args': hashicorp_vault_password_command_args, 'hashicorp_vault_masking_password_command_args': hashicorp_vault_masking_password_command_args, 'hashicorp_vault_id': hashicorp_vault_id, 'masking_hashicorp_vault_id': masking_hashicorp_vault_id, 'insecure_ssl': insecure_ssl, 'unsafe_ssl_hostname_check': unsafe_ssl_hostname_check, 'auto_tagging_config': auto_tagging_config, 'tags': tags}.items() if v is not None}
-        conf = check_confirmation('POST', '/management/engines', action, 'engine_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "name": name,
+                "hostname": hostname,
+                "username": username,
+                "password": password,
+                "masking_username": masking_username,
+                "masking_password": masking_password,
+                "hashicorp_vault_username_command_args": hashicorp_vault_username_command_args,
+                "hashicorp_vault_masking_username_command_args": hashicorp_vault_masking_username_command_args,
+                "hashicorp_vault_password_command_args": hashicorp_vault_password_command_args,
+                "hashicorp_vault_masking_password_command_args": hashicorp_vault_masking_password_command_args,
+                "hashicorp_vault_id": hashicorp_vault_id,
+                "masking_hashicorp_vault_id": masking_hashicorp_vault_id,
+                "insecure_ssl": insecure_ssl,
+                "unsafe_ssl_hostname_check": unsafe_ssl_hostname_check,
+                "auto_tagging_config": auto_tagging_config,
+                "tags": tags,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            "/management/engines",
+            action,
+            "engine_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', '/management/engines', params=params, json_body=body if body else None)
-    elif action == 'unregister':
+        return make_api_request(
+            "POST",
+            "/management/engines",
+            params=params,
+            json_body=body if body else None,
+        )
+    elif action == "unregister":
         if engine_id is None:
-            return {'error': 'Missing required parameter: engine_id for action unregister'}
-        endpoint = f'/management/engines/{engine_id}'
+            return {
+                "error": "Missing required parameter: engine_id for action unregister"
+            }
+        endpoint = f"/management/engines/{engine_id}"
         params = build_params()
-        conf = check_confirmation('DELETE', endpoint, action, 'engine_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "DELETE",
+            endpoint,
+            action,
+            "engine_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('DELETE', endpoint, params=params)
-    elif action == 'get_auto_tagging':
+        return make_api_request("DELETE", endpoint, params=params)
+    elif action == "get_auto_tagging":
         if engine_id is None:
-            return {'error': 'Missing required parameter: engine_id for action get_auto_tagging'}
-        endpoint = f'/management/engines/{engine_id}/auto-tagging'
+            return {
+                "error": "Missing required parameter: engine_id for action get_auto_tagging"
+            }
+        endpoint = f"/management/engines/{engine_id}/auto-tagging"
         params = build_params()
-        conf = check_confirmation('GET', endpoint, action, 'engine_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            endpoint,
+            action,
+            "engine_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', endpoint, params=params)
-    elif action == 'get_compliance_settings':
+        return make_api_request("GET", endpoint, params=params)
+    elif action == "get_compliance_settings":
         if engine_id is None:
-            return {'error': 'Missing required parameter: engine_id for action get_compliance_settings'}
-        endpoint = f'/management/engines/{engine_id}/compliance-application-settings'
+            return {
+                "error": "Missing required parameter: engine_id for action get_compliance_settings"
+            }
+        endpoint = f"/management/engines/{engine_id}/compliance-application-settings"
         params = build_params(limit=limit, cursor=cursor, sort=sort)
-        conf = check_confirmation('GET', endpoint, action, 'engine_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            endpoint,
+            action,
+            "engine_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', endpoint, params=params)
-    elif action == 'search_compliance_settings':
+        return make_api_request("GET", endpoint, params=params)
+    elif action == "search_compliance_settings":
         if engine_id is None:
-            return {'error': 'Missing required parameter: engine_id for action search_compliance_settings'}
-        endpoint = f'/management/engines/{engine_id}/compliance-application-settings/search'
+            return {
+                "error": "Missing required parameter: engine_id for action search_compliance_settings"
+            }
+        endpoint = (
+            f"/management/engines/{engine_id}/compliance-application-settings/search"
+        )
         params = build_params(limit=limit, cursor=cursor, sort=sort)
-        body = {'filter_expression': filter_expression} if filter_expression else {}
-        conf = check_confirmation('POST', endpoint, action, 'engine_tool', confirmed or False, request_params=params, request_body=body)
+        body = {"filter_expression": filter_expression} if filter_expression else {}
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "engine_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body)
+        return make_api_request("POST", endpoint, params=params, json_body=body)
     else:
-        return {'error': f'Unknown action: {action}. Valid actions: search, get, update, get_tags, add_tags, delete_tags, register, unregister, get_auto_tagging, get_compliance_settings, search_compliance_settings'}
+        return {
+            "error": f"Unknown action: {action}. Valid actions: search, get, update, get_tags, add_tags, delete_tags, register, unregister, get_auto_tagging, get_compliance_settings, search_compliance_settings"
+        }
 
 
 def register_tools(app, dct_client):
     global client
     client = dct_client
-    logger.info(f'Registering tools for engine_endpoints...')
+    logger.info("Registering tools for engine_endpoints...")
     try:
-        logger.info(f'  Registering tool function: engine_tool')
+        logger.info("  Registering tool function: engine_tool")
         app.add_tool(engine_tool, name="engine_tool")
     except Exception as e:
-        logger.error(f'Error registering tools for engine_endpoints: {e}')
-    logger.info(f'Tools registration finished for engine_endpoints.')
+        logger.error(f"Error registering tools for engine_endpoints: {e}")
+    logger.info("Tools registration finished for engine_endpoints.")

--- a/src/dct_mcp_server/tools/environment_endpoints_tool.py
+++ b/src/dct_mcp_server/tools/environment_endpoints_tool.py
@@ -1,7 +1,6 @@
-from mcp.server.fastmcp import FastMCP
-from typing import Dict,Any,Optional
+from typing import Dict, Any, Optional
 from dct_mcp_server.core.decorators import log_tool_execution
-from dct_mcp_server.config import get_confirmation_for_operation, requires_confirmation
+from dct_mcp_server.config import get_confirmation_for_operation
 import asyncio
 import logging
 import threading
@@ -29,7 +28,16 @@ logger = logging.getLogger(__name__)
 #       }
 # =============================================================================
 
-def check_confirmation(method: str, api_path: str, action: str, tool_name: str, confirmed: bool = False, request_params: Optional[Dict[str, Any]] = None, request_body: Optional[Dict[str, Any]] = None) -> Optional[Dict[str, Any]]:
+
+def check_confirmation(
+    method: str,
+    api_path: str,
+    action: str,
+    tool_name: str,
+    confirmed: bool = False,
+    request_params: Optional[Dict[str, Any]] = None,
+    request_body: Optional[Dict[str, Any]] = None,
+) -> Optional[Dict[str, Any]]:
     """Check if operation requires confirmation. Returns confirmation response or None if confirmed/not needed."""
     confirmation = get_confirmation_for_operation(method, api_path)
     if confirmation["level"] != "none" and not confirmed:
@@ -41,7 +49,11 @@ def check_confirmation(method: str, api_path: str, action: str, tool_name: str, 
             review.update(request_params)
         if request_body:
             review.update(request_body)
-        is_review_critical = action.startswith("provision_") or action.startswith("dsource_link_") or action == "dsource_create_snapshot"
+        is_review_critical = (
+            action.startswith("provision_")
+            or action.startswith("dsource_link_")
+            or action == "dsource_create_snapshot"
+        )
         instructions = (
             "STOP: You MUST display the confirmation_message to the user and wait for their EXPLICIT "
             "approval before re-calling with confirmed=True. Do NOT proceed without user consent."
@@ -56,7 +68,9 @@ def check_confirmation(method: str, api_path: str, action: str, tool_name: str, 
         return {
             "status": "confirmation_required",
             "confirmation_level": confirmation["level"],
-            "confirmation_message": confirmation.get("message", "Please confirm this operation."),
+            "confirmation_message": confirmation.get(
+                "message", "Please confirm this operation."
+            ),
             "action": action,
             "tool": tool_name,
             "api_path": api_path,
@@ -66,8 +80,10 @@ def check_confirmation(method: str, api_path: str, action: str, tool_name: str, 
         }
     return None
 
+
 def async_to_sync(async_func):
     """Utility decorator to convert async functions to sync with proper event loop handling."""
+
     @wraps(async_func)
     def wrapper(*args, **kwargs):
         try:
@@ -76,12 +92,14 @@ def async_to_sync(async_func):
                 # Create a task and run it synchronously
                 result = None
                 exception = None
+
                 def run_in_thread():
                     nonlocal result, exception
                     try:
                         result = asyncio.run(async_func(*args, **kwargs))
                     except Exception as e:
                         exception = e
+
                 thread = threading.Thread(target=run_in_thread)
                 thread.start()
                 thread.join()
@@ -92,18 +110,28 @@ def async_to_sync(async_func):
                 return loop.run_until_complete(async_func(*args, **kwargs))
         except RuntimeError:
             return asyncio.run(async_func(*args, **kwargs))
+
     return wrapper
 
-def make_api_request(method: str, endpoint: str, params: dict = None, json_body: dict = None):
+
+def make_api_request(
+    method: str, endpoint: str, params: dict = None, json_body: dict = None
+):
     """Utility function to make API requests with consistent parameter handling."""
+
     @async_to_sync
     async def _make_request():
-        return await client.make_request(method, endpoint, params=params or {}, json=json_body)
+        return await client.make_request(
+            method, endpoint, params=params or {}, json=json_body
+        )
+
     return _make_request()
+
 
 def build_params(**kwargs):
     """Build parameters dictionary excluding None and empty string values."""
-    return {k: v for k, v in kwargs.items() if v is not None and v != ''}
+    return {k: v for k, v in kwargs.items() if v is not None and v != ""}
+
 
 @log_tool_execution
 def environment_source_tool(
@@ -223,13 +251,13 @@ def environment_source_tool(
 ) -> Dict[str, Any]:
     """
     Unified tool for ENVIRONMENT SOURCE operations.
-    
+
     This tool supports 41 actions: search_environments, get_environment, create_environment, add_environment_users, set_environment_primary_user, update_environment_users, delete_environment_users, update_environment, delete_environment, enable_environment, disable_environment, refresh_environment, list_environment_hosts, update_environment_host, delete_environment_host, list_environment_listeners, get_environment_tags, add_environment_tags, delete_environment_tags, get_environment_compatible_repositories_by_snapshot, get_environment_compatible_repositories_by_timestamp, get_environment_compatible_repositories_by_location, update_environment_repository, delete_environment_repository, search_sources, list_sources, get_source, delete_source, verify_source_jdbc_connection, get_source_compatible_repositories, get_source_tags, add_source_tags, delete_source_tags, create_oracle_source, update_oracle_source, create_postgres_source, update_postgres_source, create_ase_source, update_ase_source, create_appdata_source, update_appdata_source
-    
+
     ======================================================================
     ACTION REFERENCE
     ======================================================================
-    
+
     ACTION: search_environments
     ----------------------------------------
     Summary: Search for environments.
@@ -237,7 +265,7 @@ def environment_source_tool(
     Endpoint: /environments/search
     Required Parameters: limit, cursor, sort
     Key Parameters (provide as applicable): filter_expression
-    
+
     Filterable Fields:
         - id: The Environment object entity ID.
         - name: The name of this environment.
@@ -268,25 +296,25 @@ def environment_source_tool(
         - ase_db_user_name: The username of the SAP ASE database user.
         - ase_enable_tls: True if SAP ASE environment configured with TLS/SSL to di...
         - ase_skip_server_certificate_validation: If True, ASE database connection will skip the server cer...
-    
+
     Filter Syntax:
         Operators: EQ, NE, GT, GE, LT, LE, CONTAINS, IN, NOT_IN
         Combine: AND, OR
         Example: "name CONTAINS 'prod' AND status EQ 'RUNNING'"
-    
+
     Example:
         >>> environment_source_tool(action='search_environments', limit=..., cursor=..., sort=..., filter_expression="name CONTAINS 'test'")
-    
+
     ACTION: get_environment
     ----------------------------------------
     Summary: Returns an environment by ID.
     Method: GET
     Endpoint: /environments/{environmentId}
     Required Parameters: environment_id
-    
+
     Example:
         >>> environment_source_tool(action='get_environment', environment_id='example-environment-123')
-    
+
     ACTION: create_environment
     ----------------------------------------
     Summary: Create an environment.
@@ -294,10 +322,10 @@ def environment_source_tool(
     Endpoint: /environments
     Required Parameters: engine_id, os_name, hostname
     Key Parameters (provide as applicable): name, is_cluster, cluster_home, staging_environment, connector_port, connector_authentication_key, is_target, ssh_port, toolkit_path, username, password, vault, vault_username, hashicorp_vault_engine, hashicorp_vault_secret_path, hashicorp_vault_username_key, hashicorp_vault_secret_key, cyberark_vault_query_string, azure_vault_name, azure_vault_username_key, azure_vault_secret_key, use_kerberos_authentication, use_engine_public_key, use_custom_key_pair, custom_private_key, custom_public_key, nfs_addresses, ase_db_vault_username, ase_db_username, ase_db_password, ase_enable_tls, ase_skip_server_certificate_validation, ase_db_vault, ase_db_hashicorp_vault_engine, ase_db_hashicorp_vault_secret_path, ase_db_hashicorp_vault_username_key, ase_db_hashicorp_vault_secret_key, ase_db_cyberark_vault_query_string, ase_db_use_kerberos_authentication, ase_db_azure_vault_name, ase_db_azure_vault_username_key, ase_db_azure_vault_secret_key, java_home, dsp_keystore_path, dsp_keystore_password, dsp_keystore_alias, dsp_truststore_path, dsp_truststore_password, description, tags, make_current_account_owner
-    
+
     Example:
         >>> environment_source_tool(action='create_environment', name=..., engine_id='example-engine-123', os_name=..., is_cluster=..., cluster_home=..., hostname=..., staging_environment=..., connector_port=..., connector_authentication_key=..., is_target=..., ssh_port=..., toolkit_path=..., username=..., password=..., vault=..., vault_username=..., hashicorp_vault_engine=..., hashicorp_vault_secret_path=..., hashicorp_vault_username_key=..., hashicorp_vault_secret_key=..., cyberark_vault_query_string=..., azure_vault_name=..., azure_vault_username_key=..., azure_vault_secret_key=..., use_kerberos_authentication=..., use_engine_public_key=..., use_custom_key_pair=..., custom_private_key=..., custom_public_key=..., nfs_addresses=..., ase_db_vault_username=..., ase_db_username=..., ase_db_password=..., ase_enable_tls=..., ase_skip_server_certificate_validation=..., ase_db_vault=..., ase_db_hashicorp_vault_engine=..., ase_db_hashicorp_vault_secret_path=..., ase_db_hashicorp_vault_username_key=..., ase_db_hashicorp_vault_secret_key=..., ase_db_cyberark_vault_query_string=..., ase_db_use_kerberos_authentication=..., ase_db_azure_vault_name=..., ase_db_azure_vault_username_key=..., ase_db_azure_vault_secret_key=..., java_home=..., dsp_keystore_path=..., dsp_keystore_password=..., dsp_keystore_alias=..., dsp_truststore_path=..., dsp_truststore_password=..., description=..., tags=..., make_current_account_owner=...)
-    
+
     ACTION: add_environment_users
     ----------------------------------------
     Summary: Create environment user.
@@ -305,20 +333,20 @@ def environment_source_tool(
     Endpoint: /environments/{environmentId}/users
     Required Parameters: environment_id
     Key Parameters (provide as applicable): username, password, vault, vault_username, hashicorp_vault_engine, hashicorp_vault_secret_path, hashicorp_vault_username_key, hashicorp_vault_secret_key, cyberark_vault_query_string, azure_vault_name, azure_vault_username_key, azure_vault_secret_key, use_kerberos_authentication, use_engine_public_key, use_custom_key_pair, custom_private_key, custom_public_key
-    
+
     Example:
         >>> environment_source_tool(action='add_environment_users', environment_id='example-environment-123', username=..., password=..., vault=..., vault_username=..., hashicorp_vault_engine=..., hashicorp_vault_secret_path=..., hashicorp_vault_username_key=..., hashicorp_vault_secret_key=..., cyberark_vault_query_string=..., azure_vault_name=..., azure_vault_username_key=..., azure_vault_secret_key=..., use_kerberos_authentication=..., use_engine_public_key=..., use_custom_key_pair=..., custom_private_key=..., custom_public_key=...)
-    
+
     ACTION: set_environment_primary_user
     ----------------------------------------
     Summary: Set primary environment user.
     Method: POST
     Endpoint: /environments/{environmentId}/users/{userRef}/primary
     Required Parameters: environment_id, user_ref
-    
+
     Example:
         >>> environment_source_tool(action='set_environment_primary_user', environment_id='example-environment-123', user_ref=...)
-    
+
     ACTION: update_environment_users
     ----------------------------------------
     Summary: Update environment user.
@@ -326,20 +354,20 @@ def environment_source_tool(
     Endpoint: /environments/{environmentId}/users/{userRef}
     Required Parameters: environment_id, user_ref
     Key Parameters (provide as applicable): username, password, vault, vault_username, hashicorp_vault_engine, hashicorp_vault_secret_path, hashicorp_vault_username_key, hashicorp_vault_secret_key, cyberark_vault_query_string, azure_vault_name, azure_vault_username_key, azure_vault_secret_key, use_kerberos_authentication, use_engine_public_key, use_custom_key_pair, custom_private_key, custom_public_key
-    
+
     Example:
         >>> environment_source_tool(action='update_environment_users', environment_id='example-environment-123', username=..., password=..., vault=..., vault_username=..., hashicorp_vault_engine=..., hashicorp_vault_secret_path=..., hashicorp_vault_username_key=..., hashicorp_vault_secret_key=..., cyberark_vault_query_string=..., azure_vault_name=..., azure_vault_username_key=..., azure_vault_secret_key=..., use_kerberos_authentication=..., use_engine_public_key=..., use_custom_key_pair=..., custom_private_key=..., custom_public_key=..., user_ref=...)
-    
+
     ACTION: delete_environment_users
     ----------------------------------------
     Summary: Delete environment user.
     Method: DELETE
     Endpoint: /environments/{environmentId}/users/{userRef}
     Required Parameters: environment_id, user_ref
-    
+
     Example:
         >>> environment_source_tool(action='delete_environment_users', environment_id='example-environment-123', user_ref=...)
-    
+
     ACTION: update_environment
     ----------------------------------------
     Summary: Update an environment by ID.
@@ -347,50 +375,50 @@ def environment_source_tool(
     Endpoint: /environments/{environmentId}
     Required Parameters: environment_id
     Key Parameters (provide as applicable): name, cluster_home, staging_environment, ase_db_vault_username, ase_db_username, ase_db_password, ase_enable_tls, ase_skip_server_certificate_validation, ase_db_vault, ase_db_hashicorp_vault_engine, ase_db_hashicorp_vault_secret_path, ase_db_hashicorp_vault_username_key, ase_db_hashicorp_vault_secret_key, ase_db_cyberark_vault_query_string, ase_db_use_kerberos_authentication, ase_db_azure_vault_name, ase_db_azure_vault_username_key, ase_db_azure_vault_secret_key, description, cluster_address, cluster_user, scan, remote_listener, encryption_enabled
-    
+
     Example:
         >>> environment_source_tool(action='update_environment', environment_id='example-environment-123', name=..., cluster_home=..., staging_environment=..., ase_db_vault_username=..., ase_db_username=..., ase_db_password=..., ase_enable_tls=..., ase_skip_server_certificate_validation=..., ase_db_vault=..., ase_db_hashicorp_vault_engine=..., ase_db_hashicorp_vault_secret_path=..., ase_db_hashicorp_vault_username_key=..., ase_db_hashicorp_vault_secret_key=..., ase_db_cyberark_vault_query_string=..., ase_db_use_kerberos_authentication=..., ase_db_azure_vault_name=..., ase_db_azure_vault_username_key=..., ase_db_azure_vault_secret_key=..., description=..., cluster_address=..., cluster_user=..., scan=..., remote_listener=..., encryption_enabled=...)
-    
+
     ACTION: delete_environment
     ----------------------------------------
     Summary: Delete an environment by ID.
     Method: DELETE
     Endpoint: /environments/{environmentId}
     Required Parameters: environment_id
-    
+
     Example:
         >>> environment_source_tool(action='delete_environment', environment_id='example-environment-123')
-    
+
     ACTION: enable_environment
     ----------------------------------------
     Summary: Enable a disabled environment.
     Method: POST
     Endpoint: /environments/{environmentId}/enable
     Required Parameters: environment_id
-    
+
     Example:
         >>> environment_source_tool(action='enable_environment', environment_id='example-environment-123')
-    
+
     ACTION: disable_environment
     ----------------------------------------
     Summary: Disable environment.
     Method: POST
     Endpoint: /environments/{environmentId}/disable
     Required Parameters: environment_id
-    
+
     Example:
         >>> environment_source_tool(action='disable_environment', environment_id='example-environment-123')
-    
+
     ACTION: refresh_environment
     ----------------------------------------
     Summary: Refresh environment.
     Method: POST
     Endpoint: /environments/{environmentId}/refresh
     Required Parameters: environment_id
-    
+
     Example:
         >>> environment_source_tool(action='refresh_environment', environment_id='example-environment-123')
-    
+
     ACTION: list_environment_hosts
     ----------------------------------------
     Summary: Create a new Host.
@@ -398,10 +426,10 @@ def environment_source_tool(
     Endpoint: /environments/{environmentId}/hosts
     Required Parameters: environment_id
     Key Parameters (provide as applicable): name, hostname, ssh_port, toolkit_path, nfs_addresses, java_home, dsp_keystore_path, dsp_keystore_password, dsp_keystore_alias, dsp_truststore_path, dsp_truststore_password, privilege_elevation_profile_reference, oracle_jdbc_keystore_password, oracle_tde_keystores_root_path, ssh_verification_strategy, oracle_cluster_node_virtual_ips
-    
+
     Example:
         >>> environment_source_tool(action='list_environment_hosts', environment_id='example-environment-123', name=..., hostname=..., ssh_port=..., toolkit_path=..., nfs_addresses=..., java_home=..., dsp_keystore_path=..., dsp_keystore_password=..., dsp_keystore_alias=..., dsp_truststore_path=..., dsp_truststore_password=..., privilege_elevation_profile_reference=..., oracle_jdbc_keystore_password=..., oracle_tde_keystores_root_path=..., ssh_verification_strategy=..., oracle_cluster_node_virtual_ips=...)
-    
+
     ACTION: update_environment_host
     ----------------------------------------
     Summary: Update a Host.
@@ -409,20 +437,20 @@ def environment_source_tool(
     Endpoint: /environments/{environmentId}/hosts/{hostId}
     Required Parameters: environment_id, host_id
     Key Parameters (provide as applicable): hostname, connector_port, connector_authentication_key, ssh_port, toolkit_path, nfs_addresses, java_home, dsp_keystore_path, dsp_keystore_password, dsp_keystore_alias, dsp_truststore_path, dsp_truststore_password, oracle_jdbc_keystore_password, oracle_tde_keystores_root_path, ssh_verification_strategy, oracle_cluster_node_virtual_ips, oracle_cluster_node_name, oracle_cluster_node_enabled, oracle_tde_okv_home_path, oracle_tde_external_key_manager_credential
-    
+
     Example:
         >>> environment_source_tool(action='update_environment_host', environment_id='example-environment-123', hostname=..., connector_port=..., connector_authentication_key=..., ssh_port=..., toolkit_path=..., nfs_addresses=..., java_home=..., dsp_keystore_path=..., dsp_keystore_password=..., dsp_keystore_alias=..., dsp_truststore_path=..., dsp_truststore_password=..., oracle_jdbc_keystore_password=..., oracle_tde_keystores_root_path=..., ssh_verification_strategy=..., oracle_cluster_node_virtual_ips=..., host_id='example-host-123', oracle_cluster_node_name=..., oracle_cluster_node_enabled=..., oracle_tde_okv_home_path=..., oracle_tde_external_key_manager_credential=...)
-    
+
     ACTION: delete_environment_host
     ----------------------------------------
     Summary: Delete a Host.
     Method: DELETE
     Endpoint: /environments/{environmentId}/hosts/{hostId}
     Required Parameters: environment_id, host_id
-    
+
     Example:
         >>> environment_source_tool(action='delete_environment_host', environment_id='example-environment-123', host_id='example-host-123')
-    
+
     ACTION: list_environment_listeners
     ----------------------------------------
     Summary: Create Oracle listener.
@@ -430,30 +458,30 @@ def environment_source_tool(
     Endpoint: /environments/{environmentId}/listeners
     Required Parameters: environment_id, type
     Key Parameters (provide as applicable): name, host_id, protocol_addresses
-    
+
     Example:
         >>> environment_source_tool(action='list_environment_listeners', environment_id='example-environment-123', name=..., host_id='example-host-123', type=..., protocol_addresses=...)
-    
+
     ACTION: get_environment_tags
     ----------------------------------------
     Summary: Get tags for an Environment.
     Method: GET
     Endpoint: /environments/{environmentId}/tags
     Required Parameters: environment_id
-    
+
     Example:
         >>> environment_source_tool(action='get_environment_tags', environment_id='example-environment-123')
-    
+
     ACTION: add_environment_tags
     ----------------------------------------
     Summary: Create tags for an Environment.
     Method: POST
     Endpoint: /environments/{environmentId}/tags
     Required Parameters: environment_id, tags
-    
+
     Example:
         >>> environment_source_tool(action='add_environment_tags', environment_id='example-environment-123', tags=...)
-    
+
     ACTION: delete_environment_tags
     ----------------------------------------
     Summary: Delete tags for an Environment.
@@ -461,40 +489,40 @@ def environment_source_tool(
     Endpoint: /environments/{environmentId}/tags/delete
     Required Parameters: environment_id
     Key Parameters (provide as applicable): tags, key, value
-    
+
     Example:
         >>> environment_source_tool(action='delete_environment_tags', environment_id='example-environment-123', tags=..., key=..., value=...)
-    
+
     ACTION: get_environment_compatible_repositories_by_snapshot
     ----------------------------------------
     Summary: Get compatible repositories corresponding to the snapshot.
     Method: POST
     Endpoint: /environments/compatible_repositories_by_snapshot
     Key Parameters (provide as applicable): environment_id, engine_id, source_data_id, snapshot_id
-    
+
     Example:
         >>> environment_source_tool(action='get_environment_compatible_repositories_by_snapshot', environment_id='example-environment-123', engine_id='example-engine-123', source_data_id='example-source_data-123', snapshot_id='example-snapshot-123')
-    
+
     ACTION: get_environment_compatible_repositories_by_timestamp
     ----------------------------------------
     Summary: Get compatible repositories corresponding to the timestamp.
     Method: POST
     Endpoint: /environments/compatible_repositories_by_timestamp
     Key Parameters (provide as applicable): environment_id, engine_id, source_data_id, timestamp, timeflow_id
-    
+
     Example:
         >>> environment_source_tool(action='get_environment_compatible_repositories_by_timestamp', environment_id='example-environment-123', engine_id='example-engine-123', source_data_id='example-source_data-123', timestamp=..., timeflow_id='example-timeflow-123')
-    
+
     ACTION: get_environment_compatible_repositories_by_location
     ----------------------------------------
     Summary: Get compatible repositories corresponding to the location.
     Method: POST
     Endpoint: /environments/compatible_repositories_by_location
     Key Parameters (provide as applicable): environment_id, engine_id, source_data_id, timeflow_id, location
-    
+
     Example:
         >>> environment_source_tool(action='get_environment_compatible_repositories_by_location', environment_id='example-environment-123', engine_id='example-engine-123', source_data_id='example-source_data-123', timeflow_id='example-timeflow-123', location=...)
-    
+
     ACTION: update_environment_repository
     ----------------------------------------
     Summary: Update a Repository.
@@ -502,20 +530,20 @@ def environment_source_tool(
     Endpoint: /environments/{environmentId}/repository/{repositoryId}
     Required Parameters: environment_id, repository_id
     Key Parameters (provide as applicable): allow_provisioning, is_staging, version, oracle_base, bits, port, instance_owner, installation_path, dump_history_file, database_username, database_password, service_principal_name, isql_path
-    
+
     Example:
         >>> environment_source_tool(action='update_environment_repository', environment_id='example-environment-123', repository_id='example-repository-123', allow_provisioning=..., is_staging=..., version=..., oracle_base=..., bits=..., port=..., instance_owner=..., installation_path=..., dump_history_file=..., database_username=..., database_password=..., service_principal_name=..., isql_path=...)
-    
+
     ACTION: delete_environment_repository
     ----------------------------------------
     Summary: Delete a repository.
     Method: DELETE
     Endpoint: /environments/{environmentId}/repository/{repositoryId}
     Required Parameters: environment_id, repository_id
-    
+
     Example:
         >>> environment_source_tool(action='delete_environment_repository', environment_id='example-environment-123', repository_id='example-repository-123')
-    
+
     ACTION: search_sources
     ----------------------------------------
     Summary: Search for Sources.
@@ -523,7 +551,7 @@ def environment_source_tool(
     Endpoint: /sources/search
     Required Parameters: limit, cursor, sort
     Key Parameters (provide as applicable): filter_expression
-    
+
     Filterable Fields:
         - id: The Source object entity ID.
         - database_type: The type of this source database.
@@ -541,18 +569,18 @@ def environment_source_tool(
         - jdbc_connection_string: The JDBC connection URL for this source database.
         - plugin_version: The version of the plugin associated with this source dat...
         - toolkit_id: The ID of the toolkit associated with this source databas...
-        - is_dsource: 
+        - is_dsource:
         - repository: The repository id for this source
         - recovery_model: Recovery model of the source database (MSSql Only).
         - mssql_source_type: The type of this mssql source database (MSSql Only).
         - appdata_source_type: The type of this appdata source database (Appdata Only).
         - is_pdb: If this source is of PDB type (Oracle Only).
         - mount_base: The base mount point for the NFS or iSCSI LUN mounts.
-        - tags: 
+        - tags:
         - instance_name: The instance name of this single instance database source.
         - instance_number: The instance number of this single instance database source.
-        - instances: 
-        - oracle_services: 
+        - instances:
+        - oracle_services:
         - user: The username of the database user.
         - environment_user_ref: The environment user reference.
         - non_sys_user: The username of a database user that does not have admini...
@@ -562,85 +590,85 @@ def environment_source_tool(
         - data_connection_id: The ID of the associated DataConnection.
         - database_name: The name of this source database.
         - database_unique_name: The unique name of the database.
-    
+
     Filter Syntax:
         Operators: EQ, NE, GT, GE, LT, LE, CONTAINS, IN, NOT_IN
         Combine: AND, OR
         Example: "name CONTAINS 'prod' AND status EQ 'RUNNING'"
-    
+
     Example:
         >>> environment_source_tool(action='search_sources', limit=..., cursor=..., sort=..., filter_expression="name CONTAINS 'test'")
-    
+
     ACTION: list_sources
     ----------------------------------------
     Summary: List all sources.
     Method: GET
     Endpoint: /sources
     Required Parameters: limit, cursor, sort
-    
+
     Example:
         >>> environment_source_tool(action='list_sources', limit=..., cursor=..., sort=...)
-    
+
     ACTION: get_source
     ----------------------------------------
     Summary: Get a source by ID.
     Method: GET
     Endpoint: /sources/{sourceId}
     Required Parameters: source_id
-    
+
     Example:
         >>> environment_source_tool(action='get_source', source_id='example-source-123')
-    
+
     ACTION: delete_source
     ----------------------------------------
     Summary: Delete a source by ID.
     Method: DELETE
     Endpoint: /sources/{sourceId}
     Required Parameters: source_id
-    
+
     Example:
         >>> environment_source_tool(action='delete_source', source_id='example-source-123')
-    
+
     ACTION: verify_source_jdbc_connection
     ----------------------------------------
     Summary: Verify JDBC connection string for a source.
     Method: POST
     Endpoint: /sources/{sourceId}/jdbc-check
     Required Parameters: database_username, database_password, source_id, jdbc_connection_string
-    
+
     Example:
         >>> environment_source_tool(action='verify_source_jdbc_connection', database_username=..., database_password=..., source_id='example-source-123', jdbc_connection_string=...)
-    
+
     ACTION: get_source_compatible_repositories
     ----------------------------------------
     Summary: Returns a list of repositories that match the specified source.
     Method: GET
     Endpoint: /sources/{sourceId}/staging_compatible_repositories
     Required Parameters: source_id
-    
+
     Example:
         >>> environment_source_tool(action='get_source_compatible_repositories', source_id='example-source-123')
-    
+
     ACTION: get_source_tags
     ----------------------------------------
     Summary: Get tags for a Source.
     Method: GET
     Endpoint: /sources/{sourceId}/tags
     Required Parameters: source_id
-    
+
     Example:
         >>> environment_source_tool(action='get_source_tags', source_id='example-source-123')
-    
+
     ACTION: add_source_tags
     ----------------------------------------
     Summary: Create tags for a Source.
     Method: POST
     Endpoint: /sources/{sourceId}/tags
     Required Parameters: tags, source_id
-    
+
     Example:
         >>> environment_source_tool(action='add_source_tags', tags=..., source_id='example-source-123')
-    
+
     ACTION: delete_source_tags
     ----------------------------------------
     Summary: Delete tags for a Source.
@@ -648,10 +676,10 @@ def environment_source_tool(
     Endpoint: /sources/{sourceId}/tags/delete
     Required Parameters: source_id
     Key Parameters (provide as applicable): tags, key, value
-    
+
     Example:
         >>> environment_source_tool(action='delete_source_tags', tags=..., key=..., value=..., source_id='example-source-123')
-    
+
     ACTION: create_oracle_source
     ----------------------------------------
     Summary: Create an Oracle Source.
@@ -659,10 +687,10 @@ def environment_source_tool(
     Endpoint: /sources/oracle
     Required Parameters: repository_id, oracle_config_type
     Key Parameters (provide as applicable): environment_id, engine_id, database_name, instances, unique_name, instance_name, oracle_services
-    
+
     Example:
         >>> environment_source_tool(action='create_oracle_source', environment_id='example-environment-123', engine_id='example-engine-123', repository_id='example-repository-123', oracle_config_type=..., database_name=..., instances=..., unique_name=..., instance_name=..., oracle_services=...)
-    
+
     ACTION: update_oracle_source
     ----------------------------------------
     Summary: Update an Oracle source by ID.
@@ -670,10 +698,10 @@ def environment_source_tool(
     Endpoint: /sources/oracle/{sourceId}
     Required Parameters: source_id
     Key Parameters (provide as applicable): password, oracle_services, user, linking_enabled
-    
+
     Example:
         >>> environment_source_tool(action='update_oracle_source', password=..., source_id='example-source-123', oracle_services=..., user=..., linking_enabled=...)
-    
+
     ACTION: create_postgres_source
     ----------------------------------------
     Summary: Create a PostgreSQL source.
@@ -681,10 +709,10 @@ def environment_source_tool(
     Endpoint: /sources/postgres
     Required Parameters: name
     Key Parameters (provide as applicable): environment_id, engine_id, repository_id
-    
+
     Example:
         >>> environment_source_tool(action='create_postgres_source', environment_id='example-environment-123', name=..., engine_id='example-engine-123', repository_id='example-repository-123')
-    
+
     ACTION: update_postgres_source
     ----------------------------------------
     Summary: Update a PostgreSQL source by ID.
@@ -692,10 +720,10 @@ def environment_source_tool(
     Endpoint: /sources/postgres/{sourceId}
     Required Parameters: source_id
     Key Parameters (provide as applicable): name
-    
+
     Example:
         >>> environment_source_tool(action='update_postgres_source', name=..., source_id='example-source-123')
-    
+
     ACTION: create_ase_source
     ----------------------------------------
     Summary: Create an ASE source.
@@ -703,10 +731,10 @@ def environment_source_tool(
     Endpoint: /sources/ase
     Required Parameters: repository_id, database_name
     Key Parameters (provide as applicable): environment_id, engine_id, linking_enabled, environment_user
-    
+
     Example:
         >>> environment_source_tool(action='create_ase_source', environment_id='example-environment-123', engine_id='example-engine-123', repository_id='example-repository-123', database_name=..., linking_enabled=..., environment_user=...)
-    
+
     ACTION: update_ase_source
     ----------------------------------------
     Summary: Update an ASE source by ID.
@@ -714,10 +742,10 @@ def environment_source_tool(
     Endpoint: /sources/ase/{sourceId}
     Required Parameters: source_id
     Key Parameters (provide as applicable): environment_id, repository_id, database_username, database_password, database_name, linking_enabled, environment_user
-    
+
     Example:
         >>> environment_source_tool(action='update_ase_source', environment_id='example-environment-123', repository_id='example-repository-123', database_username=..., database_password=..., source_id='example-source-123', database_name=..., linking_enabled=..., environment_user=...)
-    
+
     ACTION: create_appdata_source
     ----------------------------------------
     Summary: Create an AppData source.
@@ -725,10 +753,10 @@ def environment_source_tool(
     Endpoint: /sources/appdata
     Required Parameters: name, type, repository_id
     Key Parameters (provide as applicable): environment_id, engine_id, linking_enabled, environment_user, parameters, path
-    
+
     Example:
         >>> environment_source_tool(action='create_appdata_source', environment_id='example-environment-123', name=..., engine_id='example-engine-123', type=..., repository_id='example-repository-123', linking_enabled=..., environment_user=..., parameters=..., path=...)
-    
+
     ACTION: update_appdata_source
     ----------------------------------------
     Summary: Update a AppData source by ID.
@@ -736,17 +764,17 @@ def environment_source_tool(
     Endpoint: /sources/appdata/{sourceId}
     Required Parameters: source_id
     Key Parameters (provide as applicable): environment_id, name, repository_id, linking_enabled, environment_user, parameters, path
-    
+
     Example:
         >>> environment_source_tool(action='update_appdata_source', environment_id='example-environment-123', name=..., repository_id='example-repository-123', source_id='example-source-123', linking_enabled=..., environment_user=..., parameters=..., path=...)
-    
+
     ======================================================================
     PARAMETERS
     ======================================================================
-    
+
     Args:
         action (str): The operation to perform. One of: search_environments, get_environment, create_environment, add_environment_users, set_environment_primary_user, update_environment_users, delete_environment_users, update_environment, delete_environment, enable_environment, disable_environment, refresh_environment, list_environment_hosts, update_environment_host, delete_environment_host, list_environment_listeners, get_environment_tags, add_environment_tags, delete_environment_tags, get_environment_compatible_repositories_by_snapshot, get_environment_compatible_repositories_by_timestamp, get_environment_compatible_repositories_by_location, update_environment_repository, delete_environment_repository, search_sources, list_sources, get_source, delete_source, verify_source_jdbc_connection, get_source_compatible_repositories, get_source_tags, add_source_tags, delete_source_tags, create_oracle_source, update_oracle_source, create_postgres_source, update_postgres_source, create_ase_source, update_ase_source, create_appdata_source, update_appdata_source
-    
+
       -- General parameters (all database types) --
         allow_provisioning (bool): Flag indicating whether the repository should be used for provisioning.
             [Optional for all actions]
@@ -970,392 +998,1193 @@ def environment_source_tool(
             [Optional for all actions]
         version (str): Version of the repository.
             [Optional for all actions]
-    
+
     Returns:
         Dict[str, Any]: The API response containing operation results
-    
+
     Raises:
         Returns error dict if required parameters are missing for the action
     """
     # Route to appropriate API based on action
-    if action == 'search_environments':
+    if action == "search_environments":
         params = build_params(limit=limit, cursor=cursor, sort=sort)
-        body = {'filter_expression': filter_expression} if filter_expression else {}
-        conf = check_confirmation('POST', '/environments/search', action, 'environment_source_tool', confirmed or False, request_params=params, request_body=body)
+        body = {"filter_expression": filter_expression} if filter_expression else {}
+        conf = check_confirmation(
+            "POST",
+            "/environments/search",
+            action,
+            "environment_source_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', '/environments/search', params=params, json_body=body)
-    elif action == 'get_environment':
+        return make_api_request(
+            "POST", "/environments/search", params=params, json_body=body
+        )
+    elif action == "get_environment":
         if environment_id is None:
-            return {'error': 'Missing required parameter: environment_id for action get_environment'}
-        endpoint = f'/environments/{environment_id}'
+            return {
+                "error": "Missing required parameter: environment_id for action get_environment"
+            }
+        endpoint = f"/environments/{environment_id}"
         params = build_params()
-        conf = check_confirmation('GET', endpoint, action, 'environment_source_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            endpoint,
+            action,
+            "environment_source_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', endpoint, params=params)
-    elif action == 'create_environment':
+        return make_api_request("GET", endpoint, params=params)
+    elif action == "create_environment":
         params = build_params(os_name=os_name, hostname=hostname)
-        body = {k: v for k, v in {'name': name, 'engine_id': engine_id, 'os_name': os_name, 'is_cluster': is_cluster, 'cluster_home': cluster_home, 'hostname': hostname, 'staging_environment': staging_environment, 'connector_port': connector_port, 'connector_authentication_key': connector_authentication_key, 'is_target': is_target, 'ssh_port': ssh_port, 'toolkit_path': toolkit_path, 'username': username, 'password': password, 'vault': vault, 'vault_username': vault_username, 'hashicorp_vault_engine': hashicorp_vault_engine, 'hashicorp_vault_secret_path': hashicorp_vault_secret_path, 'hashicorp_vault_username_key': hashicorp_vault_username_key, 'hashicorp_vault_secret_key': hashicorp_vault_secret_key, 'cyberark_vault_query_string': cyberark_vault_query_string, 'azure_vault_name': azure_vault_name, 'azure_vault_username_key': azure_vault_username_key, 'azure_vault_secret_key': azure_vault_secret_key, 'use_kerberos_authentication': use_kerberos_authentication, 'use_engine_public_key': use_engine_public_key, 'use_custom_key_pair': use_custom_key_pair, 'custom_private_key': custom_private_key, 'custom_public_key': custom_public_key, 'nfs_addresses': nfs_addresses, 'ase_db_vault_username': ase_db_vault_username, 'ase_db_username': ase_db_username, 'ase_db_password': ase_db_password, 'ase_enable_tls': ase_enable_tls, 'ase_skip_server_certificate_validation': ase_skip_server_certificate_validation, 'ase_db_vault': ase_db_vault, 'ase_db_hashicorp_vault_engine': ase_db_hashicorp_vault_engine, 'ase_db_hashicorp_vault_secret_path': ase_db_hashicorp_vault_secret_path, 'ase_db_hashicorp_vault_username_key': ase_db_hashicorp_vault_username_key, 'ase_db_hashicorp_vault_secret_key': ase_db_hashicorp_vault_secret_key, 'ase_db_cyberark_vault_query_string': ase_db_cyberark_vault_query_string, 'ase_db_use_kerberos_authentication': ase_db_use_kerberos_authentication, 'ase_db_azure_vault_name': ase_db_azure_vault_name, 'ase_db_azure_vault_username_key': ase_db_azure_vault_username_key, 'ase_db_azure_vault_secret_key': ase_db_azure_vault_secret_key, 'java_home': java_home, 'dsp_keystore_path': dsp_keystore_path, 'dsp_keystore_password': dsp_keystore_password, 'dsp_keystore_alias': dsp_keystore_alias, 'dsp_truststore_path': dsp_truststore_path, 'dsp_truststore_password': dsp_truststore_password, 'description': description, 'tags': tags, 'make_current_account_owner': make_current_account_owner}.items() if v is not None}
-        conf = check_confirmation('POST', '/environments', action, 'environment_source_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "name": name,
+                "engine_id": engine_id,
+                "os_name": os_name,
+                "is_cluster": is_cluster,
+                "cluster_home": cluster_home,
+                "hostname": hostname,
+                "staging_environment": staging_environment,
+                "connector_port": connector_port,
+                "connector_authentication_key": connector_authentication_key,
+                "is_target": is_target,
+                "ssh_port": ssh_port,
+                "toolkit_path": toolkit_path,
+                "username": username,
+                "password": password,
+                "vault": vault,
+                "vault_username": vault_username,
+                "hashicorp_vault_engine": hashicorp_vault_engine,
+                "hashicorp_vault_secret_path": hashicorp_vault_secret_path,
+                "hashicorp_vault_username_key": hashicorp_vault_username_key,
+                "hashicorp_vault_secret_key": hashicorp_vault_secret_key,
+                "cyberark_vault_query_string": cyberark_vault_query_string,
+                "azure_vault_name": azure_vault_name,
+                "azure_vault_username_key": azure_vault_username_key,
+                "azure_vault_secret_key": azure_vault_secret_key,
+                "use_kerberos_authentication": use_kerberos_authentication,
+                "use_engine_public_key": use_engine_public_key,
+                "use_custom_key_pair": use_custom_key_pair,
+                "custom_private_key": custom_private_key,
+                "custom_public_key": custom_public_key,
+                "nfs_addresses": nfs_addresses,
+                "ase_db_vault_username": ase_db_vault_username,
+                "ase_db_username": ase_db_username,
+                "ase_db_password": ase_db_password,
+                "ase_enable_tls": ase_enable_tls,
+                "ase_skip_server_certificate_validation": ase_skip_server_certificate_validation,
+                "ase_db_vault": ase_db_vault,
+                "ase_db_hashicorp_vault_engine": ase_db_hashicorp_vault_engine,
+                "ase_db_hashicorp_vault_secret_path": ase_db_hashicorp_vault_secret_path,
+                "ase_db_hashicorp_vault_username_key": ase_db_hashicorp_vault_username_key,
+                "ase_db_hashicorp_vault_secret_key": ase_db_hashicorp_vault_secret_key,
+                "ase_db_cyberark_vault_query_string": ase_db_cyberark_vault_query_string,
+                "ase_db_use_kerberos_authentication": ase_db_use_kerberos_authentication,
+                "ase_db_azure_vault_name": ase_db_azure_vault_name,
+                "ase_db_azure_vault_username_key": ase_db_azure_vault_username_key,
+                "ase_db_azure_vault_secret_key": ase_db_azure_vault_secret_key,
+                "java_home": java_home,
+                "dsp_keystore_path": dsp_keystore_path,
+                "dsp_keystore_password": dsp_keystore_password,
+                "dsp_keystore_alias": dsp_keystore_alias,
+                "dsp_truststore_path": dsp_truststore_path,
+                "dsp_truststore_password": dsp_truststore_password,
+                "description": description,
+                "tags": tags,
+                "make_current_account_owner": make_current_account_owner,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            "/environments",
+            action,
+            "environment_source_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', '/environments', params=params, json_body=body if body else None)
-    elif action == 'add_environment_users':
+        return make_api_request(
+            "POST", "/environments", params=params, json_body=body if body else None
+        )
+    elif action == "add_environment_users":
         if environment_id is None:
-            return {'error': 'Missing required parameter: environment_id for action add_environment_users'}
-        endpoint = f'/environments/{environment_id}/users'
+            return {
+                "error": "Missing required parameter: environment_id for action add_environment_users"
+            }
+        endpoint = f"/environments/{environment_id}/users"
         params = build_params()
-        body = {k: v for k, v in {'username': username, 'password': password, 'vault': vault, 'vault_username': vault_username, 'hashicorp_vault_engine': hashicorp_vault_engine, 'hashicorp_vault_secret_path': hashicorp_vault_secret_path, 'hashicorp_vault_username_key': hashicorp_vault_username_key, 'hashicorp_vault_secret_key': hashicorp_vault_secret_key, 'cyberark_vault_query_string': cyberark_vault_query_string, 'azure_vault_name': azure_vault_name, 'azure_vault_username_key': azure_vault_username_key, 'azure_vault_secret_key': azure_vault_secret_key, 'use_kerberos_authentication': use_kerberos_authentication, 'use_engine_public_key': use_engine_public_key, 'use_custom_key_pair': use_custom_key_pair, 'custom_private_key': custom_private_key, 'custom_public_key': custom_public_key}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'environment_source_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "username": username,
+                "password": password,
+                "vault": vault,
+                "vault_username": vault_username,
+                "hashicorp_vault_engine": hashicorp_vault_engine,
+                "hashicorp_vault_secret_path": hashicorp_vault_secret_path,
+                "hashicorp_vault_username_key": hashicorp_vault_username_key,
+                "hashicorp_vault_secret_key": hashicorp_vault_secret_key,
+                "cyberark_vault_query_string": cyberark_vault_query_string,
+                "azure_vault_name": azure_vault_name,
+                "azure_vault_username_key": azure_vault_username_key,
+                "azure_vault_secret_key": azure_vault_secret_key,
+                "use_kerberos_authentication": use_kerberos_authentication,
+                "use_engine_public_key": use_engine_public_key,
+                "use_custom_key_pair": use_custom_key_pair,
+                "custom_private_key": custom_private_key,
+                "custom_public_key": custom_public_key,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "environment_source_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'set_environment_primary_user':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "set_environment_primary_user":
         if environment_id is None:
-            return {'error': 'Missing required parameter: environment_id for action set_environment_primary_user'}
+            return {
+                "error": "Missing required parameter: environment_id for action set_environment_primary_user"
+            }
         if user_ref is None:
-            return {'error': 'Missing required parameter: user_ref for action set_environment_primary_user'}
-        endpoint = f'/environments/{environment_id}/users/{user_ref}/primary'
+            return {
+                "error": "Missing required parameter: user_ref for action set_environment_primary_user"
+            }
+        endpoint = f"/environments/{environment_id}/users/{user_ref}/primary"
         params = build_params(user_ref=user_ref)
-        conf = check_confirmation('POST', endpoint, action, 'environment_source_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "environment_source_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params)
-    elif action == 'update_environment_users':
+        return make_api_request("POST", endpoint, params=params)
+    elif action == "update_environment_users":
         if environment_id is None:
-            return {'error': 'Missing required parameter: environment_id for action update_environment_users'}
+            return {
+                "error": "Missing required parameter: environment_id for action update_environment_users"
+            }
         if user_ref is None:
-            return {'error': 'Missing required parameter: user_ref for action update_environment_users'}
-        endpoint = f'/environments/{environment_id}/users/{user_ref}'
+            return {
+                "error": "Missing required parameter: user_ref for action update_environment_users"
+            }
+        endpoint = f"/environments/{environment_id}/users/{user_ref}"
         params = build_params(user_ref=user_ref)
-        body = {k: v for k, v in {'username': username, 'password': password, 'vault': vault, 'vault_username': vault_username, 'hashicorp_vault_engine': hashicorp_vault_engine, 'hashicorp_vault_secret_path': hashicorp_vault_secret_path, 'hashicorp_vault_username_key': hashicorp_vault_username_key, 'hashicorp_vault_secret_key': hashicorp_vault_secret_key, 'cyberark_vault_query_string': cyberark_vault_query_string, 'azure_vault_name': azure_vault_name, 'azure_vault_username_key': azure_vault_username_key, 'azure_vault_secret_key': azure_vault_secret_key, 'use_kerberos_authentication': use_kerberos_authentication, 'use_engine_public_key': use_engine_public_key, 'use_custom_key_pair': use_custom_key_pair, 'custom_private_key': custom_private_key, 'custom_public_key': custom_public_key}.items() if v is not None}
-        conf = check_confirmation('PUT', endpoint, action, 'environment_source_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "username": username,
+                "password": password,
+                "vault": vault,
+                "vault_username": vault_username,
+                "hashicorp_vault_engine": hashicorp_vault_engine,
+                "hashicorp_vault_secret_path": hashicorp_vault_secret_path,
+                "hashicorp_vault_username_key": hashicorp_vault_username_key,
+                "hashicorp_vault_secret_key": hashicorp_vault_secret_key,
+                "cyberark_vault_query_string": cyberark_vault_query_string,
+                "azure_vault_name": azure_vault_name,
+                "azure_vault_username_key": azure_vault_username_key,
+                "azure_vault_secret_key": azure_vault_secret_key,
+                "use_kerberos_authentication": use_kerberos_authentication,
+                "use_engine_public_key": use_engine_public_key,
+                "use_custom_key_pair": use_custom_key_pair,
+                "custom_private_key": custom_private_key,
+                "custom_public_key": custom_public_key,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "PUT",
+            endpoint,
+            action,
+            "environment_source_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('PUT', endpoint, params=params, json_body=body if body else None)
-    elif action == 'delete_environment_users':
+        return make_api_request(
+            "PUT", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "delete_environment_users":
         if environment_id is None:
-            return {'error': 'Missing required parameter: environment_id for action delete_environment_users'}
+            return {
+                "error": "Missing required parameter: environment_id for action delete_environment_users"
+            }
         if user_ref is None:
-            return {'error': 'Missing required parameter: user_ref for action delete_environment_users'}
-        endpoint = f'/environments/{environment_id}/users/{user_ref}'
+            return {
+                "error": "Missing required parameter: user_ref for action delete_environment_users"
+            }
+        endpoint = f"/environments/{environment_id}/users/{user_ref}"
         params = build_params(user_ref=user_ref)
-        conf = check_confirmation('DELETE', endpoint, action, 'environment_source_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "DELETE",
+            endpoint,
+            action,
+            "environment_source_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('DELETE', endpoint, params=params)
-    elif action == 'update_environment':
+        return make_api_request("DELETE", endpoint, params=params)
+    elif action == "update_environment":
         if environment_id is None:
-            return {'error': 'Missing required parameter: environment_id for action update_environment'}
-        endpoint = f'/environments/{environment_id}'
+            return {
+                "error": "Missing required parameter: environment_id for action update_environment"
+            }
+        endpoint = f"/environments/{environment_id}"
         params = build_params()
-        body = {k: v for k, v in {'name': name, 'staging_environment': staging_environment, 'cluster_address': cluster_address, 'cluster_home': cluster_home, 'cluster_user': cluster_user, 'scan': scan, 'remote_listener': remote_listener, 'ase_db_username': ase_db_username, 'ase_db_password': ase_db_password, 'ase_enable_tls': ase_enable_tls, 'ase_skip_server_certificate_validation': ase_skip_server_certificate_validation, 'ase_db_vault': ase_db_vault, 'ase_db_vault_username': ase_db_vault_username, 'ase_db_hashicorp_vault_engine': ase_db_hashicorp_vault_engine, 'ase_db_hashicorp_vault_secret_path': ase_db_hashicorp_vault_secret_path, 'ase_db_hashicorp_vault_username_key': ase_db_hashicorp_vault_username_key, 'ase_db_hashicorp_vault_secret_key': ase_db_hashicorp_vault_secret_key, 'ase_db_cyberark_vault_query_string': ase_db_cyberark_vault_query_string, 'ase_db_azure_vault_name': ase_db_azure_vault_name, 'ase_db_azure_vault_username_key': ase_db_azure_vault_username_key, 'ase_db_azure_vault_secret_key': ase_db_azure_vault_secret_key, 'ase_db_use_kerberos_authentication': ase_db_use_kerberos_authentication, 'encryption_enabled': encryption_enabled, 'description': description}.items() if v is not None}
-        conf = check_confirmation('PATCH', endpoint, action, 'environment_source_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "name": name,
+                "staging_environment": staging_environment,
+                "cluster_address": cluster_address,
+                "cluster_home": cluster_home,
+                "cluster_user": cluster_user,
+                "scan": scan,
+                "remote_listener": remote_listener,
+                "ase_db_username": ase_db_username,
+                "ase_db_password": ase_db_password,
+                "ase_enable_tls": ase_enable_tls,
+                "ase_skip_server_certificate_validation": ase_skip_server_certificate_validation,
+                "ase_db_vault": ase_db_vault,
+                "ase_db_vault_username": ase_db_vault_username,
+                "ase_db_hashicorp_vault_engine": ase_db_hashicorp_vault_engine,
+                "ase_db_hashicorp_vault_secret_path": ase_db_hashicorp_vault_secret_path,
+                "ase_db_hashicorp_vault_username_key": ase_db_hashicorp_vault_username_key,
+                "ase_db_hashicorp_vault_secret_key": ase_db_hashicorp_vault_secret_key,
+                "ase_db_cyberark_vault_query_string": ase_db_cyberark_vault_query_string,
+                "ase_db_azure_vault_name": ase_db_azure_vault_name,
+                "ase_db_azure_vault_username_key": ase_db_azure_vault_username_key,
+                "ase_db_azure_vault_secret_key": ase_db_azure_vault_secret_key,
+                "ase_db_use_kerberos_authentication": ase_db_use_kerberos_authentication,
+                "encryption_enabled": encryption_enabled,
+                "description": description,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "PATCH",
+            endpoint,
+            action,
+            "environment_source_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('PATCH', endpoint, params=params, json_body=body if body else None)
-    elif action == 'delete_environment':
+        return make_api_request(
+            "PATCH", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "delete_environment":
         if environment_id is None:
-            return {'error': 'Missing required parameter: environment_id for action delete_environment'}
-        endpoint = f'/environments/{environment_id}'
+            return {
+                "error": "Missing required parameter: environment_id for action delete_environment"
+            }
+        endpoint = f"/environments/{environment_id}"
         params = build_params()
-        conf = check_confirmation('DELETE', endpoint, action, 'environment_source_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "DELETE",
+            endpoint,
+            action,
+            "environment_source_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('DELETE', endpoint, params=params)
-    elif action == 'enable_environment':
+        return make_api_request("DELETE", endpoint, params=params)
+    elif action == "enable_environment":
         if environment_id is None:
-            return {'error': 'Missing required parameter: environment_id for action enable_environment'}
-        endpoint = f'/environments/{environment_id}/enable'
+            return {
+                "error": "Missing required parameter: environment_id for action enable_environment"
+            }
+        endpoint = f"/environments/{environment_id}/enable"
         params = build_params()
-        conf = check_confirmation('POST', endpoint, action, 'environment_source_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "environment_source_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params)
-    elif action == 'disable_environment':
+        return make_api_request("POST", endpoint, params=params)
+    elif action == "disable_environment":
         if environment_id is None:
-            return {'error': 'Missing required parameter: environment_id for action disable_environment'}
-        endpoint = f'/environments/{environment_id}/disable'
+            return {
+                "error": "Missing required parameter: environment_id for action disable_environment"
+            }
+        endpoint = f"/environments/{environment_id}/disable"
         params = build_params()
-        conf = check_confirmation('POST', endpoint, action, 'environment_source_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "environment_source_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params)
-    elif action == 'refresh_environment':
+        return make_api_request("POST", endpoint, params=params)
+    elif action == "refresh_environment":
         if environment_id is None:
-            return {'error': 'Missing required parameter: environment_id for action refresh_environment'}
-        endpoint = f'/environments/{environment_id}/refresh'
+            return {
+                "error": "Missing required parameter: environment_id for action refresh_environment"
+            }
+        endpoint = f"/environments/{environment_id}/refresh"
         params = build_params()
-        conf = check_confirmation('POST', endpoint, action, 'environment_source_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "environment_source_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params)
-    elif action == 'list_environment_hosts':
+        return make_api_request("POST", endpoint, params=params)
+    elif action == "list_environment_hosts":
         if environment_id is None:
-            return {'error': 'Missing required parameter: environment_id for action list_environment_hosts'}
-        endpoint = f'/environments/{environment_id}/hosts'
+            return {
+                "error": "Missing required parameter: environment_id for action list_environment_hosts"
+            }
+        endpoint = f"/environments/{environment_id}/hosts"
         params = build_params()
-        body = {k: v for k, v in {'name': name, 'hostname': hostname, 'nfs_addresses': nfs_addresses, 'ssh_port': ssh_port, 'privilege_elevation_profile_reference': privilege_elevation_profile_reference, 'dsp_keystore_alias': dsp_keystore_alias, 'dsp_keystore_password': dsp_keystore_password, 'dsp_keystore_path': dsp_keystore_path, 'dsp_truststore_password': dsp_truststore_password, 'dsp_truststore_path': dsp_truststore_path, 'java_home': java_home, 'toolkit_path': toolkit_path, 'oracle_jdbc_keystore_password': oracle_jdbc_keystore_password, 'oracle_tde_keystores_root_path': oracle_tde_keystores_root_path, 'ssh_verification_strategy': ssh_verification_strategy, 'oracle_cluster_node_virtual_ips': oracle_cluster_node_virtual_ips}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'environment_source_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "name": name,
+                "hostname": hostname,
+                "nfs_addresses": nfs_addresses,
+                "ssh_port": ssh_port,
+                "privilege_elevation_profile_reference": privilege_elevation_profile_reference,
+                "dsp_keystore_alias": dsp_keystore_alias,
+                "dsp_keystore_password": dsp_keystore_password,
+                "dsp_keystore_path": dsp_keystore_path,
+                "dsp_truststore_password": dsp_truststore_password,
+                "dsp_truststore_path": dsp_truststore_path,
+                "java_home": java_home,
+                "toolkit_path": toolkit_path,
+                "oracle_jdbc_keystore_password": oracle_jdbc_keystore_password,
+                "oracle_tde_keystores_root_path": oracle_tde_keystores_root_path,
+                "ssh_verification_strategy": ssh_verification_strategy,
+                "oracle_cluster_node_virtual_ips": oracle_cluster_node_virtual_ips,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "environment_source_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'update_environment_host':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "update_environment_host":
         if environment_id is None:
-            return {'error': 'Missing required parameter: environment_id for action update_environment_host'}
+            return {
+                "error": "Missing required parameter: environment_id for action update_environment_host"
+            }
         if host_id is None:
-            return {'error': 'Missing required parameter: host_id for action update_environment_host'}
-        endpoint = f'/environments/{environment_id}/hosts/{host_id}'
+            return {
+                "error": "Missing required parameter: host_id for action update_environment_host"
+            }
+        endpoint = f"/environments/{environment_id}/hosts/{host_id}"
         params = build_params()
-        body = {k: v for k, v in {'hostname': hostname, 'oracle_cluster_node_name': oracle_cluster_node_name, 'oracle_cluster_node_enabled': oracle_cluster_node_enabled, 'oracle_cluster_node_virtual_ips': oracle_cluster_node_virtual_ips, 'nfs_addresses': nfs_addresses, 'ssh_port': ssh_port, 'toolkit_path': toolkit_path, 'java_home': java_home, 'dsp_keystore_path': dsp_keystore_path, 'dsp_keystore_password': dsp_keystore_password, 'dsp_keystore_alias': dsp_keystore_alias, 'dsp_truststore_path': dsp_truststore_path, 'dsp_truststore_password': dsp_truststore_password, 'connector_port': connector_port, 'oracle_jdbc_keystore_password': oracle_jdbc_keystore_password, 'oracle_tde_keystores_root_path': oracle_tde_keystores_root_path, 'ssh_verification_strategy': ssh_verification_strategy, 'connector_authentication_key': connector_authentication_key, 'oracle_tde_okv_home_path': oracle_tde_okv_home_path, 'oracle_tde_external_key_manager_credential': oracle_tde_external_key_manager_credential}.items() if v is not None}
-        conf = check_confirmation('PATCH', endpoint, action, 'environment_source_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "hostname": hostname,
+                "oracle_cluster_node_name": oracle_cluster_node_name,
+                "oracle_cluster_node_enabled": oracle_cluster_node_enabled,
+                "oracle_cluster_node_virtual_ips": oracle_cluster_node_virtual_ips,
+                "nfs_addresses": nfs_addresses,
+                "ssh_port": ssh_port,
+                "toolkit_path": toolkit_path,
+                "java_home": java_home,
+                "dsp_keystore_path": dsp_keystore_path,
+                "dsp_keystore_password": dsp_keystore_password,
+                "dsp_keystore_alias": dsp_keystore_alias,
+                "dsp_truststore_path": dsp_truststore_path,
+                "dsp_truststore_password": dsp_truststore_password,
+                "connector_port": connector_port,
+                "oracle_jdbc_keystore_password": oracle_jdbc_keystore_password,
+                "oracle_tde_keystores_root_path": oracle_tde_keystores_root_path,
+                "ssh_verification_strategy": ssh_verification_strategy,
+                "connector_authentication_key": connector_authentication_key,
+                "oracle_tde_okv_home_path": oracle_tde_okv_home_path,
+                "oracle_tde_external_key_manager_credential": oracle_tde_external_key_manager_credential,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "PATCH",
+            endpoint,
+            action,
+            "environment_source_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('PATCH', endpoint, params=params, json_body=body if body else None)
-    elif action == 'delete_environment_host':
+        return make_api_request(
+            "PATCH", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "delete_environment_host":
         if environment_id is None:
-            return {'error': 'Missing required parameter: environment_id for action delete_environment_host'}
+            return {
+                "error": "Missing required parameter: environment_id for action delete_environment_host"
+            }
         if host_id is None:
-            return {'error': 'Missing required parameter: host_id for action delete_environment_host'}
-        endpoint = f'/environments/{environment_id}/hosts/{host_id}'
+            return {
+                "error": "Missing required parameter: host_id for action delete_environment_host"
+            }
+        endpoint = f"/environments/{environment_id}/hosts/{host_id}"
         params = build_params()
-        conf = check_confirmation('DELETE', endpoint, action, 'environment_source_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "DELETE",
+            endpoint,
+            action,
+            "environment_source_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('DELETE', endpoint, params=params)
-    elif action == 'list_environment_listeners':
+        return make_api_request("DELETE", endpoint, params=params)
+    elif action == "list_environment_listeners":
         if environment_id is None:
-            return {'error': 'Missing required parameter: environment_id for action list_environment_listeners'}
-        endpoint = f'/environments/{environment_id}/listeners'
+            return {
+                "error": "Missing required parameter: environment_id for action list_environment_listeners"
+            }
+        endpoint = f"/environments/{environment_id}/listeners"
         params = build_params(type=type)
-        body = {k: v for k, v in {'type': type, 'name': name, 'protocol_addresses': protocol_addresses, 'host_id': host_id}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'environment_source_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "type": type,
+                "name": name,
+                "protocol_addresses": protocol_addresses,
+                "host_id": host_id,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "environment_source_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'get_environment_tags':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "get_environment_tags":
         if environment_id is None:
-            return {'error': 'Missing required parameter: environment_id for action get_environment_tags'}
-        endpoint = f'/environments/{environment_id}/tags'
+            return {
+                "error": "Missing required parameter: environment_id for action get_environment_tags"
+            }
+        endpoint = f"/environments/{environment_id}/tags"
         params = build_params()
-        conf = check_confirmation('GET', endpoint, action, 'environment_source_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            endpoint,
+            action,
+            "environment_source_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', endpoint, params=params)
-    elif action == 'add_environment_tags':
+        return make_api_request("GET", endpoint, params=params)
+    elif action == "add_environment_tags":
         if environment_id is None:
-            return {'error': 'Missing required parameter: environment_id for action add_environment_tags'}
-        endpoint = f'/environments/{environment_id}/tags'
+            return {
+                "error": "Missing required parameter: environment_id for action add_environment_tags"
+            }
+        endpoint = f"/environments/{environment_id}/tags"
         params = build_params(tags=tags)
-        body = {k: v for k, v in {'tags': tags}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'environment_source_tool', confirmed or False, request_params=params, request_body=body)
+        body = {k: v for k, v in {"tags": tags}.items() if v is not None}
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "environment_source_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'delete_environment_tags':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "delete_environment_tags":
         if environment_id is None:
-            return {'error': 'Missing required parameter: environment_id for action delete_environment_tags'}
-        endpoint = f'/environments/{environment_id}/tags/delete'
+            return {
+                "error": "Missing required parameter: environment_id for action delete_environment_tags"
+            }
+        endpoint = f"/environments/{environment_id}/tags/delete"
         params = build_params()
-        body = {k: v for k, v in {'key': key, 'value': value, 'tags': tags}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'environment_source_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {"key": key, "value": value, "tags": tags}.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "environment_source_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'get_environment_compatible_repositories_by_snapshot':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "get_environment_compatible_repositories_by_snapshot":
         params = build_params()
-        body = {k: v for k, v in {'source_data_id': source_data_id, 'engine_id': engine_id, 'snapshot_id': snapshot_id, 'environment_id': environment_id}.items() if v is not None}
-        conf = check_confirmation('POST', '/environments/compatible_repositories_by_snapshot', action, 'environment_source_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "source_data_id": source_data_id,
+                "engine_id": engine_id,
+                "snapshot_id": snapshot_id,
+                "environment_id": environment_id,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            "/environments/compatible_repositories_by_snapshot",
+            action,
+            "environment_source_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', '/environments/compatible_repositories_by_snapshot', params=params, json_body=body if body else None)
-    elif action == 'get_environment_compatible_repositories_by_timestamp':
+        return make_api_request(
+            "POST",
+            "/environments/compatible_repositories_by_snapshot",
+            params=params,
+            json_body=body if body else None,
+        )
+    elif action == "get_environment_compatible_repositories_by_timestamp":
         params = build_params()
-        body = {k: v for k, v in {'source_data_id': source_data_id, 'engine_id': engine_id, 'timestamp': timestamp, 'timeflow_id': timeflow_id, 'environment_id': environment_id}.items() if v is not None}
-        conf = check_confirmation('POST', '/environments/compatible_repositories_by_timestamp', action, 'environment_source_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "source_data_id": source_data_id,
+                "engine_id": engine_id,
+                "timestamp": timestamp,
+                "timeflow_id": timeflow_id,
+                "environment_id": environment_id,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            "/environments/compatible_repositories_by_timestamp",
+            action,
+            "environment_source_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', '/environments/compatible_repositories_by_timestamp', params=params, json_body=body if body else None)
-    elif action == 'get_environment_compatible_repositories_by_location':
+        return make_api_request(
+            "POST",
+            "/environments/compatible_repositories_by_timestamp",
+            params=params,
+            json_body=body if body else None,
+        )
+    elif action == "get_environment_compatible_repositories_by_location":
         params = build_params()
-        body = {k: v for k, v in {'source_data_id': source_data_id, 'engine_id': engine_id, 'location': location, 'timeflow_id': timeflow_id, 'environment_id': environment_id}.items() if v is not None}
-        conf = check_confirmation('POST', '/environments/compatible_repositories_by_location', action, 'environment_source_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "source_data_id": source_data_id,
+                "engine_id": engine_id,
+                "location": location,
+                "timeflow_id": timeflow_id,
+                "environment_id": environment_id,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            "/environments/compatible_repositories_by_location",
+            action,
+            "environment_source_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', '/environments/compatible_repositories_by_location', params=params, json_body=body if body else None)
-    elif action == 'update_environment_repository':
+        return make_api_request(
+            "POST",
+            "/environments/compatible_repositories_by_location",
+            params=params,
+            json_body=body if body else None,
+        )
+    elif action == "update_environment_repository":
         if environment_id is None:
-            return {'error': 'Missing required parameter: environment_id for action update_environment_repository'}
+            return {
+                "error": "Missing required parameter: environment_id for action update_environment_repository"
+            }
         if repository_id is None:
-            return {'error': 'Missing required parameter: repository_id for action update_environment_repository'}
-        endpoint = f'/environments/{environment_id}/repository/{repository_id}'
+            return {
+                "error": "Missing required parameter: repository_id for action update_environment_repository"
+            }
+        endpoint = f"/environments/{environment_id}/repository/{repository_id}"
         params = build_params()
-        body = {k: v for k, v in {'allow_provisioning': allow_provisioning, 'is_staging': is_staging, 'version': version, 'oracle_base': oracle_base, 'bits': bits, 'port': port, 'instance_owner': instance_owner, 'installation_path': installation_path, 'dump_history_file': dump_history_file, 'database_username': database_username, 'database_password': database_password, 'service_principal_name': service_principal_name, 'isql_path': isql_path}.items() if v is not None}
-        conf = check_confirmation('PATCH', endpoint, action, 'environment_source_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "allow_provisioning": allow_provisioning,
+                "is_staging": is_staging,
+                "version": version,
+                "oracle_base": oracle_base,
+                "bits": bits,
+                "port": port,
+                "instance_owner": instance_owner,
+                "installation_path": installation_path,
+                "dump_history_file": dump_history_file,
+                "database_username": database_username,
+                "database_password": database_password,
+                "service_principal_name": service_principal_name,
+                "isql_path": isql_path,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "PATCH",
+            endpoint,
+            action,
+            "environment_source_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('PATCH', endpoint, params=params, json_body=body if body else None)
-    elif action == 'delete_environment_repository':
+        return make_api_request(
+            "PATCH", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "delete_environment_repository":
         if environment_id is None:
-            return {'error': 'Missing required parameter: environment_id for action delete_environment_repository'}
+            return {
+                "error": "Missing required parameter: environment_id for action delete_environment_repository"
+            }
         if repository_id is None:
-            return {'error': 'Missing required parameter: repository_id for action delete_environment_repository'}
-        endpoint = f'/environments/{environment_id}/repository/{repository_id}'
+            return {
+                "error": "Missing required parameter: repository_id for action delete_environment_repository"
+            }
+        endpoint = f"/environments/{environment_id}/repository/{repository_id}"
         params = build_params()
-        conf = check_confirmation('DELETE', endpoint, action, 'environment_source_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "DELETE",
+            endpoint,
+            action,
+            "environment_source_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('DELETE', endpoint, params=params)
-    elif action == 'search_sources':
+        return make_api_request("DELETE", endpoint, params=params)
+    elif action == "search_sources":
         params = build_params(limit=limit, cursor=cursor, sort=sort)
-        body = {'filter_expression': filter_expression} if filter_expression else {}
-        conf = check_confirmation('POST', '/sources/search', action, 'environment_source_tool', confirmed or False, request_params=params, request_body=body)
+        body = {"filter_expression": filter_expression} if filter_expression else {}
+        conf = check_confirmation(
+            "POST",
+            "/sources/search",
+            action,
+            "environment_source_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', '/sources/search', params=params, json_body=body)
-    elif action == 'list_sources':
+        return make_api_request(
+            "POST", "/sources/search", params=params, json_body=body
+        )
+    elif action == "list_sources":
         params = build_params(limit=limit, cursor=cursor, sort=sort)
-        conf = check_confirmation('GET', '/sources', action, 'environment_source_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            "/sources",
+            action,
+            "environment_source_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', '/sources', params=params)
-    elif action == 'get_source':
+        return make_api_request("GET", "/sources", params=params)
+    elif action == "get_source":
         if source_id is None:
-            return {'error': 'Missing required parameter: source_id for action get_source'}
-        endpoint = f'/sources/{source_id}'
+            return {
+                "error": "Missing required parameter: source_id for action get_source"
+            }
+        endpoint = f"/sources/{source_id}"
         params = build_params()
-        conf = check_confirmation('GET', endpoint, action, 'environment_source_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            endpoint,
+            action,
+            "environment_source_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', endpoint, params=params)
-    elif action == 'delete_source':
+        return make_api_request("GET", endpoint, params=params)
+    elif action == "delete_source":
         if source_id is None:
-            return {'error': 'Missing required parameter: source_id for action delete_source'}
-        endpoint = f'/sources/{source_id}'
+            return {
+                "error": "Missing required parameter: source_id for action delete_source"
+            }
+        endpoint = f"/sources/{source_id}"
         params = build_params()
-        conf = check_confirmation('DELETE', endpoint, action, 'environment_source_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "DELETE",
+            endpoint,
+            action,
+            "environment_source_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('DELETE', endpoint, params=params)
-    elif action == 'verify_source_jdbc_connection':
+        return make_api_request("DELETE", endpoint, params=params)
+    elif action == "verify_source_jdbc_connection":
         if source_id is None:
-            return {'error': 'Missing required parameter: source_id for action verify_source_jdbc_connection'}
-        endpoint = f'/sources/{source_id}/jdbc-check'
-        params = build_params(database_username=database_username, database_password=database_password, jdbc_connection_string=jdbc_connection_string)
-        body = {k: v for k, v in {'database_username': database_username, 'database_password': database_password, 'jdbc_connection_string': jdbc_connection_string}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'environment_source_tool', confirmed or False, request_params=params, request_body=body)
+            return {
+                "error": "Missing required parameter: source_id for action verify_source_jdbc_connection"
+            }
+        endpoint = f"/sources/{source_id}/jdbc-check"
+        params = build_params(
+            database_username=database_username,
+            database_password=database_password,
+            jdbc_connection_string=jdbc_connection_string,
+        )
+        body = {
+            k: v
+            for k, v in {
+                "database_username": database_username,
+                "database_password": database_password,
+                "jdbc_connection_string": jdbc_connection_string,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "environment_source_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'get_source_compatible_repositories':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "get_source_compatible_repositories":
         if source_id is None:
-            return {'error': 'Missing required parameter: source_id for action get_source_compatible_repositories'}
-        endpoint = f'/sources/{source_id}/staging_compatible_repositories'
+            return {
+                "error": "Missing required parameter: source_id for action get_source_compatible_repositories"
+            }
+        endpoint = f"/sources/{source_id}/staging_compatible_repositories"
         params = build_params()
-        conf = check_confirmation('GET', endpoint, action, 'environment_source_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            endpoint,
+            action,
+            "environment_source_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', endpoint, params=params)
-    elif action == 'get_source_tags':
+        return make_api_request("GET", endpoint, params=params)
+    elif action == "get_source_tags":
         if source_id is None:
-            return {'error': 'Missing required parameter: source_id for action get_source_tags'}
-        endpoint = f'/sources/{source_id}/tags'
+            return {
+                "error": "Missing required parameter: source_id for action get_source_tags"
+            }
+        endpoint = f"/sources/{source_id}/tags"
         params = build_params()
-        conf = check_confirmation('GET', endpoint, action, 'environment_source_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            endpoint,
+            action,
+            "environment_source_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', endpoint, params=params)
-    elif action == 'add_source_tags':
+        return make_api_request("GET", endpoint, params=params)
+    elif action == "add_source_tags":
         if source_id is None:
-            return {'error': 'Missing required parameter: source_id for action add_source_tags'}
-        endpoint = f'/sources/{source_id}/tags'
+            return {
+                "error": "Missing required parameter: source_id for action add_source_tags"
+            }
+        endpoint = f"/sources/{source_id}/tags"
         params = build_params(tags=tags)
-        body = {k: v for k, v in {'tags': tags}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'environment_source_tool', confirmed or False, request_params=params, request_body=body)
+        body = {k: v for k, v in {"tags": tags}.items() if v is not None}
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "environment_source_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'delete_source_tags':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "delete_source_tags":
         if source_id is None:
-            return {'error': 'Missing required parameter: source_id for action delete_source_tags'}
-        endpoint = f'/sources/{source_id}/tags/delete'
+            return {
+                "error": "Missing required parameter: source_id for action delete_source_tags"
+            }
+        endpoint = f"/sources/{source_id}/tags/delete"
         params = build_params()
-        body = {k: v for k, v in {'key': key, 'value': value, 'tags': tags}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'environment_source_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {"key": key, "value": value, "tags": tags}.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "environment_source_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'create_oracle_source':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "create_oracle_source":
         params = build_params(oracle_config_type=oracle_config_type)
-        body = {k: v for k, v in {'oracle_config_type': oracle_config_type, 'engine_id': engine_id, 'environment_id': environment_id, 'database_name': database_name, 'repository_id': repository_id, 'instances': instances, 'unique_name': unique_name, 'instance_name': instance_name, 'oracle_services': oracle_services}.items() if v is not None}
-        conf = check_confirmation('POST', '/sources/oracle', action, 'environment_source_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "oracle_config_type": oracle_config_type,
+                "engine_id": engine_id,
+                "environment_id": environment_id,
+                "database_name": database_name,
+                "repository_id": repository_id,
+                "instances": instances,
+                "unique_name": unique_name,
+                "instance_name": instance_name,
+                "oracle_services": oracle_services,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            "/sources/oracle",
+            action,
+            "environment_source_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', '/sources/oracle', params=params, json_body=body if body else None)
-    elif action == 'update_oracle_source':
+        return make_api_request(
+            "POST", "/sources/oracle", params=params, json_body=body if body else None
+        )
+    elif action == "update_oracle_source":
         if source_id is None:
-            return {'error': 'Missing required parameter: source_id for action update_oracle_source'}
-        endpoint = f'/sources/oracle/{source_id}'
+            return {
+                "error": "Missing required parameter: source_id for action update_oracle_source"
+            }
+        endpoint = f"/sources/oracle/{source_id}"
         params = build_params()
-        body = {k: v for k, v in {'oracle_services': oracle_services, 'user': user, 'password': password, 'linking_enabled': linking_enabled}.items() if v is not None}
-        conf = check_confirmation('PATCH', endpoint, action, 'environment_source_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "oracle_services": oracle_services,
+                "user": user,
+                "password": password,
+                "linking_enabled": linking_enabled,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "PATCH",
+            endpoint,
+            action,
+            "environment_source_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('PATCH', endpoint, params=params, json_body=body if body else None)
-    elif action == 'create_postgres_source':
+        return make_api_request(
+            "PATCH", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "create_postgres_source":
         params = build_params(name=name)
-        body = {k: v for k, v in {'name': name, 'repository_id': repository_id, 'engine_id': engine_id, 'environment_id': environment_id}.items() if v is not None}
-        conf = check_confirmation('POST', '/sources/postgres', action, 'environment_source_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "name": name,
+                "repository_id": repository_id,
+                "engine_id": engine_id,
+                "environment_id": environment_id,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            "/sources/postgres",
+            action,
+            "environment_source_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', '/sources/postgres', params=params, json_body=body if body else None)
-    elif action == 'update_postgres_source':
+        return make_api_request(
+            "POST", "/sources/postgres", params=params, json_body=body if body else None
+        )
+    elif action == "update_postgres_source":
         if source_id is None:
-            return {'error': 'Missing required parameter: source_id for action update_postgres_source'}
-        endpoint = f'/sources/postgres/{source_id}'
+            return {
+                "error": "Missing required parameter: source_id for action update_postgres_source"
+            }
+        endpoint = f"/sources/postgres/{source_id}"
         params = build_params()
-        body = {k: v for k, v in {'name': name}.items() if v is not None}
-        conf = check_confirmation('PATCH', endpoint, action, 'environment_source_tool', confirmed or False, request_params=params, request_body=body)
+        body = {k: v for k, v in {"name": name}.items() if v is not None}
+        conf = check_confirmation(
+            "PATCH",
+            endpoint,
+            action,
+            "environment_source_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('PATCH', endpoint, params=params, json_body=body if body else None)
-    elif action == 'create_ase_source':
+        return make_api_request(
+            "PATCH", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "create_ase_source":
         params = build_params(database_name=database_name)
-        body = {k: v for k, v in {'database_name': database_name, 'repository_id': repository_id, 'linking_enabled': linking_enabled, 'environment_id': environment_id, 'environment_user': environment_user, 'engine_id': engine_id}.items() if v is not None}
-        conf = check_confirmation('POST', '/sources/ase', action, 'environment_source_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "database_name": database_name,
+                "repository_id": repository_id,
+                "linking_enabled": linking_enabled,
+                "environment_id": environment_id,
+                "environment_user": environment_user,
+                "engine_id": engine_id,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            "/sources/ase",
+            action,
+            "environment_source_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', '/sources/ase', params=params, json_body=body if body else None)
-    elif action == 'update_ase_source':
+        return make_api_request(
+            "POST", "/sources/ase", params=params, json_body=body if body else None
+        )
+    elif action == "update_ase_source":
         if source_id is None:
-            return {'error': 'Missing required parameter: source_id for action update_ase_source'}
-        endpoint = f'/sources/ase/{source_id}'
+            return {
+                "error": "Missing required parameter: source_id for action update_ase_source"
+            }
+        endpoint = f"/sources/ase/{source_id}"
         params = build_params()
-        body = {k: v for k, v in {'database_name': database_name, 'repository_id': repository_id, 'linking_enabled': linking_enabled, 'environment_id': environment_id, 'environment_user': environment_user, 'database_username': database_username, 'database_password': database_password}.items() if v is not None}
-        conf = check_confirmation('PATCH', endpoint, action, 'environment_source_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "database_name": database_name,
+                "repository_id": repository_id,
+                "linking_enabled": linking_enabled,
+                "environment_id": environment_id,
+                "environment_user": environment_user,
+                "database_username": database_username,
+                "database_password": database_password,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "PATCH",
+            endpoint,
+            action,
+            "environment_source_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('PATCH', endpoint, params=params, json_body=body if body else None)
-    elif action == 'create_appdata_source':
+        return make_api_request(
+            "PATCH", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "create_appdata_source":
         params = build_params(name=name, type=type)
-        body = {k: v for k, v in {'type': type, 'name': name, 'repository_id': repository_id, 'linking_enabled': linking_enabled, 'environment_user': environment_user, 'parameters': parameters, 'path': path, 'environment_id': environment_id, 'engine_id': engine_id}.items() if v is not None}
-        conf = check_confirmation('POST', '/sources/appdata', action, 'environment_source_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "type": type,
+                "name": name,
+                "repository_id": repository_id,
+                "linking_enabled": linking_enabled,
+                "environment_user": environment_user,
+                "parameters": parameters,
+                "path": path,
+                "environment_id": environment_id,
+                "engine_id": engine_id,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            "/sources/appdata",
+            action,
+            "environment_source_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', '/sources/appdata', params=params, json_body=body if body else None)
-    elif action == 'update_appdata_source':
+        return make_api_request(
+            "POST", "/sources/appdata", params=params, json_body=body if body else None
+        )
+    elif action == "update_appdata_source":
         if source_id is None:
-            return {'error': 'Missing required parameter: source_id for action update_appdata_source'}
-        endpoint = f'/sources/appdata/{source_id}'
+            return {
+                "error": "Missing required parameter: source_id for action update_appdata_source"
+            }
+        endpoint = f"/sources/appdata/{source_id}"
         params = build_params()
-        body = {k: v for k, v in {'name': name, 'repository_id': repository_id, 'environment_id': environment_id, 'linking_enabled': linking_enabled, 'environment_user': environment_user, 'parameters': parameters, 'path': path}.items() if v is not None}
-        conf = check_confirmation('PATCH', endpoint, action, 'environment_source_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "name": name,
+                "repository_id": repository_id,
+                "environment_id": environment_id,
+                "linking_enabled": linking_enabled,
+                "environment_user": environment_user,
+                "parameters": parameters,
+                "path": path,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "PATCH",
+            endpoint,
+            action,
+            "environment_source_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('PATCH', endpoint, params=params, json_body=body if body else None)
+        return make_api_request(
+            "PATCH", endpoint, params=params, json_body=body if body else None
+        )
     else:
-        return {'error': f'Unknown action: {action}. Valid actions: search_environments, get_environment, create_environment, add_environment_users, set_environment_primary_user, update_environment_users, delete_environment_users, update_environment, delete_environment, enable_environment, disable_environment, refresh_environment, list_environment_hosts, update_environment_host, delete_environment_host, list_environment_listeners, get_environment_tags, add_environment_tags, delete_environment_tags, get_environment_compatible_repositories_by_snapshot, get_environment_compatible_repositories_by_timestamp, get_environment_compatible_repositories_by_location, update_environment_repository, delete_environment_repository, search_sources, list_sources, get_source, delete_source, verify_source_jdbc_connection, get_source_compatible_repositories, get_source_tags, add_source_tags, delete_source_tags, create_oracle_source, update_oracle_source, create_postgres_source, update_postgres_source, create_ase_source, update_ase_source, create_appdata_source, update_appdata_source'}
+        return {
+            "error": f"Unknown action: {action}. Valid actions: search_environments, get_environment, create_environment, add_environment_users, set_environment_primary_user, update_environment_users, delete_environment_users, update_environment, delete_environment, enable_environment, disable_environment, refresh_environment, list_environment_hosts, update_environment_host, delete_environment_host, list_environment_listeners, get_environment_tags, add_environment_tags, delete_environment_tags, get_environment_compatible_repositories_by_snapshot, get_environment_compatible_repositories_by_timestamp, get_environment_compatible_repositories_by_location, update_environment_repository, delete_environment_repository, search_sources, list_sources, get_source, delete_source, verify_source_jdbc_connection, get_source_compatible_repositories, get_source_tags, add_source_tags, delete_source_tags, create_oracle_source, update_oracle_source, create_postgres_source, update_postgres_source, create_ase_source, update_ase_source, create_appdata_source, update_appdata_source"
+        }
+
 
 @log_tool_execution
 def toolkit_tool(
@@ -1372,13 +2201,13 @@ def toolkit_tool(
 ) -> Dict[str, Any]:
     """
     Unified tool for TOOLKIT operations.
-    
+
     This tool supports 7 actions: search, get, upload_toolkit, delete_toolkit, get_tags, add_tags, delete_tags
-    
+
     ======================================================================
     ACTION REFERENCE
     ======================================================================
-    
+
     ACTION: search
     ----------------------------------------
     Summary: Search for toolkits.
@@ -1386,7 +2215,7 @@ def toolkit_tool(
     Endpoint: /toolkits/search
     Required Parameters: limit, cursor, sort
     Key Parameters (provide as applicable): filter_expression
-    
+
     Filterable Fields:
         - id: Id of the toolkit.
         - type: Specifies whether this object is toolkit or plugin
@@ -1399,81 +2228,81 @@ def toolkit_tool(
         - upgrade_definition: Definition of how to upgrade sources of this type.
         - snapshot_parameters_definition: The schema that defines the structure of the fields in Ap...
         - build_api: The Delphix API version that the toolkit was built against.
-        - display_name: 
-        - pretty_name: 
-        - version: 
-        - namespace: 
-        - identifier: 
-        - root_squash_enabled: 
-        - default_locale: 
-        - status: 
-        - language: 
-        - extended_start_stop_hooks: 
-        - entry_point: 
-        - lua_name: 
-        - minimum_lua_version: 
-        - host_types: 
-        - snapshot_schema: 
-        - resources: 
+        - display_name:
+        - pretty_name:
+        - version:
+        - namespace:
+        - identifier:
+        - root_squash_enabled:
+        - default_locale:
+        - status:
+        - language:
+        - extended_start_stop_hooks:
+        - entry_point:
+        - lua_name:
+        - minimum_lua_version:
+        - host_types:
+        - snapshot_schema:
+        - resources:
         - tags: Tags associated to this toolkit.
-    
+
     Filter Syntax:
         Operators: EQ, NE, GT, GE, LT, LE, CONTAINS, IN, NOT_IN
         Combine: AND, OR
         Example: "name CONTAINS 'prod' AND status EQ 'RUNNING'"
-    
+
     Example:
         >>> toolkit_tool(action='search', limit=..., cursor=..., sort=..., filter_expression="name CONTAINS 'test'")
-    
+
     ACTION: get
     ----------------------------------------
     Summary: Get Toolkit by ID.
     Method: GET
     Endpoint: /toolkits/{toolkitId}
     Required Parameters: toolkit_id
-    
+
     Example:
         >>> toolkit_tool(action='get', toolkit_id='example-toolkit-123')
-    
+
     ACTION: upload_toolkit
     ----------------------------------------
     Summary: Upload toolkit to engines.
     Method: POST
     Endpoint: /toolkits/upload
-    
+
     Example:
         >>> toolkit_tool(action='upload_toolkit')
-    
+
     ACTION: delete_toolkit
     ----------------------------------------
     Summary: Delete a Toolkit by ID.
     Method: DELETE
     Endpoint: /toolkits/{toolkitId}
     Required Parameters: toolkit_id
-    
+
     Example:
         >>> toolkit_tool(action='delete_toolkit', toolkit_id='example-toolkit-123')
-    
+
     ACTION: get_tags
     ----------------------------------------
     Summary: Get tags for a Toolkit.
     Method: GET
     Endpoint: /toolkits/{toolkitId}/tags
     Required Parameters: toolkit_id
-    
+
     Example:
         >>> toolkit_tool(action='get_tags', toolkit_id='example-toolkit-123')
-    
+
     ACTION: add_tags
     ----------------------------------------
     Summary: Create tags for a toolkit.
     Method: POST
     Endpoint: /toolkits/{toolkitId}/tags
     Required Parameters: toolkit_id, tags
-    
+
     Example:
         >>> toolkit_tool(action='add_tags', toolkit_id='example-toolkit-123', tags=...)
-    
+
     ACTION: delete_tags
     ----------------------------------------
     Summary: Delete tags for a Toolkit.
@@ -1481,17 +2310,17 @@ def toolkit_tool(
     Endpoint: /toolkits/{toolkitId}/tags/delete
     Required Parameters: toolkit_id
     Key Parameters (provide as applicable): tags, key, value
-    
+
     Example:
         >>> toolkit_tool(action='delete_tags', toolkit_id='example-toolkit-123', tags=..., key=..., value=...)
-    
+
     ======================================================================
     PARAMETERS
     ======================================================================
-    
+
     Args:
         action (str): The operation to perform. One of: search, get, upload_toolkit, delete_toolkit, get_tags, add_tags, delete_tags
-    
+
       -- General parameters (all database types) --
         cursor (str): Cursor to fetch the next or previous page of results. The value of this prope...
             [Required for: search]
@@ -1509,87 +2338,163 @@ def toolkit_tool(
             [Required for: get, delete_toolkit, get_tags, add_tags, delete_tags]
         value (str): Value of the tag
             [Optional for all actions]
-    
+
     Returns:
         Dict[str, Any]: The API response containing operation results
-    
+
     Raises:
         Returns error dict if required parameters are missing for the action
     """
     # Route to appropriate API based on action
-    if action == 'search':
+    if action == "search":
         params = build_params(limit=limit, cursor=cursor, sort=sort)
-        body = {'filter_expression': filter_expression} if filter_expression else {}
-        conf = check_confirmation('POST', '/toolkits/search', action, 'toolkit_tool', confirmed or False, request_params=params, request_body=body)
+        body = {"filter_expression": filter_expression} if filter_expression else {}
+        conf = check_confirmation(
+            "POST",
+            "/toolkits/search",
+            action,
+            "toolkit_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', '/toolkits/search', params=params, json_body=body)
-    elif action == 'get':
+        return make_api_request(
+            "POST", "/toolkits/search", params=params, json_body=body
+        )
+    elif action == "get":
         if toolkit_id is None:
-            return {'error': 'Missing required parameter: toolkit_id for action get'}
-        endpoint = f'/toolkits/{toolkit_id}'
+            return {"error": "Missing required parameter: toolkit_id for action get"}
+        endpoint = f"/toolkits/{toolkit_id}"
         params = build_params()
-        conf = check_confirmation('GET', endpoint, action, 'toolkit_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            endpoint,
+            action,
+            "toolkit_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', endpoint, params=params)
-    elif action == 'upload_toolkit':
+        return make_api_request("GET", endpoint, params=params)
+    elif action == "upload_toolkit":
         params = build_params()
-        conf = check_confirmation('POST', '/toolkits/upload', action, 'toolkit_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "POST",
+            "/toolkits/upload",
+            action,
+            "toolkit_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('POST', '/toolkits/upload', params=params)
-    elif action == 'delete_toolkit':
+        return make_api_request("POST", "/toolkits/upload", params=params)
+    elif action == "delete_toolkit":
         if toolkit_id is None:
-            return {'error': 'Missing required parameter: toolkit_id for action delete_toolkit'}
-        endpoint = f'/toolkits/{toolkit_id}'
+            return {
+                "error": "Missing required parameter: toolkit_id for action delete_toolkit"
+            }
+        endpoint = f"/toolkits/{toolkit_id}"
         params = build_params()
-        conf = check_confirmation('DELETE', endpoint, action, 'toolkit_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "DELETE",
+            endpoint,
+            action,
+            "toolkit_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('DELETE', endpoint, params=params)
-    elif action == 'get_tags':
+        return make_api_request("DELETE", endpoint, params=params)
+    elif action == "get_tags":
         if toolkit_id is None:
-            return {'error': 'Missing required parameter: toolkit_id for action get_tags'}
-        endpoint = f'/toolkits/{toolkit_id}/tags'
+            return {
+                "error": "Missing required parameter: toolkit_id for action get_tags"
+            }
+        endpoint = f"/toolkits/{toolkit_id}/tags"
         params = build_params()
-        conf = check_confirmation('GET', endpoint, action, 'toolkit_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            endpoint,
+            action,
+            "toolkit_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', endpoint, params=params)
-    elif action == 'add_tags':
+        return make_api_request("GET", endpoint, params=params)
+    elif action == "add_tags":
         if toolkit_id is None:
-            return {'error': 'Missing required parameter: toolkit_id for action add_tags'}
-        endpoint = f'/toolkits/{toolkit_id}/tags'
+            return {
+                "error": "Missing required parameter: toolkit_id for action add_tags"
+            }
+        endpoint = f"/toolkits/{toolkit_id}/tags"
         params = build_params(tags=tags)
-        body = {k: v for k, v in {'tags': tags}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'toolkit_tool', confirmed or False, request_params=params, request_body=body)
+        body = {k: v for k, v in {"tags": tags}.items() if v is not None}
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "toolkit_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'delete_tags':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "delete_tags":
         if toolkit_id is None:
-            return {'error': 'Missing required parameter: toolkit_id for action delete_tags'}
-        endpoint = f'/toolkits/{toolkit_id}/tags/delete'
+            return {
+                "error": "Missing required parameter: toolkit_id for action delete_tags"
+            }
+        endpoint = f"/toolkits/{toolkit_id}/tags/delete"
         params = build_params()
-        body = {k: v for k, v in {'key': key, 'value': value, 'tags': tags}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'toolkit_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {"key": key, "value": value, "tags": tags}.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "toolkit_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
     else:
-        return {'error': f'Unknown action: {action}. Valid actions: search, get, upload_toolkit, delete_toolkit, get_tags, add_tags, delete_tags'}
+        return {
+            "error": f"Unknown action: {action}. Valid actions: search, get, upload_toolkit, delete_toolkit, get_tags, add_tags, delete_tags"
+        }
 
 
 def register_tools(app, dct_client):
     global client
     client = dct_client
-    logger.info(f'Registering tools for environment_endpoints...')
+    logger.info("Registering tools for environment_endpoints...")
     try:
-        logger.info(f'  Registering tool function: environment_source_tool')
+        logger.info("  Registering tool function: environment_source_tool")
         app.add_tool(environment_source_tool, name="environment_source_tool")
-        logger.info(f'  Registering tool function: toolkit_tool')
+        logger.info("  Registering tool function: toolkit_tool")
         app.add_tool(toolkit_tool, name="toolkit_tool")
     except Exception as e:
-        logger.error(f'Error registering tools for environment_endpoints: {e}')
-    logger.info(f'Tools registration finished for environment_endpoints.')
+        logger.error(f"Error registering tools for environment_endpoints: {e}")
+    logger.info("Tools registration finished for environment_endpoints.")

--- a/src/dct_mcp_server/tools/iam_endpoints_tool.py
+++ b/src/dct_mcp_server/tools/iam_endpoints_tool.py
@@ -1,7 +1,6 @@
-from mcp.server.fastmcp import FastMCP
-from typing import Dict,Any,Optional
+from typing import Dict, Any, Optional
 from dct_mcp_server.core.decorators import log_tool_execution
-from dct_mcp_server.config import get_confirmation_for_operation, requires_confirmation
+from dct_mcp_server.config import get_confirmation_for_operation
 import asyncio
 import logging
 import threading
@@ -29,7 +28,16 @@ logger = logging.getLogger(__name__)
 #       }
 # =============================================================================
 
-def check_confirmation(method: str, api_path: str, action: str, tool_name: str, confirmed: bool = False, request_params: Optional[Dict[str, Any]] = None, request_body: Optional[Dict[str, Any]] = None) -> Optional[Dict[str, Any]]:
+
+def check_confirmation(
+    method: str,
+    api_path: str,
+    action: str,
+    tool_name: str,
+    confirmed: bool = False,
+    request_params: Optional[Dict[str, Any]] = None,
+    request_body: Optional[Dict[str, Any]] = None,
+) -> Optional[Dict[str, Any]]:
     """Check if operation requires confirmation. Returns confirmation response or None if confirmed/not needed."""
     confirmation = get_confirmation_for_operation(method, api_path)
     if confirmation["level"] != "none" and not confirmed:
@@ -41,7 +49,11 @@ def check_confirmation(method: str, api_path: str, action: str, tool_name: str, 
             review.update(request_params)
         if request_body:
             review.update(request_body)
-        is_review_critical = action.startswith("provision_") or action.startswith("dsource_link_") or action == "dsource_create_snapshot"
+        is_review_critical = (
+            action.startswith("provision_")
+            or action.startswith("dsource_link_")
+            or action == "dsource_create_snapshot"
+        )
         instructions = (
             "STOP: You MUST display the confirmation_message to the user and wait for their EXPLICIT "
             "approval before re-calling with confirmed=True. Do NOT proceed without user consent."
@@ -56,7 +68,9 @@ def check_confirmation(method: str, api_path: str, action: str, tool_name: str, 
         return {
             "status": "confirmation_required",
             "confirmation_level": confirmation["level"],
-            "confirmation_message": confirmation.get("message", "Please confirm this operation."),
+            "confirmation_message": confirmation.get(
+                "message", "Please confirm this operation."
+            ),
             "action": action,
             "tool": tool_name,
             "api_path": api_path,
@@ -66,8 +80,10 @@ def check_confirmation(method: str, api_path: str, action: str, tool_name: str, 
         }
     return None
 
+
 def async_to_sync(async_func):
     """Utility decorator to convert async functions to sync with proper event loop handling."""
+
     @wraps(async_func)
     def wrapper(*args, **kwargs):
         try:
@@ -76,12 +92,14 @@ def async_to_sync(async_func):
                 # Create a task and run it synchronously
                 result = None
                 exception = None
+
                 def run_in_thread():
                     nonlocal result, exception
                     try:
                         result = asyncio.run(async_func(*args, **kwargs))
                     except Exception as e:
                         exception = e
+
                 thread = threading.Thread(target=run_in_thread)
                 thread.start()
                 thread.join()
@@ -92,18 +110,28 @@ def async_to_sync(async_func):
                 return loop.run_until_complete(async_func(*args, **kwargs))
         except RuntimeError:
             return asyncio.run(async_func(*args, **kwargs))
+
     return wrapper
 
-def make_api_request(method: str, endpoint: str, params: dict = None, json_body: dict = None):
+
+def make_api_request(
+    method: str, endpoint: str, params: dict = None, json_body: dict = None
+):
     """Utility function to make API requests with consistent parameter handling."""
+
     @async_to_sync
     async def _make_request():
-        return await client.make_request(method, endpoint, params=params or {}, json=json_body)
+        return await client.make_request(
+            method, endpoint, params=params or {}, json=json_body
+        )
+
     return _make_request()
+
 
 def build_params(**kwargs):
     """Build parameters dictionary excluding None and empty string values."""
-    return {k: v for k, v in kwargs.items() if v is not None and v != ''}
+    return {k: v for k, v in kwargs.items() if v is not None and v != ""}
+
 
 @log_tool_execution
 def iam_tool(
@@ -155,13 +183,13 @@ def iam_tool(
 ) -> Dict[str, Any]:
     """
     Unified tool for IAM operations.
-    
+
     This tool supports 42 actions: search_accounts, get_account, create_account, delete_account, enable_account, disable_account, reset_password, get_account_tags, add_account_tags, delete_account_tags, get_account_ui_profiles, get_password_policies, update_password_policies, search_roles, get_role, create_role, update_role, delete_role, add_role_permissions, delete_role_permissions, get_role_tags, add_role_tags, delete_role_tags, add_role_ui_profiles, delete_role_ui_profiles, search_access_groups, get_access_group, create_access_group, update_access_group, delete_access_group, add_access_group_tags, delete_access_group_tags, add_access_group_scopes, get_access_group_scope, update_access_group_scope, delete_access_group_scope, add_scope_object_tags, delete_scope_object_tags, add_scope_objects, delete_scope_objects, add_scope_always_allowed_permissions, delete_scope_always_allowed_permissions
-    
+
     ======================================================================
     ACTION REFERENCE
     ======================================================================
-    
+
     ACTION: search_accounts
     ----------------------------------------
     Summary: Search for Accounts.
@@ -169,7 +197,7 @@ def iam_tool(
     Endpoint: /management/accounts/search
     Required Parameters: limit, cursor, sort
     Key Parameters (provide as applicable): filter_expression
-    
+
     Filterable Fields:
         - id: Numeric ID of the Account.
         - api_client_id: The unique ID which is used to identify the identity of a...
@@ -184,25 +212,25 @@ def iam_tool(
         - effective_scopes: Access group scopes associated with this account.
         - tags: The tags to be created for this Account.
         - enabled: Whether this account can be used to make API calls.
-    
+
     Filter Syntax:
         Operators: EQ, NE, GT, GE, LT, LE, CONTAINS, IN, NOT_IN
         Combine: AND, OR
         Example: "name CONTAINS 'prod' AND status EQ 'RUNNING'"
-    
+
     Example:
         >>> iam_tool(action='search_accounts', limit=..., cursor=..., sort=..., filter_expression="name CONTAINS 'test'")
-    
+
     ACTION: get_account
     ----------------------------------------
     Summary: Get an Account by id
     Method: GET
     Endpoint: /management/accounts/{id}
     Required Parameters: id
-    
+
     Example:
         >>> iam_tool(action='get_account', id=...)
-    
+
     ACTION: create_account
     ----------------------------------------
     Summary: Create a new Account
@@ -210,40 +238,40 @@ def iam_tool(
     Method: POST
     Endpoint: /management/accounts
     Key Parameters (provide as applicable): is_admin, generate_api_key, api_client_id, first_name, last_name, email, username, password, ldap_principal, tags
-    
+
     Example:
         >>> iam_tool(action='create_account', is_admin=..., generate_api_key=..., api_client_id='example-api_client-123', first_name=..., last_name=..., email=..., username=..., password=..., ldap_principal=..., tags=...)
-    
+
     ACTION: delete_account
     ----------------------------------------
     Summary: Delete an Account
     Method: DELETE
     Endpoint: /management/accounts/{id}
     Required Parameters: id
-    
+
     Example:
         >>> iam_tool(action='delete_account', id=...)
-    
+
     ACTION: enable_account
     ----------------------------------------
     Summary: Enable an Account.
     Method: POST
     Endpoint: /management/accounts/{id}/enable
     Required Parameters: id
-    
+
     Example:
         >>> iam_tool(action='enable_account', id=...)
-    
+
     ACTION: disable_account
     ----------------------------------------
     Summary: Disable an Account.
     Method: POST
     Endpoint: /management/accounts/{id}/disable
     Required Parameters: id
-    
+
     Example:
         >>> iam_tool(action='disable_account', id=...)
-    
+
     ACTION: reset_password
     ----------------------------------------
     Summary: Reset Account Password.
@@ -252,30 +280,30 @@ def iam_tool(
     Endpoint: /management/accounts/{id}/reset_password
     Required Parameters: id
     Key Parameters (provide as applicable): new_password
-    
+
     Example:
         >>> iam_tool(action='reset_password', id=..., new_password=...)
-    
+
     ACTION: get_account_tags
     ----------------------------------------
     Summary: Get tags for an Account.
     Method: GET
     Endpoint: /management/accounts/{id}/tags
     Required Parameters: id
-    
+
     Example:
         >>> iam_tool(action='get_account_tags', id=...)
-    
+
     ACTION: add_account_tags
     ----------------------------------------
     Summary: Create tags for an Account.
     Method: POST
     Endpoint: /management/accounts/{id}/tags
     Required Parameters: id, tags
-    
+
     Example:
         >>> iam_tool(action='add_account_tags', id=..., tags=...)
-    
+
     ACTION: delete_account_tags
     ----------------------------------------
     Summary: Delete tags for an Account.
@@ -283,39 +311,39 @@ def iam_tool(
     Endpoint: /management/accounts/{id}/tags/delete
     Required Parameters: id
     Key Parameters (provide as applicable): tags, key, value
-    
+
     Example:
         >>> iam_tool(action='delete_account_tags', id=..., tags=..., key=..., value=...)
-    
+
     ACTION: get_account_ui_profiles
     ----------------------------------------
     Summary: Returns the list of effective UI profiles for an account. This can only be called for one's own account.
     Method: GET
     Endpoint: /management/accounts/{id}/ui-profiles
     Required Parameters: id
-    
+
     Example:
         >>> iam_tool(action='get_account_ui_profiles', id=...)
-    
+
     ACTION: get_password_policies
     ----------------------------------------
     Summary: Returns the password policies
     Method: GET
     Endpoint: /management/accounts/password-policies
-    
+
     Example:
         >>> iam_tool(action='get_password_policies')
-    
+
     ACTION: update_password_policies
     ----------------------------------------
     Summary: Update password policies.
     Method: PATCH
     Endpoint: /management/accounts/password-policies
     Key Parameters (provide as applicable): enabled, min_length, reuse_disallow_limit, digit, uppercase_letter, lowercase_letter, special_character, disallow_username_as_password, maximum_password_attempts
-    
+
     Example:
         >>> iam_tool(action='update_password_policies', enabled=..., min_length=..., reuse_disallow_limit=..., digit=..., uppercase_letter=..., lowercase_letter=..., special_character=..., disallow_username_as_password=..., maximum_password_attempts=...)
-    
+
     ACTION: search_roles
     ----------------------------------------
     Summary: Search for roles.
@@ -323,27 +351,27 @@ def iam_tool(
     Endpoint: /roles/search
     Required Parameters: limit, cursor, sort
     Key Parameters (provide as applicable): filter_expression
-    
+
     Filterable Fields:
-    
+
     Filter Syntax:
         Operators: EQ, NE, GT, GE, LT, LE, CONTAINS, IN, NOT_IN
         Combine: AND, OR
         Example: "name CONTAINS 'prod' AND status EQ 'RUNNING'"
-    
+
     Example:
         >>> iam_tool(action='search_roles', limit=..., cursor=..., sort=..., filter_expression="name CONTAINS 'test'")
-    
+
     ACTION: get_role
     ----------------------------------------
     Summary: Returns role by ID.
     Method: GET
     Endpoint: /roles/{roleId}
     Required Parameters: role_id
-    
+
     Example:
         >>> iam_tool(action='get_role', role_id='example-role-123')
-    
+
     ACTION: create_role
     ----------------------------------------
     Summary: Create custom role
@@ -351,10 +379,10 @@ def iam_tool(
     Endpoint: /roles
     Required Parameters: name, permission_objects
     Key Parameters (provide as applicable): tags, description, immutable, ui_profiles
-    
+
     Example:
         >>> iam_tool(action='create_role', tags=..., name=..., description=..., permission_objects=..., immutable=..., ui_profiles=...)
-    
+
     ACTION: update_role
     ----------------------------------------
     Summary: Update a Role.
@@ -362,60 +390,60 @@ def iam_tool(
     Endpoint: /roles/{roleId}
     Required Parameters: role_id
     Key Parameters (provide as applicable): name, description
-    
+
     Example:
         >>> iam_tool(action='update_role', role_id='example-role-123', name=..., description=...)
-    
+
     ACTION: delete_role
     ----------------------------------------
     Summary: Delete role by ID.
     Method: DELETE
     Endpoint: /roles/{roleId}
     Required Parameters: role_id
-    
+
     Example:
         >>> iam_tool(action='delete_role', role_id='example-role-123')
-    
+
     ACTION: add_role_permissions
     ----------------------------------------
     Summary: Add permissions to a role.
     Method: POST
     Endpoint: /roles/{roleId}/permissions
     Required Parameters: role_id, permission_objects
-    
+
     Example:
         >>> iam_tool(action='add_role_permissions', role_id='example-role-123', permission_objects=...)
-    
+
     ACTION: delete_role_permissions
     ----------------------------------------
     Summary: Remove permissions from a role.
     Method: POST
     Endpoint: /roles/{roleId}/permissions/delete
     Required Parameters: role_id, permission_objects
-    
+
     Example:
         >>> iam_tool(action='delete_role_permissions', role_id='example-role-123', permission_objects=...)
-    
+
     ACTION: get_role_tags
     ----------------------------------------
     Summary: Get tags for a Role.
     Method: GET
     Endpoint: /roles/{roleId}/tags
     Required Parameters: role_id
-    
+
     Example:
         >>> iam_tool(action='get_role_tags', role_id='example-role-123')
-    
+
     ACTION: add_role_tags
     ----------------------------------------
     Summary: Create tags for a role.
     Method: POST
     Endpoint: /roles/{roleId}/tags
     Required Parameters: tags, role_id
-    
+
     Example:
         >>> iam_tool(action='add_role_tags', tags=..., role_id='example-role-123')
-    
+
     ACTION: delete_role_tags
     ----------------------------------------
     Summary: Delete tags for a Role.
@@ -423,30 +451,30 @@ def iam_tool(
     Endpoint: /roles/{roleId}/tags/delete
     Required Parameters: role_id
     Key Parameters (provide as applicable): tags, key, value
-    
+
     Example:
         >>> iam_tool(action='delete_role_tags', tags=..., key=..., value=..., role_id='example-role-123')
-    
+
     ACTION: add_role_ui_profiles
     ----------------------------------------
     Summary: Add UI profiles to a role.
     Method: POST
     Endpoint: /roles/{roleId}/ui-profiles
     Required Parameters: role_id, ui_profiles
-    
+
     Example:
         >>> iam_tool(action='add_role_ui_profiles', role_id='example-role-123', ui_profiles=...)
-    
+
     ACTION: delete_role_ui_profiles
     ----------------------------------------
     Summary: Delete UI profiles from a Role.
     Method: POST
     Endpoint: /roles/{roleId}/ui-profiles/delete
     Required Parameters: role_id, ui_profiles
-    
+
     Example:
         >>> iam_tool(action='delete_role_ui_profiles', role_id='example-role-123', ui_profiles=...)
-    
+
     ACTION: search_access_groups
     ----------------------------------------
     Summary: Search for access groups.
@@ -454,7 +482,7 @@ def iam_tool(
     Endpoint: /access-groups/search
     Required Parameters: limit, cursor, sort
     Key Parameters (provide as applicable): filter_expression
-    
+
     Filterable Fields:
         - id: The Access group ID.
         - name: The Access group name
@@ -463,25 +491,25 @@ def iam_tool(
         - tagged_account_ids: List of accounts ids included by tags in the Access group.
         - account_tags: List of account tags. Accounts matching any of these tags...
         - scopes: The Access group scopes.
-    
+
     Filter Syntax:
         Operators: EQ, NE, GT, GE, LT, LE, CONTAINS, IN, NOT_IN
         Combine: AND, OR
         Example: "name CONTAINS 'prod' AND status EQ 'RUNNING'"
-    
+
     Example:
         >>> iam_tool(action='search_access_groups', limit=..., cursor=..., sort=..., filter_expression="name CONTAINS 'test'")
-    
+
     ACTION: get_access_group
     ----------------------------------------
     Summary: Returns an Access group by ID.
     Method: GET
     Endpoint: /access-groups/{accessGroupId}
     Required Parameters: access_group_id
-    
+
     Example:
         >>> iam_tool(action='get_access_group', access_group_id='example-access_group-123')
-    
+
     ACTION: create_access_group
     ----------------------------------------
     Summary: Create a new access group.
@@ -489,10 +517,10 @@ def iam_tool(
     Endpoint: /access-groups
     Required Parameters: name
     Key Parameters (provide as applicable): id, single_account, account_ids, tagged_account_ids, account_tags, scopes
-    
+
     Example:
         >>> iam_tool(action='create_access_group', id=..., name=..., single_account=..., account_ids=..., tagged_account_ids=..., account_tags=..., scopes=...)
-    
+
     ACTION: update_access_group
     ----------------------------------------
     Summary: Update an Access group.
@@ -500,30 +528,30 @@ def iam_tool(
     Endpoint: /access-groups/{accessGroupId}
     Required Parameters: access_group_id
     Key Parameters (provide as applicable): name
-    
+
     Example:
         >>> iam_tool(action='update_access_group', name=..., access_group_id='example-access_group-123')
-    
+
     ACTION: delete_access_group
     ----------------------------------------
     Summary: Delete an Access group.
     Method: DELETE
     Endpoint: /access-groups/{accessGroupId}
     Required Parameters: access_group_id
-    
+
     Example:
         >>> iam_tool(action='delete_access_group', access_group_id='example-access_group-123')
-    
+
     ACTION: add_access_group_tags
     ----------------------------------------
     Summary: Add account tags to an Access group
     Method: POST
     Endpoint: /access-groups/{accessGroupId}/tags
     Required Parameters: tags, access_group_id
-    
+
     Example:
         >>> iam_tool(action='add_access_group_tags', tags=..., access_group_id='example-access_group-123')
-    
+
     ACTION: delete_access_group_tags
     ----------------------------------------
     Summary: Remove account tags from an access group.
@@ -531,30 +559,30 @@ def iam_tool(
     Endpoint: /access-groups/{accessGroupId}/tags/delete
     Required Parameters: access_group_id
     Key Parameters (provide as applicable): tags, key, value
-    
+
     Example:
         >>> iam_tool(action='delete_access_group_tags', tags=..., key=..., value=..., access_group_id='example-access_group-123')
-    
+
     ACTION: add_access_group_scopes
     ----------------------------------------
     Summary: Add scopes to an Access group
     Method: POST
     Endpoint: /access-groups/{accessGroupId}/scopes
     Required Parameters: access_group_id, scopes
-    
+
     Example:
         >>> iam_tool(action='add_access_group_scopes', access_group_id='example-access_group-123', scopes=...)
-    
+
     ACTION: get_access_group_scope
     ----------------------------------------
     Summary: Get access group scope.
     Method: GET
     Endpoint: /access-groups/{accessGroupId}/scopes/{scopeId}
     Required Parameters: access_group_id, scope_id
-    
+
     Example:
         >>> iam_tool(action='get_access_group_scope', access_group_id='example-access_group-123', scope_id='example-scope-123')
-    
+
     ACTION: update_access_group_scope
     ----------------------------------------
     Summary: Update access group scope.
@@ -562,30 +590,30 @@ def iam_tool(
     Endpoint: /access-groups/{accessGroupId}/scopes/{scopeId}
     Required Parameters: access_group_id, scope_id
     Key Parameters (provide as applicable): name, scope_type
-    
+
     Example:
         >>> iam_tool(action='update_access_group_scope', name=..., access_group_id='example-access_group-123', scope_id='example-scope-123', scope_type=...)
-    
+
     ACTION: delete_access_group_scope
     ----------------------------------------
     Summary: Remove the scope from the Access group.
     Method: DELETE
     Endpoint: /access-groups/{accessGroupId}/scopes/{scopeId}
     Required Parameters: access_group_id, scope_id
-    
+
     Example:
         >>> iam_tool(action='delete_access_group_scope', access_group_id='example-access_group-123', scope_id='example-scope-123')
-    
+
     ACTION: add_scope_object_tags
     ----------------------------------------
     Summary: Add object tags to the access group scope.
     Method: POST
     Endpoint: /access-groups/{accessGroupId}/scopes/{scopeId}/object-tags
     Required Parameters: tags, access_group_id, scope_id
-    
+
     Example:
         >>> iam_tool(action='add_scope_object_tags', tags=..., access_group_id='example-access_group-123', scope_id='example-scope-123')
-    
+
     ACTION: delete_scope_object_tags
     ----------------------------------------
     Summary: Remove tags from the access group scope.
@@ -593,57 +621,57 @@ def iam_tool(
     Endpoint: /access-groups/{accessGroupId}/scopes/{scopeId}/object-tags/delete
     Required Parameters: access_group_id, scope_id
     Key Parameters (provide as applicable): tags
-    
+
     Example:
         >>> iam_tool(action='delete_scope_object_tags', tags=..., access_group_id='example-access_group-123', scope_id='example-scope-123')
-    
+
     ACTION: add_scope_objects
     ----------------------------------------
     Summary: Add objects to the access group scope.
     Method: POST
     Endpoint: /access-groups/{accessGroupId}/scopes/{scopeId}/objects
     Required Parameters: access_group_id, scope_id, objects
-    
+
     Example:
         >>> iam_tool(action='add_scope_objects', access_group_id='example-access_group-123', scope_id='example-scope-123', objects=...)
-    
+
     ACTION: delete_scope_objects
     ----------------------------------------
     Summary: Remove objects from the access group scope.
     Method: POST
     Endpoint: /access-groups/{accessGroupId}/scopes/{scopeId}/objects/delete
     Required Parameters: access_group_id, scope_id, objects
-    
+
     Example:
         >>> iam_tool(action='delete_scope_objects', access_group_id='example-access_group-123', scope_id='example-scope-123', objects=...)
-    
+
     ACTION: add_scope_always_allowed_permissions
     ----------------------------------------
     Summary: Add always allowed permissions for given object type.
     Method: POST
     Endpoint: /access-groups/{accessGroupId}/scopes/{scopeId}/always_allowed_permissions
     Required Parameters: access_group_id, scope_id, always_allowed_permissions
-    
+
     Example:
         >>> iam_tool(action='add_scope_always_allowed_permissions', access_group_id='example-access_group-123', scope_id='example-scope-123', always_allowed_permissions=...)
-    
+
     ACTION: delete_scope_always_allowed_permissions
     ----------------------------------------
     Summary: Remove always allowed permissions for given object type.
     Method: POST
     Endpoint: /access-groups/{accessGroupId}/scopes/{scopeId}/always_allowed_permissions/delete
     Required Parameters: access_group_id, scope_id, always_allowed_permissions
-    
+
     Example:
         >>> iam_tool(action='delete_scope_always_allowed_permissions', access_group_id='example-access_group-123', scope_id='example-scope-123', always_allowed_permissions=...)
-    
+
     ======================================================================
     PARAMETERS
     ======================================================================
-    
+
     Args:
         action (str): The operation to perform. One of: search_accounts, get_account, create_account, delete_account, enable_account, disable_account, reset_password, get_account_tags, add_account_tags, delete_account_tags, get_account_ui_profiles, get_password_policies, update_password_policies, search_roles, get_role, create_role, update_role, delete_role, add_role_permissions, delete_role_permissions, get_role_tags, add_role_tags, delete_role_tags, add_role_ui_profiles, delete_role_ui_profiles, search_access_groups, get_access_group, create_access_group, update_access_group, delete_access_group, add_access_group_tags, delete_access_group_tags, add_access_group_scopes, get_access_group_scope, update_access_group_scope, delete_access_group_scope, add_scope_object_tags, delete_scope_object_tags, add_scope_objects, delete_scope_objects, add_scope_always_allowed_permissions, delete_scope_always_allowed_permissions
-    
+
       -- General parameters (all database types) --
         access_group_id (str): The unique identifier for the accessGroup.
             [Required for: get_access_group, update_access_group, delete_access_group, add_access_group_tags, delete_access_group_tags, add_access_group_scopes, get_access_group_scope, update_access_group_scope, delete_access_group_scope, add_scope_object_tags, delete_scope_object_tags, add_scope_objects, delete_scope_objects, add_scope_always_allowed_permissions, delete_scope_always_allowed_permissions]
@@ -731,416 +759,989 @@ def iam_tool(
             [Optional for all actions]
         value (str): Value of the tag
             [Optional for all actions]
-    
+
     Returns:
         Dict[str, Any]: The API response containing operation results
-    
+
     Raises:
         Returns error dict if required parameters are missing for the action
     """
     # Route to appropriate API based on action
-    if action == 'search_accounts':
+    if action == "search_accounts":
         params = build_params(limit=limit, cursor=cursor, sort=sort)
-        body = {'filter_expression': filter_expression} if filter_expression else {}
-        conf = check_confirmation('POST', '/management/accounts/search', action, 'iam_tool', confirmed or False, request_params=params, request_body=body)
+        body = {"filter_expression": filter_expression} if filter_expression else {}
+        conf = check_confirmation(
+            "POST",
+            "/management/accounts/search",
+            action,
+            "iam_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', '/management/accounts/search', params=params, json_body=body)
-    elif action == 'get_account':
+        return make_api_request(
+            "POST", "/management/accounts/search", params=params, json_body=body
+        )
+    elif action == "get_account":
         if id is None:
-            return {'error': 'Missing required parameter: id for action get_account'}
-        endpoint = f'/management/accounts/{id}'
+            return {"error": "Missing required parameter: id for action get_account"}
+        endpoint = f"/management/accounts/{id}"
         params = build_params(id=id)
-        conf = check_confirmation('GET', endpoint, action, 'iam_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            endpoint,
+            action,
+            "iam_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', endpoint, params=params)
-    elif action == 'create_account':
+        return make_api_request("GET", endpoint, params=params)
+    elif action == "create_account":
         params = build_params()
-        body = {k: v for k, v in {'is_admin': is_admin, 'generate_api_key': generate_api_key, 'api_client_id': api_client_id, 'first_name': first_name, 'last_name': last_name, 'email': email, 'username': username, 'password': password, 'ldap_principal': ldap_principal, 'tags': tags}.items() if v is not None}
-        conf = check_confirmation('POST', '/management/accounts', action, 'iam_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "is_admin": is_admin,
+                "generate_api_key": generate_api_key,
+                "api_client_id": api_client_id,
+                "first_name": first_name,
+                "last_name": last_name,
+                "email": email,
+                "username": username,
+                "password": password,
+                "ldap_principal": ldap_principal,
+                "tags": tags,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            "/management/accounts",
+            action,
+            "iam_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', '/management/accounts', params=params, json_body=body if body else None)
-    elif action == 'delete_account':
+        return make_api_request(
+            "POST",
+            "/management/accounts",
+            params=params,
+            json_body=body if body else None,
+        )
+    elif action == "delete_account":
         if id is None:
-            return {'error': 'Missing required parameter: id for action delete_account'}
-        endpoint = f'/management/accounts/{id}'
+            return {"error": "Missing required parameter: id for action delete_account"}
+        endpoint = f"/management/accounts/{id}"
         params = build_params(id=id)
-        conf = check_confirmation('DELETE', endpoint, action, 'iam_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "DELETE",
+            endpoint,
+            action,
+            "iam_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('DELETE', endpoint, params=params)
-    elif action == 'enable_account':
+        return make_api_request("DELETE", endpoint, params=params)
+    elif action == "enable_account":
         if id is None:
-            return {'error': 'Missing required parameter: id for action enable_account'}
-        endpoint = f'/management/accounts/{id}/enable'
+            return {"error": "Missing required parameter: id for action enable_account"}
+        endpoint = f"/management/accounts/{id}/enable"
         params = build_params(id=id)
-        conf = check_confirmation('POST', endpoint, action, 'iam_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "iam_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params)
-    elif action == 'disable_account':
+        return make_api_request("POST", endpoint, params=params)
+    elif action == "disable_account":
         if id is None:
-            return {'error': 'Missing required parameter: id for action disable_account'}
-        endpoint = f'/management/accounts/{id}/disable'
+            return {
+                "error": "Missing required parameter: id for action disable_account"
+            }
+        endpoint = f"/management/accounts/{id}/disable"
         params = build_params(id=id)
-        conf = check_confirmation('POST', endpoint, action, 'iam_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "iam_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params)
-    elif action == 'reset_password':
+        return make_api_request("POST", endpoint, params=params)
+    elif action == "reset_password":
         if id is None:
-            return {'error': 'Missing required parameter: id for action reset_password'}
-        endpoint = f'/management/accounts/{id}/reset_password'
+            return {"error": "Missing required parameter: id for action reset_password"}
+        endpoint = f"/management/accounts/{id}/reset_password"
         params = build_params(id=id)
-        body = {k: v for k, v in {'new_password': new_password}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'iam_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v for k, v in {"new_password": new_password}.items() if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "iam_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'get_account_tags':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "get_account_tags":
         if id is None:
-            return {'error': 'Missing required parameter: id for action get_account_tags'}
-        endpoint = f'/management/accounts/{id}/tags'
+            return {
+                "error": "Missing required parameter: id for action get_account_tags"
+            }
+        endpoint = f"/management/accounts/{id}/tags"
         params = build_params(id=id)
-        conf = check_confirmation('GET', endpoint, action, 'iam_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            endpoint,
+            action,
+            "iam_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', endpoint, params=params)
-    elif action == 'add_account_tags':
+        return make_api_request("GET", endpoint, params=params)
+    elif action == "add_account_tags":
         if id is None:
-            return {'error': 'Missing required parameter: id for action add_account_tags'}
-        endpoint = f'/management/accounts/{id}/tags'
+            return {
+                "error": "Missing required parameter: id for action add_account_tags"
+            }
+        endpoint = f"/management/accounts/{id}/tags"
         params = build_params(id=id, tags=tags)
-        body = {k: v for k, v in {'tags': tags}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'iam_tool', confirmed or False, request_params=params, request_body=body)
+        body = {k: v for k, v in {"tags": tags}.items() if v is not None}
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "iam_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'delete_account_tags':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "delete_account_tags":
         if id is None:
-            return {'error': 'Missing required parameter: id for action delete_account_tags'}
-        endpoint = f'/management/accounts/{id}/tags/delete'
+            return {
+                "error": "Missing required parameter: id for action delete_account_tags"
+            }
+        endpoint = f"/management/accounts/{id}/tags/delete"
         params = build_params(id=id)
-        body = {k: v for k, v in {'key': key, 'value': value, 'tags': tags}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'iam_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {"key": key, "value": value, "tags": tags}.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "iam_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'get_account_ui_profiles':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "get_account_ui_profiles":
         if id is None:
-            return {'error': 'Missing required parameter: id for action get_account_ui_profiles'}
-        endpoint = f'/management/accounts/{id}/ui-profiles'
+            return {
+                "error": "Missing required parameter: id for action get_account_ui_profiles"
+            }
+        endpoint = f"/management/accounts/{id}/ui-profiles"
         params = build_params(id=id)
-        conf = check_confirmation('GET', endpoint, action, 'iam_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            endpoint,
+            action,
+            "iam_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', endpoint, params=params)
-    elif action == 'get_password_policies':
+        return make_api_request("GET", endpoint, params=params)
+    elif action == "get_password_policies":
         params = build_params()
-        conf = check_confirmation('GET', '/management/accounts/password-policies', action, 'iam_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            "/management/accounts/password-policies",
+            action,
+            "iam_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', '/management/accounts/password-policies', params=params)
-    elif action == 'update_password_policies':
+        return make_api_request(
+            "GET", "/management/accounts/password-policies", params=params
+        )
+    elif action == "update_password_policies":
         params = build_params()
-        body = {k: v for k, v in {'enabled': enabled, 'min_length': min_length, 'reuse_disallow_limit': reuse_disallow_limit, 'digit': digit, 'uppercase_letter': uppercase_letter, 'lowercase_letter': lowercase_letter, 'special_character': special_character, 'disallow_username_as_password': disallow_username_as_password, 'maximum_password_attempts': maximum_password_attempts}.items() if v is not None}
-        conf = check_confirmation('PATCH', '/management/accounts/password-policies', action, 'iam_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "enabled": enabled,
+                "min_length": min_length,
+                "reuse_disallow_limit": reuse_disallow_limit,
+                "digit": digit,
+                "uppercase_letter": uppercase_letter,
+                "lowercase_letter": lowercase_letter,
+                "special_character": special_character,
+                "disallow_username_as_password": disallow_username_as_password,
+                "maximum_password_attempts": maximum_password_attempts,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "PATCH",
+            "/management/accounts/password-policies",
+            action,
+            "iam_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('PATCH', '/management/accounts/password-policies', params=params, json_body=body if body else None)
-    elif action == 'search_roles':
+        return make_api_request(
+            "PATCH",
+            "/management/accounts/password-policies",
+            params=params,
+            json_body=body if body else None,
+        )
+    elif action == "search_roles":
         params = build_params(limit=limit, cursor=cursor, sort=sort)
-        body = {'filter_expression': filter_expression} if filter_expression else {}
-        conf = check_confirmation('POST', '/roles/search', action, 'iam_tool', confirmed or False, request_params=params, request_body=body)
+        body = {"filter_expression": filter_expression} if filter_expression else {}
+        conf = check_confirmation(
+            "POST",
+            "/roles/search",
+            action,
+            "iam_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', '/roles/search', params=params, json_body=body)
-    elif action == 'get_role':
+        return make_api_request("POST", "/roles/search", params=params, json_body=body)
+    elif action == "get_role":
         if role_id is None:
-            return {'error': 'Missing required parameter: role_id for action get_role'}
-        endpoint = f'/roles/{role_id}'
+            return {"error": "Missing required parameter: role_id for action get_role"}
+        endpoint = f"/roles/{role_id}"
         params = build_params()
-        conf = check_confirmation('GET', endpoint, action, 'iam_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            endpoint,
+            action,
+            "iam_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', endpoint, params=params)
-    elif action == 'create_role':
+        return make_api_request("GET", endpoint, params=params)
+    elif action == "create_role":
         params = build_params(name=name, permission_objects=permission_objects)
-        body = {k: v for k, v in {'name': name, 'description': description, 'permission_objects': permission_objects, 'immutable': immutable, 'tags': tags, 'ui_profiles': ui_profiles}.items() if v is not None}
-        conf = check_confirmation('POST', '/roles', action, 'iam_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "name": name,
+                "description": description,
+                "permission_objects": permission_objects,
+                "immutable": immutable,
+                "tags": tags,
+                "ui_profiles": ui_profiles,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            "/roles",
+            action,
+            "iam_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', '/roles', params=params, json_body=body if body else None)
-    elif action == 'update_role':
+        return make_api_request(
+            "POST", "/roles", params=params, json_body=body if body else None
+        )
+    elif action == "update_role":
         if role_id is None:
-            return {'error': 'Missing required parameter: role_id for action update_role'}
-        endpoint = f'/roles/{role_id}'
+            return {
+                "error": "Missing required parameter: role_id for action update_role"
+            }
+        endpoint = f"/roles/{role_id}"
         params = build_params()
-        body = {k: v for k, v in {'name': name, 'description': description}.items() if v is not None}
-        conf = check_confirmation('PATCH', endpoint, action, 'iam_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {"name": name, "description": description}.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "PATCH",
+            endpoint,
+            action,
+            "iam_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('PATCH', endpoint, params=params, json_body=body if body else None)
-    elif action == 'delete_role':
+        return make_api_request(
+            "PATCH", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "delete_role":
         if role_id is None:
-            return {'error': 'Missing required parameter: role_id for action delete_role'}
-        endpoint = f'/roles/{role_id}'
+            return {
+                "error": "Missing required parameter: role_id for action delete_role"
+            }
+        endpoint = f"/roles/{role_id}"
         params = build_params()
-        conf = check_confirmation('DELETE', endpoint, action, 'iam_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "DELETE",
+            endpoint,
+            action,
+            "iam_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('DELETE', endpoint, params=params)
-    elif action == 'add_role_permissions':
+        return make_api_request("DELETE", endpoint, params=params)
+    elif action == "add_role_permissions":
         if role_id is None:
-            return {'error': 'Missing required parameter: role_id for action add_role_permissions'}
-        endpoint = f'/roles/{role_id}/permissions'
+            return {
+                "error": "Missing required parameter: role_id for action add_role_permissions"
+            }
+        endpoint = f"/roles/{role_id}/permissions"
         params = build_params(permission_objects=permission_objects)
-        body = {k: v for k, v in {'permission_objects': permission_objects}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'iam_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {"permission_objects": permission_objects}.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "iam_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'delete_role_permissions':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "delete_role_permissions":
         if role_id is None:
-            return {'error': 'Missing required parameter: role_id for action delete_role_permissions'}
-        endpoint = f'/roles/{role_id}/permissions/delete'
+            return {
+                "error": "Missing required parameter: role_id for action delete_role_permissions"
+            }
+        endpoint = f"/roles/{role_id}/permissions/delete"
         params = build_params(permission_objects=permission_objects)
-        body = {k: v for k, v in {'permission_objects': permission_objects}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'iam_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {"permission_objects": permission_objects}.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "iam_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'get_role_tags':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "get_role_tags":
         if role_id is None:
-            return {'error': 'Missing required parameter: role_id for action get_role_tags'}
-        endpoint = f'/roles/{role_id}/tags'
+            return {
+                "error": "Missing required parameter: role_id for action get_role_tags"
+            }
+        endpoint = f"/roles/{role_id}/tags"
         params = build_params()
-        conf = check_confirmation('GET', endpoint, action, 'iam_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            endpoint,
+            action,
+            "iam_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', endpoint, params=params)
-    elif action == 'add_role_tags':
+        return make_api_request("GET", endpoint, params=params)
+    elif action == "add_role_tags":
         if role_id is None:
-            return {'error': 'Missing required parameter: role_id for action add_role_tags'}
-        endpoint = f'/roles/{role_id}/tags'
+            return {
+                "error": "Missing required parameter: role_id for action add_role_tags"
+            }
+        endpoint = f"/roles/{role_id}/tags"
         params = build_params(tags=tags)
-        body = {k: v for k, v in {'tags': tags}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'iam_tool', confirmed or False, request_params=params, request_body=body)
+        body = {k: v for k, v in {"tags": tags}.items() if v is not None}
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "iam_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'delete_role_tags':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "delete_role_tags":
         if role_id is None:
-            return {'error': 'Missing required parameter: role_id for action delete_role_tags'}
-        endpoint = f'/roles/{role_id}/tags/delete'
+            return {
+                "error": "Missing required parameter: role_id for action delete_role_tags"
+            }
+        endpoint = f"/roles/{role_id}/tags/delete"
         params = build_params()
-        body = {k: v for k, v in {'key': key, 'value': value, 'tags': tags}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'iam_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {"key": key, "value": value, "tags": tags}.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "iam_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'add_role_ui_profiles':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "add_role_ui_profiles":
         if role_id is None:
-            return {'error': 'Missing required parameter: role_id for action add_role_ui_profiles'}
-        endpoint = f'/roles/{role_id}/ui-profiles'
+            return {
+                "error": "Missing required parameter: role_id for action add_role_ui_profiles"
+            }
+        endpoint = f"/roles/{role_id}/ui-profiles"
         params = build_params(ui_profiles=ui_profiles)
-        body = {k: v for k, v in {'ui_profiles': ui_profiles}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'iam_tool', confirmed or False, request_params=params, request_body=body)
+        body = {k: v for k, v in {"ui_profiles": ui_profiles}.items() if v is not None}
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "iam_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'delete_role_ui_profiles':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "delete_role_ui_profiles":
         if role_id is None:
-            return {'error': 'Missing required parameter: role_id for action delete_role_ui_profiles'}
-        endpoint = f'/roles/{role_id}/ui-profiles/delete'
+            return {
+                "error": "Missing required parameter: role_id for action delete_role_ui_profiles"
+            }
+        endpoint = f"/roles/{role_id}/ui-profiles/delete"
         params = build_params(ui_profiles=ui_profiles)
-        body = {k: v for k, v in {'ui_profiles': ui_profiles}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'iam_tool', confirmed or False, request_params=params, request_body=body)
+        body = {k: v for k, v in {"ui_profiles": ui_profiles}.items() if v is not None}
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "iam_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'search_access_groups':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "search_access_groups":
         params = build_params(limit=limit, cursor=cursor, sort=sort)
-        body = {'filter_expression': filter_expression} if filter_expression else {}
-        conf = check_confirmation('POST', '/access-groups/search', action, 'iam_tool', confirmed or False, request_params=params, request_body=body)
+        body = {"filter_expression": filter_expression} if filter_expression else {}
+        conf = check_confirmation(
+            "POST",
+            "/access-groups/search",
+            action,
+            "iam_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', '/access-groups/search', params=params, json_body=body)
-    elif action == 'get_access_group':
+        return make_api_request(
+            "POST", "/access-groups/search", params=params, json_body=body
+        )
+    elif action == "get_access_group":
         if access_group_id is None:
-            return {'error': 'Missing required parameter: access_group_id for action get_access_group'}
-        endpoint = f'/access-groups/{access_group_id}'
+            return {
+                "error": "Missing required parameter: access_group_id for action get_access_group"
+            }
+        endpoint = f"/access-groups/{access_group_id}"
         params = build_params()
-        conf = check_confirmation('GET', endpoint, action, 'iam_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            endpoint,
+            action,
+            "iam_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', endpoint, params=params)
-    elif action == 'create_access_group':
+        return make_api_request("GET", endpoint, params=params)
+    elif action == "create_access_group":
         params = build_params(name=name)
-        body = {k: v for k, v in {'id': id, 'name': name, 'single_account': single_account, 'account_ids': account_ids, 'tagged_account_ids': tagged_account_ids, 'account_tags': account_tags, 'scopes': scopes}.items() if v is not None}
-        conf = check_confirmation('POST', '/access-groups', action, 'iam_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "id": id,
+                "name": name,
+                "single_account": single_account,
+                "account_ids": account_ids,
+                "tagged_account_ids": tagged_account_ids,
+                "account_tags": account_tags,
+                "scopes": scopes,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            "/access-groups",
+            action,
+            "iam_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', '/access-groups', params=params, json_body=body if body else None)
-    elif action == 'update_access_group':
+        return make_api_request(
+            "POST", "/access-groups", params=params, json_body=body if body else None
+        )
+    elif action == "update_access_group":
         if access_group_id is None:
-            return {'error': 'Missing required parameter: access_group_id for action update_access_group'}
-        endpoint = f'/access-groups/{access_group_id}'
+            return {
+                "error": "Missing required parameter: access_group_id for action update_access_group"
+            }
+        endpoint = f"/access-groups/{access_group_id}"
         params = build_params()
-        body = {k: v for k, v in {'name': name}.items() if v is not None}
-        conf = check_confirmation('PATCH', endpoint, action, 'iam_tool', confirmed or False, request_params=params, request_body=body)
+        body = {k: v for k, v in {"name": name}.items() if v is not None}
+        conf = check_confirmation(
+            "PATCH",
+            endpoint,
+            action,
+            "iam_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('PATCH', endpoint, params=params, json_body=body if body else None)
-    elif action == 'delete_access_group':
+        return make_api_request(
+            "PATCH", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "delete_access_group":
         if access_group_id is None:
-            return {'error': 'Missing required parameter: access_group_id for action delete_access_group'}
-        endpoint = f'/access-groups/{access_group_id}'
+            return {
+                "error": "Missing required parameter: access_group_id for action delete_access_group"
+            }
+        endpoint = f"/access-groups/{access_group_id}"
         params = build_params()
-        conf = check_confirmation('DELETE', endpoint, action, 'iam_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "DELETE",
+            endpoint,
+            action,
+            "iam_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('DELETE', endpoint, params=params)
-    elif action == 'add_access_group_tags':
+        return make_api_request("DELETE", endpoint, params=params)
+    elif action == "add_access_group_tags":
         if access_group_id is None:
-            return {'error': 'Missing required parameter: access_group_id for action add_access_group_tags'}
-        endpoint = f'/access-groups/{access_group_id}/tags'
+            return {
+                "error": "Missing required parameter: access_group_id for action add_access_group_tags"
+            }
+        endpoint = f"/access-groups/{access_group_id}/tags"
         params = build_params(tags=tags)
-        body = {k: v for k, v in {'tags': tags}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'iam_tool', confirmed or False, request_params=params, request_body=body)
+        body = {k: v for k, v in {"tags": tags}.items() if v is not None}
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "iam_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'delete_access_group_tags':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "delete_access_group_tags":
         if access_group_id is None:
-            return {'error': 'Missing required parameter: access_group_id for action delete_access_group_tags'}
-        endpoint = f'/access-groups/{access_group_id}/tags/delete'
+            return {
+                "error": "Missing required parameter: access_group_id for action delete_access_group_tags"
+            }
+        endpoint = f"/access-groups/{access_group_id}/tags/delete"
         params = build_params()
-        body = {k: v for k, v in {'key': key, 'value': value, 'tags': tags}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'iam_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {"key": key, "value": value, "tags": tags}.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "iam_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'add_access_group_scopes':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "add_access_group_scopes":
         if access_group_id is None:
-            return {'error': 'Missing required parameter: access_group_id for action add_access_group_scopes'}
-        endpoint = f'/access-groups/{access_group_id}/scopes'
+            return {
+                "error": "Missing required parameter: access_group_id for action add_access_group_scopes"
+            }
+        endpoint = f"/access-groups/{access_group_id}/scopes"
         params = build_params(scopes=scopes)
-        body = {k: v for k, v in {'scopes': scopes}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'iam_tool', confirmed or False, request_params=params, request_body=body)
+        body = {k: v for k, v in {"scopes": scopes}.items() if v is not None}
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "iam_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'get_access_group_scope':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "get_access_group_scope":
         if access_group_id is None:
-            return {'error': 'Missing required parameter: access_group_id for action get_access_group_scope'}
+            return {
+                "error": "Missing required parameter: access_group_id for action get_access_group_scope"
+            }
         if scope_id is None:
-            return {'error': 'Missing required parameter: scope_id for action get_access_group_scope'}
-        endpoint = f'/access-groups/{access_group_id}/scopes/{scope_id}'
+            return {
+                "error": "Missing required parameter: scope_id for action get_access_group_scope"
+            }
+        endpoint = f"/access-groups/{access_group_id}/scopes/{scope_id}"
         params = build_params()
-        conf = check_confirmation('GET', endpoint, action, 'iam_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            endpoint,
+            action,
+            "iam_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', endpoint, params=params)
-    elif action == 'update_access_group_scope':
+        return make_api_request("GET", endpoint, params=params)
+    elif action == "update_access_group_scope":
         if access_group_id is None:
-            return {'error': 'Missing required parameter: access_group_id for action update_access_group_scope'}
+            return {
+                "error": "Missing required parameter: access_group_id for action update_access_group_scope"
+            }
         if scope_id is None:
-            return {'error': 'Missing required parameter: scope_id for action update_access_group_scope'}
-        endpoint = f'/access-groups/{access_group_id}/scopes/{scope_id}'
+            return {
+                "error": "Missing required parameter: scope_id for action update_access_group_scope"
+            }
+        endpoint = f"/access-groups/{access_group_id}/scopes/{scope_id}"
         params = build_params()
-        body = {k: v for k, v in {'name': name, 'scope_type': scope_type}.items() if v is not None}
-        conf = check_confirmation('PATCH', endpoint, action, 'iam_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {"name": name, "scope_type": scope_type}.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "PATCH",
+            endpoint,
+            action,
+            "iam_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('PATCH', endpoint, params=params, json_body=body if body else None)
-    elif action == 'delete_access_group_scope':
+        return make_api_request(
+            "PATCH", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "delete_access_group_scope":
         if access_group_id is None:
-            return {'error': 'Missing required parameter: access_group_id for action delete_access_group_scope'}
+            return {
+                "error": "Missing required parameter: access_group_id for action delete_access_group_scope"
+            }
         if scope_id is None:
-            return {'error': 'Missing required parameter: scope_id for action delete_access_group_scope'}
-        endpoint = f'/access-groups/{access_group_id}/scopes/{scope_id}'
+            return {
+                "error": "Missing required parameter: scope_id for action delete_access_group_scope"
+            }
+        endpoint = f"/access-groups/{access_group_id}/scopes/{scope_id}"
         params = build_params()
-        conf = check_confirmation('DELETE', endpoint, action, 'iam_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "DELETE",
+            endpoint,
+            action,
+            "iam_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('DELETE', endpoint, params=params)
-    elif action == 'add_scope_object_tags':
+        return make_api_request("DELETE", endpoint, params=params)
+    elif action == "add_scope_object_tags":
         if access_group_id is None:
-            return {'error': 'Missing required parameter: access_group_id for action add_scope_object_tags'}
+            return {
+                "error": "Missing required parameter: access_group_id for action add_scope_object_tags"
+            }
         if scope_id is None:
-            return {'error': 'Missing required parameter: scope_id for action add_scope_object_tags'}
-        endpoint = f'/access-groups/{access_group_id}/scopes/{scope_id}/object-tags'
+            return {
+                "error": "Missing required parameter: scope_id for action add_scope_object_tags"
+            }
+        endpoint = f"/access-groups/{access_group_id}/scopes/{scope_id}/object-tags"
         params = build_params(tags=tags)
-        body = {k: v for k, v in {'tags': tags}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'iam_tool', confirmed or False, request_params=params, request_body=body)
+        body = {k: v for k, v in {"tags": tags}.items() if v is not None}
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "iam_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'delete_scope_object_tags':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "delete_scope_object_tags":
         if access_group_id is None:
-            return {'error': 'Missing required parameter: access_group_id for action delete_scope_object_tags'}
+            return {
+                "error": "Missing required parameter: access_group_id for action delete_scope_object_tags"
+            }
         if scope_id is None:
-            return {'error': 'Missing required parameter: scope_id for action delete_scope_object_tags'}
-        endpoint = f'/access-groups/{access_group_id}/scopes/{scope_id}/object-tags/delete'
+            return {
+                "error": "Missing required parameter: scope_id for action delete_scope_object_tags"
+            }
+        endpoint = (
+            f"/access-groups/{access_group_id}/scopes/{scope_id}/object-tags/delete"
+        )
         params = build_params()
-        body = {k: v for k, v in {'tags': tags}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'iam_tool', confirmed or False, request_params=params, request_body=body)
+        body = {k: v for k, v in {"tags": tags}.items() if v is not None}
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "iam_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'add_scope_objects':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "add_scope_objects":
         if access_group_id is None:
-            return {'error': 'Missing required parameter: access_group_id for action add_scope_objects'}
+            return {
+                "error": "Missing required parameter: access_group_id for action add_scope_objects"
+            }
         if scope_id is None:
-            return {'error': 'Missing required parameter: scope_id for action add_scope_objects'}
-        endpoint = f'/access-groups/{access_group_id}/scopes/{scope_id}/objects'
+            return {
+                "error": "Missing required parameter: scope_id for action add_scope_objects"
+            }
+        endpoint = f"/access-groups/{access_group_id}/scopes/{scope_id}/objects"
         params = build_params(objects=objects)
-        body = {k: v for k, v in {'objects': objects}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'iam_tool', confirmed or False, request_params=params, request_body=body)
+        body = {k: v for k, v in {"objects": objects}.items() if v is not None}
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "iam_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'delete_scope_objects':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "delete_scope_objects":
         if access_group_id is None:
-            return {'error': 'Missing required parameter: access_group_id for action delete_scope_objects'}
+            return {
+                "error": "Missing required parameter: access_group_id for action delete_scope_objects"
+            }
         if scope_id is None:
-            return {'error': 'Missing required parameter: scope_id for action delete_scope_objects'}
-        endpoint = f'/access-groups/{access_group_id}/scopes/{scope_id}/objects/delete'
+            return {
+                "error": "Missing required parameter: scope_id for action delete_scope_objects"
+            }
+        endpoint = f"/access-groups/{access_group_id}/scopes/{scope_id}/objects/delete"
         params = build_params(objects=objects)
-        body = {k: v for k, v in {'objects': objects}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'iam_tool', confirmed or False, request_params=params, request_body=body)
+        body = {k: v for k, v in {"objects": objects}.items() if v is not None}
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "iam_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'add_scope_always_allowed_permissions':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "add_scope_always_allowed_permissions":
         if access_group_id is None:
-            return {'error': 'Missing required parameter: access_group_id for action add_scope_always_allowed_permissions'}
+            return {
+                "error": "Missing required parameter: access_group_id for action add_scope_always_allowed_permissions"
+            }
         if scope_id is None:
-            return {'error': 'Missing required parameter: scope_id for action add_scope_always_allowed_permissions'}
-        endpoint = f'/access-groups/{access_group_id}/scopes/{scope_id}/always_allowed_permissions'
+            return {
+                "error": "Missing required parameter: scope_id for action add_scope_always_allowed_permissions"
+            }
+        endpoint = f"/access-groups/{access_group_id}/scopes/{scope_id}/always_allowed_permissions"
         params = build_params(always_allowed_permissions=always_allowed_permissions)
-        body = {k: v for k, v in {'always_allowed_permissions': always_allowed_permissions}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'iam_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "always_allowed_permissions": always_allowed_permissions
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "iam_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'delete_scope_always_allowed_permissions':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "delete_scope_always_allowed_permissions":
         if access_group_id is None:
-            return {'error': 'Missing required parameter: access_group_id for action delete_scope_always_allowed_permissions'}
+            return {
+                "error": "Missing required parameter: access_group_id for action delete_scope_always_allowed_permissions"
+            }
         if scope_id is None:
-            return {'error': 'Missing required parameter: scope_id for action delete_scope_always_allowed_permissions'}
-        endpoint = f'/access-groups/{access_group_id}/scopes/{scope_id}/always_allowed_permissions/delete'
+            return {
+                "error": "Missing required parameter: scope_id for action delete_scope_always_allowed_permissions"
+            }
+        endpoint = f"/access-groups/{access_group_id}/scopes/{scope_id}/always_allowed_permissions/delete"
         params = build_params(always_allowed_permissions=always_allowed_permissions)
-        body = {k: v for k, v in {'always_allowed_permissions': always_allowed_permissions}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'iam_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "always_allowed_permissions": always_allowed_permissions
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "iam_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
     else:
-        return {'error': f'Unknown action: {action}. Valid actions: search_accounts, get_account, create_account, delete_account, enable_account, disable_account, reset_password, get_account_tags, add_account_tags, delete_account_tags, get_account_ui_profiles, get_password_policies, update_password_policies, search_roles, get_role, create_role, update_role, delete_role, add_role_permissions, delete_role_permissions, get_role_tags, add_role_tags, delete_role_tags, add_role_ui_profiles, delete_role_ui_profiles, search_access_groups, get_access_group, create_access_group, update_access_group, delete_access_group, add_access_group_tags, delete_access_group_tags, add_access_group_scopes, get_access_group_scope, update_access_group_scope, delete_access_group_scope, add_scope_object_tags, delete_scope_object_tags, add_scope_objects, delete_scope_objects, add_scope_always_allowed_permissions, delete_scope_always_allowed_permissions'}
+        return {
+            "error": f"Unknown action: {action}. Valid actions: search_accounts, get_account, create_account, delete_account, enable_account, disable_account, reset_password, get_account_tags, add_account_tags, delete_account_tags, get_account_ui_profiles, get_password_policies, update_password_policies, search_roles, get_role, create_role, update_role, delete_role, add_role_permissions, delete_role_permissions, get_role_tags, add_role_tags, delete_role_tags, add_role_ui_profiles, delete_role_ui_profiles, search_access_groups, get_access_group, create_access_group, update_access_group, delete_access_group, add_access_group_tags, delete_access_group_tags, add_access_group_scopes, get_access_group_scope, update_access_group_scope, delete_access_group_scope, add_scope_object_tags, delete_scope_object_tags, add_scope_objects, delete_scope_objects, add_scope_always_allowed_permissions, delete_scope_always_allowed_permissions"
+        }
+
 
 @log_tool_execution
 def tag_tool(
@@ -1154,13 +1755,13 @@ def tag_tool(
 ) -> Dict[str, Any]:
     """
     Unified tool for TAG operations.
-    
+
     This tool supports 4 actions: search, get, get_usages, search_usages
-    
+
     ======================================================================
     ACTION REFERENCE
     ======================================================================
-    
+
     ACTION: search
     ----------------------------------------
     Summary: Search for global tags.
@@ -1168,42 +1769,42 @@ def tag_tool(
     Endpoint: /management/tags/search
     Required Parameters: limit, cursor, sort
     Key Parameters (provide as applicable): filter_expression
-    
+
     Filterable Fields:
         - id: ID of the tag.
         - key: Key of the tag
         - value: Value of the tag
         - used_for_access: True if this tag is used in any access group scopes.
         - usage_count: The number of objects this tag applies to.
-    
+
     Filter Syntax:
         Operators: EQ, NE, GT, GE, LT, LE, CONTAINS, IN, NOT_IN
         Combine: AND, OR
         Example: "name CONTAINS 'prod' AND status EQ 'RUNNING'"
-    
+
     Example:
         >>> tag_tool(action='search', limit=..., cursor=..., sort=..., filter_expression="name CONTAINS 'test'")
-    
+
     ACTION: get
     ----------------------------------------
     Summary: Get a global tag by id
     Method: GET
     Endpoint: /management/tags/{tagId}
     Required Parameters: tag_id
-    
+
     Example:
         >>> tag_tool(action='get', tag_id='example-tag-123')
-    
+
     ACTION: get_usages
     ----------------------------------------
     Summary: List specific usages of this global tag.
     Method: GET
     Endpoint: /management/tags/{tagId}/usages
     Required Parameters: limit, cursor, sort, tag_id
-    
+
     Example:
         >>> tag_tool(action='get_usages', limit=..., cursor=..., sort=..., tag_id='example-tag-123')
-    
+
     ACTION: search_usages
     ----------------------------------------
     Summary: Search specific usages of this global tag.
@@ -1211,30 +1812,30 @@ def tag_tool(
     Endpoint: /management/tags/{tagId}/usages/search
     Required Parameters: limit, cursor, sort, tag_id
     Key Parameters (provide as applicable): filter_expression
-    
+
     Filterable Fields:
         - id: Unique ID for this GlobalTagUsage.
-        - object_type: 
+        - object_type:
         - object_id: ID of the object this tag applies to.
         - object_name: Name of the object this tag applies to.
         - creator_account_id: ID of the account that applied this tag to the object.
         - creator_account_name: Name of the account that applied this tag to the object.
-    
+
     Filter Syntax:
         Operators: EQ, NE, GT, GE, LT, LE, CONTAINS, IN, NOT_IN
         Combine: AND, OR
         Example: "name CONTAINS 'prod' AND status EQ 'RUNNING'"
-    
+
     Example:
         >>> tag_tool(action='search_usages', limit=..., cursor=..., sort=..., filter_expression="name CONTAINS 'test'", tag_id='example-tag-123')
-    
+
     ======================================================================
     PARAMETERS
     ======================================================================
-    
+
     Args:
         action (str): The operation to perform. One of: search, get, get_usages, search_usages
-    
+
       -- General parameters (all database types) --
         cursor (str): Cursor to fetch the next or previous page of results. The value of this prope...
             [Required for: search, get_usages, search_usages]
@@ -1246,62 +1847,100 @@ def tag_tool(
             [Required for: search, get_usages, search_usages]
         tag_id (str): The unique identifier for the tag.
             [Required for: get, get_usages, search_usages]
-    
+
     Returns:
         Dict[str, Any]: The API response containing operation results
-    
+
     Raises:
         Returns error dict if required parameters are missing for the action
     """
     # Route to appropriate API based on action
-    if action == 'search':
+    if action == "search":
         params = build_params(limit=limit, cursor=cursor, sort=sort)
-        body = {'filter_expression': filter_expression} if filter_expression else {}
-        conf = check_confirmation('POST', '/management/tags/search', action, 'tag_tool', confirmed or False, request_params=params, request_body=body)
+        body = {"filter_expression": filter_expression} if filter_expression else {}
+        conf = check_confirmation(
+            "POST",
+            "/management/tags/search",
+            action,
+            "tag_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', '/management/tags/search', params=params, json_body=body)
-    elif action == 'get':
+        return make_api_request(
+            "POST", "/management/tags/search", params=params, json_body=body
+        )
+    elif action == "get":
         if tag_id is None:
-            return {'error': 'Missing required parameter: tag_id for action get'}
-        endpoint = f'/management/tags/{tag_id}'
+            return {"error": "Missing required parameter: tag_id for action get"}
+        endpoint = f"/management/tags/{tag_id}"
         params = build_params()
-        conf = check_confirmation('GET', endpoint, action, 'tag_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            endpoint,
+            action,
+            "tag_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', endpoint, params=params)
-    elif action == 'get_usages':
+        return make_api_request("GET", endpoint, params=params)
+    elif action == "get_usages":
         if tag_id is None:
-            return {'error': 'Missing required parameter: tag_id for action get_usages'}
-        endpoint = f'/management/tags/{tag_id}/usages'
+            return {"error": "Missing required parameter: tag_id for action get_usages"}
+        endpoint = f"/management/tags/{tag_id}/usages"
         params = build_params(limit=limit, cursor=cursor, sort=sort)
-        conf = check_confirmation('GET', endpoint, action, 'tag_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            endpoint,
+            action,
+            "tag_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', endpoint, params=params)
-    elif action == 'search_usages':
+        return make_api_request("GET", endpoint, params=params)
+    elif action == "search_usages":
         if tag_id is None:
-            return {'error': 'Missing required parameter: tag_id for action search_usages'}
-        endpoint = f'/management/tags/{tag_id}/usages/search'
+            return {
+                "error": "Missing required parameter: tag_id for action search_usages"
+            }
+        endpoint = f"/management/tags/{tag_id}/usages/search"
         params = build_params(limit=limit, cursor=cursor, sort=sort)
-        body = {'filter_expression': filter_expression} if filter_expression else {}
-        conf = check_confirmation('POST', endpoint, action, 'tag_tool', confirmed or False, request_params=params, request_body=body)
+        body = {"filter_expression": filter_expression} if filter_expression else {}
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "tag_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body)
+        return make_api_request("POST", endpoint, params=params, json_body=body)
     else:
-        return {'error': f'Unknown action: {action}. Valid actions: search, get, get_usages, search_usages'}
+        return {
+            "error": f"Unknown action: {action}. Valid actions: search, get, get_usages, search_usages"
+        }
 
 
 def register_tools(app, dct_client):
     global client
     client = dct_client
-    logger.info(f'Registering tools for iam_endpoints...')
+    logger.info("Registering tools for iam_endpoints...")
     try:
-        logger.info(f'  Registering tool function: iam_tool')
+        logger.info("  Registering tool function: iam_tool")
         app.add_tool(iam_tool, name="iam_tool")
-        logger.info(f'  Registering tool function: tag_tool')
+        logger.info("  Registering tool function: tag_tool")
         app.add_tool(tag_tool, name="tag_tool")
     except Exception as e:
-        logger.error(f'Error registering tools for iam_endpoints: {e}')
-    logger.info(f'Tools registration finished for iam_endpoints.')
+        logger.error(f"Error registering tools for iam_endpoints: {e}")
+    logger.info("Tools registration finished for iam_endpoints.")

--- a/src/dct_mcp_server/tools/job_endpoints_tool.py
+++ b/src/dct_mcp_server/tools/job_endpoints_tool.py
@@ -1,7 +1,6 @@
-from mcp.server.fastmcp import FastMCP
-from typing import Dict,Any,Optional
+from typing import Dict, Any, Optional
 from dct_mcp_server.core.decorators import log_tool_execution
-from dct_mcp_server.config import get_confirmation_for_operation, requires_confirmation
+from dct_mcp_server.config import get_confirmation_for_operation
 import asyncio
 import logging
 import threading
@@ -29,7 +28,16 @@ logger = logging.getLogger(__name__)
 #       }
 # =============================================================================
 
-def check_confirmation(method: str, api_path: str, action: str, tool_name: str, confirmed: bool = False, request_params: Optional[Dict[str, Any]] = None, request_body: Optional[Dict[str, Any]] = None) -> Optional[Dict[str, Any]]:
+
+def check_confirmation(
+    method: str,
+    api_path: str,
+    action: str,
+    tool_name: str,
+    confirmed: bool = False,
+    request_params: Optional[Dict[str, Any]] = None,
+    request_body: Optional[Dict[str, Any]] = None,
+) -> Optional[Dict[str, Any]]:
     """Check if operation requires confirmation. Returns confirmation response or None if confirmed/not needed."""
     confirmation = get_confirmation_for_operation(method, api_path)
     if confirmation["level"] != "none" and not confirmed:
@@ -41,7 +49,11 @@ def check_confirmation(method: str, api_path: str, action: str, tool_name: str, 
             review.update(request_params)
         if request_body:
             review.update(request_body)
-        is_review_critical = action.startswith("provision_") or action.startswith("dsource_link_") or action == "dsource_create_snapshot"
+        is_review_critical = (
+            action.startswith("provision_")
+            or action.startswith("dsource_link_")
+            or action == "dsource_create_snapshot"
+        )
         instructions = (
             "STOP: You MUST display the confirmation_message to the user and wait for their EXPLICIT "
             "approval before re-calling with confirmed=True. Do NOT proceed without user consent."
@@ -56,7 +68,9 @@ def check_confirmation(method: str, api_path: str, action: str, tool_name: str, 
         return {
             "status": "confirmation_required",
             "confirmation_level": confirmation["level"],
-            "confirmation_message": confirmation.get("message", "Please confirm this operation."),
+            "confirmation_message": confirmation.get(
+                "message", "Please confirm this operation."
+            ),
             "action": action,
             "tool": tool_name,
             "api_path": api_path,
@@ -66,8 +80,10 @@ def check_confirmation(method: str, api_path: str, action: str, tool_name: str, 
         }
     return None
 
+
 def async_to_sync(async_func):
     """Utility decorator to convert async functions to sync with proper event loop handling."""
+
     @wraps(async_func)
     def wrapper(*args, **kwargs):
         try:
@@ -76,12 +92,14 @@ def async_to_sync(async_func):
                 # Create a task and run it synchronously
                 result = None
                 exception = None
+
                 def run_in_thread():
                     nonlocal result, exception
                     try:
                         result = asyncio.run(async_func(*args, **kwargs))
                     except Exception as e:
                         exception = e
+
                 thread = threading.Thread(target=run_in_thread)
                 thread.start()
                 thread.join()
@@ -92,18 +110,28 @@ def async_to_sync(async_func):
                 return loop.run_until_complete(async_func(*args, **kwargs))
         except RuntimeError:
             return asyncio.run(async_func(*args, **kwargs))
+
     return wrapper
 
-def make_api_request(method: str, endpoint: str, params: dict = None, json_body: dict = None):
+
+def make_api_request(
+    method: str, endpoint: str, params: dict = None, json_body: dict = None
+):
     """Utility function to make API requests with consistent parameter handling."""
+
     @async_to_sync
     async def _make_request():
-        return await client.make_request(method, endpoint, params=params or {}, json=json_body)
+        return await client.make_request(
+            method, endpoint, params=params or {}, json=json_body
+        )
+
     return _make_request()
+
 
 def build_params(**kwargs):
     """Build parameters dictionary excluding None and empty string values."""
-    return {k: v for k, v in kwargs.items() if v is not None and v != ''}
+    return {k: v for k, v in kwargs.items() if v is not None and v != ""}
+
 
 @log_tool_execution
 def job_tool(
@@ -113,20 +141,20 @@ def job_tool(
     job_id: Optional[str] = None,
     key: Optional[str] = None,
     limit: Optional[int] = 100,
-    sort: Optional[str] = '-start_time',
+    sort: Optional[str] = "-start_time",
     tags: Optional[list] = None,
     value: Optional[str] = None,
     confirmed: Optional[bool] = None,
 ) -> Dict[str, Any]:
     """
     Unified tool for JOB operations.
-    
+
     This tool supports 7 actions: search, get, abandon, get_result, get_tags, add_tags, delete_tags
-    
+
     ======================================================================
     ACTION REFERENCE
     ======================================================================
-    
+
     ACTION: search
     ----------------------------------------
     Summary: Search for jobs.
@@ -134,7 +162,7 @@ def job_tool(
     Endpoint: /jobs/search
     Required Parameters: limit, cursor, sort
     Key Parameters (provide as applicable): filter_expression
-    
+
     Filterable Fields:
         - id: The Job entity ID.
         - status: The status of the job.
@@ -149,75 +177,75 @@ def job_tool(
         - update_time: The time the job was last updated.
         - trace_id: traceId of the request which created this Job
         - engine_ids: IDs of the engines this Job is executing on.
-        - tags: 
-        - engines: 
+        - tags:
+        - engines:
         - account_id: The ID of the account who initiated this job.
         - account_name: The account name which initiated this job. It can be eith...
         - percent_complete: Completion percentage of the Job.
-        - virtualization_tasks: 
-        - tasks: 
+        - virtualization_tasks:
+        - tasks:
         - execution_id: The ID of the associated masking execution, if any.
         - result_type: The type of the job result. This is the type of the objec...
         - result: The result of the job execution. This is JSON serialized ...
-    
+
     Filter Syntax:
         Operators: EQ, NE, GT, GE, LT, LE, CONTAINS, IN, NOT_IN
         Combine: AND, OR
         Example: "name CONTAINS 'prod' AND status EQ 'RUNNING'"
-    
+
     Example:
         >>> job_tool(action='search', limit=..., cursor=..., sort=..., filter_expression="name CONTAINS 'test'")
-    
+
     ACTION: get
     ----------------------------------------
     Summary: Returns a job by ID.
     Method: GET
     Endpoint: /jobs/{jobId}
     Required Parameters: job_id
-    
+
     Example:
         >>> job_tool(action='get', job_id='example-job-123')
-    
+
     ACTION: abandon
     ----------------------------------------
     Summary: Abandons a job.
     Method: POST
     Endpoint: /jobs/{jobId}/abandon
     Required Parameters: job_id
-    
+
     Example:
         >>> job_tool(action='abandon', job_id='example-job-123')
-    
+
     ACTION: get_result
     ----------------------------------------
     Summary: Get job result.
     Method: GET
     Endpoint: /jobs/{jobId}/result
     Required Parameters: job_id
-    
+
     Example:
         >>> job_tool(action='get_result', job_id='example-job-123')
-    
+
     ACTION: get_tags
     ----------------------------------------
     Summary: Get tags for a Job.
     Method: GET
     Endpoint: /jobs/{jobId}/tags
     Required Parameters: job_id
-    
+
     Example:
         >>> job_tool(action='get_tags', job_id='example-job-123')
-    
+
     ACTION: add_tags
     ----------------------------------------
     Summary: Create tags for a Job.
     Method: POST
     Endpoint: /jobs/{jobId}/tags
     Required Parameters: job_id, tags
-    
+
     Example:
         >>> job_tool(action='add_tags', job_id='example-job-123', tags=...)
-    
+
     ACTION: delete_tags
     ----------------------------------------
     Summary: Delete tags for a Job.
@@ -225,17 +253,17 @@ def job_tool(
     Endpoint: /jobs/{jobId}/tags/delete
     Required Parameters: job_id
     Key Parameters (provide as applicable): tags, key, value
-    
+
     Example:
         >>> job_tool(action='delete_tags', job_id='example-job-123', tags=..., key=..., value=...)
-    
+
     ======================================================================
     PARAMETERS
     ======================================================================
-    
+
     Args:
         action (str): The operation to perform. One of: search, get, abandon, get_result, get_tags, add_tags, delete_tags
-    
+
       -- General parameters (all database types) --
         cursor (str): Cursor to fetch the next or previous page of results. The value of this prope...
             [Required for: search]
@@ -253,88 +281,156 @@ def job_tool(
             [Required for: add_tags]
         value (str): Value of the tag
             [Optional for all actions]
-    
+
     Returns:
         Dict[str, Any]: The API response containing operation results
-    
+
     Raises:
         Returns error dict if required parameters are missing for the action
     """
     # Route to appropriate API based on action
-    if action == 'search':
+    if action == "search":
         params = build_params(limit=limit, cursor=cursor, sort=sort)
-        body = {'filter_expression': filter_expression} if filter_expression else {}
-        conf = check_confirmation('POST', '/jobs/search', action, 'job_tool', confirmed or False, request_params=params, request_body=body)
+        body = {"filter_expression": filter_expression} if filter_expression else {}
+        conf = check_confirmation(
+            "POST",
+            "/jobs/search",
+            action,
+            "job_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', '/jobs/search', params=params, json_body=body)
-    elif action == 'get':
+        return make_api_request("POST", "/jobs/search", params=params, json_body=body)
+    elif action == "get":
         if job_id is None:
-            return {'error': 'Missing required parameter: job_id for action get'}
-        endpoint = f'/jobs/{job_id}'
+            return {"error": "Missing required parameter: job_id for action get"}
+        endpoint = f"/jobs/{job_id}"
         params = build_params()
-        conf = check_confirmation('GET', endpoint, action, 'job_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            endpoint,
+            action,
+            "job_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', endpoint, params=params)
-    elif action == 'abandon':
+        return make_api_request("GET", endpoint, params=params)
+    elif action == "abandon":
         if job_id is None:
-            return {'error': 'Missing required parameter: job_id for action abandon'}
-        endpoint = f'/jobs/{job_id}/abandon'
+            return {"error": "Missing required parameter: job_id for action abandon"}
+        endpoint = f"/jobs/{job_id}/abandon"
         params = build_params()
-        conf = check_confirmation('POST', endpoint, action, 'job_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "job_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params)
-    elif action == 'get_result':
+        return make_api_request("POST", endpoint, params=params)
+    elif action == "get_result":
         if job_id is None:
-            return {'error': 'Missing required parameter: job_id for action get_result'}
-        endpoint = f'/jobs/{job_id}/result'
+            return {"error": "Missing required parameter: job_id for action get_result"}
+        endpoint = f"/jobs/{job_id}/result"
         params = build_params()
-        conf = check_confirmation('GET', endpoint, action, 'job_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            endpoint,
+            action,
+            "job_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', endpoint, params=params)
-    elif action == 'get_tags':
+        return make_api_request("GET", endpoint, params=params)
+    elif action == "get_tags":
         if job_id is None:
-            return {'error': 'Missing required parameter: job_id for action get_tags'}
-        endpoint = f'/jobs/{job_id}/tags'
+            return {"error": "Missing required parameter: job_id for action get_tags"}
+        endpoint = f"/jobs/{job_id}/tags"
         params = build_params()
-        conf = check_confirmation('GET', endpoint, action, 'job_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            endpoint,
+            action,
+            "job_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', endpoint, params=params)
-    elif action == 'add_tags':
+        return make_api_request("GET", endpoint, params=params)
+    elif action == "add_tags":
         if job_id is None:
-            return {'error': 'Missing required parameter: job_id for action add_tags'}
-        endpoint = f'/jobs/{job_id}/tags'
+            return {"error": "Missing required parameter: job_id for action add_tags"}
+        endpoint = f"/jobs/{job_id}/tags"
         params = build_params(tags=tags)
-        body = {k: v for k, v in {'tags': tags}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'job_tool', confirmed or False, request_params=params, request_body=body)
+        body = {k: v for k, v in {"tags": tags}.items() if v is not None}
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "job_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'delete_tags':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "delete_tags":
         if job_id is None:
-            return {'error': 'Missing required parameter: job_id for action delete_tags'}
-        endpoint = f'/jobs/{job_id}/tags/delete'
+            return {
+                "error": "Missing required parameter: job_id for action delete_tags"
+            }
+        endpoint = f"/jobs/{job_id}/tags/delete"
         params = build_params()
-        body = {k: v for k, v in {'key': key, 'value': value, 'tags': tags}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'job_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {"key": key, "value": value, "tags": tags}.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "job_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
     else:
-        return {'error': f'Unknown action: {action}. Valid actions: search, get, abandon, get_result, get_tags, add_tags, delete_tags'}
+        return {
+            "error": f"Unknown action: {action}. Valid actions: search, get, abandon, get_result, get_tags, add_tags, delete_tags"
+        }
 
 
 def register_tools(app, dct_client):
     global client
     client = dct_client
-    logger.info(f'Registering tools for job_endpoints...')
+    logger.info("Registering tools for job_endpoints...")
     try:
-        logger.info(f'  Registering tool function: job_tool')
+        logger.info("  Registering tool function: job_tool")
         app.add_tool(job_tool, name="job_tool")
     except Exception as e:
-        logger.error(f'Error registering tools for job_endpoints: {e}')
-    logger.info(f'Tools registration finished for job_endpoints.')
+        logger.error(f"Error registering tools for job_endpoints: {e}")
+    logger.info("Tools registration finished for job_endpoints.")

--- a/src/dct_mcp_server/tools/misc_endpoints_tool.py
+++ b/src/dct_mcp_server/tools/misc_endpoints_tool.py
@@ -1,7 +1,6 @@
-from mcp.server.fastmcp import FastMCP
-from typing import Dict,Any,Optional
+from typing import Dict, Any, Optional
 from dct_mcp_server.core.decorators import log_tool_execution
-from dct_mcp_server.config import get_confirmation_for_operation, requires_confirmation
+from dct_mcp_server.config import get_confirmation_for_operation
 import asyncio
 import logging
 import threading
@@ -29,7 +28,16 @@ logger = logging.getLogger(__name__)
 #       }
 # =============================================================================
 
-def check_confirmation(method: str, api_path: str, action: str, tool_name: str, confirmed: bool = False, request_params: Optional[Dict[str, Any]] = None, request_body: Optional[Dict[str, Any]] = None) -> Optional[Dict[str, Any]]:
+
+def check_confirmation(
+    method: str,
+    api_path: str,
+    action: str,
+    tool_name: str,
+    confirmed: bool = False,
+    request_params: Optional[Dict[str, Any]] = None,
+    request_body: Optional[Dict[str, Any]] = None,
+) -> Optional[Dict[str, Any]]:
     """Check if operation requires confirmation. Returns confirmation response or None if confirmed/not needed."""
     confirmation = get_confirmation_for_operation(method, api_path)
     if confirmation["level"] != "none" and not confirmed:
@@ -41,7 +49,11 @@ def check_confirmation(method: str, api_path: str, action: str, tool_name: str, 
             review.update(request_params)
         if request_body:
             review.update(request_body)
-        is_review_critical = action.startswith("provision_") or action.startswith("dsource_link_") or action == "dsource_create_snapshot"
+        is_review_critical = (
+            action.startswith("provision_")
+            or action.startswith("dsource_link_")
+            or action == "dsource_create_snapshot"
+        )
         instructions = (
             "STOP: You MUST display the confirmation_message to the user and wait for their EXPLICIT "
             "approval before re-calling with confirmed=True. Do NOT proceed without user consent."
@@ -56,7 +68,9 @@ def check_confirmation(method: str, api_path: str, action: str, tool_name: str, 
         return {
             "status": "confirmation_required",
             "confirmation_level": confirmation["level"],
-            "confirmation_message": confirmation.get("message", "Please confirm this operation."),
+            "confirmation_message": confirmation.get(
+                "message", "Please confirm this operation."
+            ),
             "action": action,
             "tool": tool_name,
             "api_path": api_path,
@@ -66,8 +80,10 @@ def check_confirmation(method: str, api_path: str, action: str, tool_name: str, 
         }
     return None
 
+
 def async_to_sync(async_func):
     """Utility decorator to convert async functions to sync with proper event loop handling."""
+
     @wraps(async_func)
     def wrapper(*args, **kwargs):
         try:
@@ -76,12 +92,14 @@ def async_to_sync(async_func):
                 # Create a task and run it synchronously
                 result = None
                 exception = None
+
                 def run_in_thread():
                     nonlocal result, exception
                     try:
                         result = asyncio.run(async_func(*args, **kwargs))
                     except Exception as e:
                         exception = e
+
                 thread = threading.Thread(target=run_in_thread)
                 thread.start()
                 thread.join()
@@ -92,18 +110,28 @@ def async_to_sync(async_func):
                 return loop.run_until_complete(async_func(*args, **kwargs))
         except RuntimeError:
             return asyncio.run(async_func(*args, **kwargs))
+
     return wrapper
 
-def make_api_request(method: str, endpoint: str, params: dict = None, json_body: dict = None):
+
+def make_api_request(
+    method: str, endpoint: str, params: dict = None, json_body: dict = None
+):
     """Utility function to make API requests with consistent parameter handling."""
+
     @async_to_sync
     async def _make_request():
-        return await client.make_request(method, endpoint, params=params or {}, json=json_body)
+        return await client.make_request(
+            method, endpoint, params=params or {}, json=json_body
+        )
+
     return _make_request()
+
 
 def build_params(**kwargs):
     """Build parameters dictionary excluding None and empty string values."""
-    return {k: v for k, v in kwargs.items() if v is not None and v != ''}
+    return {k: v for k, v in kwargs.items() if v is not None and v != ""}
+
 
 @log_tool_execution
 def instance_tool(
@@ -162,13 +190,13 @@ def instance_tool(
 ) -> Dict[str, Any]:
     """
     Unified tool for INSTANCE operations.
-    
+
     This tool supports 20 actions: search_cdbs, get_cdb, update_cdb, delete_cdb, enable_cdb, disable_cdb, get_cdb_tags, add_cdb_tags, delete_cdb_tags, search_vcdbs, get_vcdb, update_vcdb, delete_vcdb, enable_vcdb, disable_vcdb, start_vcdb, stop_vcdb, get_vcdb_tags, add_vcdb_tags, delete_vcdb_tags
-    
+
     ======================================================================
     ACTION REFERENCE
     ======================================================================
-    
+
     ACTION: search_cdbs
     ----------------------------------------
     Summary: Search for CDBs (Oracle only).
@@ -176,7 +204,7 @@ def instance_tool(
     Endpoint: /cdbs/search
     Required Parameters: limit, cursor, sort
     Key Parameters (provide as applicable): filter_expression
-    
+
     Filterable Fields:
         - id: The CDB object entity ID.
         - name: The name of this CDB.
@@ -199,19 +227,19 @@ def instance_tool(
         - jdbc_connection_string: The JDBC connection URL for this CDB.
         - engine_id: A reference to the Engine that this CDB belongs to.
         - is_linked: Whether this CDB is linked or not.
-        - tags: 
+        - tags:
         - group_name: The name of the group containing this CDB.
         - status: The runtime status of the vCDB.
         - enabled: Whether the CDB is enabled or not.
         - instance_name: The instance name of this single instance CDB.
         - instance_number: The instance number of this single instance CDB.
-        - instances: 
-        - oracle_services: 
+        - instances:
+        - oracle_services:
         - repository_id: The repository id of this CDB.
         - logsync_enabled: True if LogSync is enabled for this dSource.
-        - logsync_mode: 
+        - logsync_mode:
         - logsync_interval: Interval between LogSync requests, in seconds.
-        - tde_keystore_config_type: 
+        - tde_keystore_config_type:
         - database_name: The database name of this container database.
         - database_unique_name: The unique name of the container database.
         - tde_kms_pkcs11_config_path: The path to the TDE KMS PKC11 configuration file.
@@ -220,25 +248,25 @@ def instance_tool(
         - db_username: The name of the database user.
         - non_sys_username: The username of a database user that does not have admini...
         - okv_client_id: The id of the OKV client used for TDE keystore access.
-    
+
     Filter Syntax:
         Operators: EQ, NE, GT, GE, LT, LE, CONTAINS, IN, NOT_IN
         Combine: AND, OR
         Example: "name CONTAINS 'prod' AND status EQ 'RUNNING'"
-    
+
     Example:
         >>> instance_tool(action='search_cdbs', limit=..., cursor=..., sort=..., filter_expression="name CONTAINS 'test'")
-    
+
     ACTION: get_cdb
     ----------------------------------------
     Summary: Get a CDB by ID (Oracle only).
     Method: GET
     Endpoint: /cdbs/{cdbId}
     Required Parameters: cdb_id
-    
+
     Example:
         >>> instance_tool(action='get_cdb', cdb_id='example-cdb-123')
-    
+
     ACTION: update_cdb
     ----------------------------------------
     Summary: Update a CDB.
@@ -246,10 +274,10 @@ def instance_tool(
     Endpoint: /cdbs/{cdbId}/update
     Required Parameters: cdb_id
     Key Parameters (provide as applicable): oracle_services, logsync_enabled, logsync_mode, logsync_interval, tde_keystore_password, tde_keystore_config_type, tde_kms_pkcs11_config_path, description, diagnose_no_logging_faults, environment_user_id, rman_channels, files_per_set, encrypted_linking_enabled, compressed_linking_enabled, bandwidth_limit, number_of_connections, backup_level_enabled, check_logical, db_username, db_password, non_sys_username, non_sys_password, okv_client_id, instance_name, instance_number, instances
-    
+
     Example:
         >>> instance_tool(action='update_cdb', cdb_id='example-cdb-123', oracle_services=..., logsync_enabled=..., logsync_mode=..., logsync_interval=..., tde_keystore_password=..., tde_keystore_config_type=..., tde_kms_pkcs11_config_path=..., description=..., diagnose_no_logging_faults=..., environment_user_id='example-environment_user-123', rman_channels=..., files_per_set=..., encrypted_linking_enabled=..., compressed_linking_enabled=..., bandwidth_limit=..., number_of_connections=..., backup_level_enabled=..., check_logical=..., db_username=..., db_password=..., non_sys_username=..., non_sys_password=..., okv_client_id='example-okv_client-123', instance_name=..., instance_number=..., instances=...)
-    
+
     ACTION: delete_cdb
     ----------------------------------------
     Summary: Delete a CDB.
@@ -257,10 +285,10 @@ def instance_tool(
     Endpoint: /cdbs/{cdbId}/delete
     Required Parameters: cdb_id
     Key Parameters (provide as applicable): force, delete_all_dependent_datasets
-    
+
     Example:
         >>> instance_tool(action='delete_cdb', cdb_id='example-cdb-123', force=..., delete_all_dependent_datasets=...)
-    
+
     ACTION: enable_cdb
     ----------------------------------------
     Summary: Enable a CDB.
@@ -268,10 +296,10 @@ def instance_tool(
     Endpoint: /cdbs/{cdbId}/enable
     Required Parameters: cdb_id
     Key Parameters (provide as applicable): attempt_start
-    
+
     Example:
         >>> instance_tool(action='enable_cdb', cdb_id='example-cdb-123', attempt_start=...)
-    
+
     ACTION: disable_cdb
     ----------------------------------------
     Summary: Disable a CDB.
@@ -279,30 +307,30 @@ def instance_tool(
     Endpoint: /cdbs/{cdbId}/disable
     Required Parameters: cdb_id
     Key Parameters (provide as applicable): attempt_cleanup
-    
+
     Example:
         >>> instance_tool(action='disable_cdb', cdb_id='example-cdb-123', attempt_cleanup=...)
-    
+
     ACTION: get_cdb_tags
     ----------------------------------------
     Summary: Get tags for a CDB.
     Method: GET
     Endpoint: /cdbs/{cdbId}/tags
     Required Parameters: cdb_id
-    
+
     Example:
         >>> instance_tool(action='get_cdb_tags', cdb_id='example-cdb-123')
-    
+
     ACTION: add_cdb_tags
     ----------------------------------------
     Summary: Create tags for a CDB.
     Method: POST
     Endpoint: /cdbs/{cdbId}/tags
     Required Parameters: cdb_id, tags
-    
+
     Example:
         >>> instance_tool(action='add_cdb_tags', cdb_id='example-cdb-123', tags=...)
-    
+
     ACTION: delete_cdb_tags
     ----------------------------------------
     Summary: Delete tags for a CDB.
@@ -310,10 +338,10 @@ def instance_tool(
     Endpoint: /cdbs/{cdbId}/tags/delete
     Required Parameters: cdb_id
     Key Parameters (provide as applicable): tags, key, value
-    
+
     Example:
         >>> instance_tool(action='delete_cdb_tags', cdb_id='example-cdb-123', tags=..., key=..., value=...)
-    
+
     ACTION: search_vcdbs
     ----------------------------------------
     Summary: Search for vCDBs (Oracle only).
@@ -321,7 +349,7 @@ def instance_tool(
     Endpoint: /vcdbs/search
     Required Parameters: limit, cursor, sort
     Key Parameters (provide as applicable): filter_expression
-    
+
     Filterable Fields:
         - id: The vCDB object entity ID.
         - name: The name of this vCDB.
@@ -341,51 +369,51 @@ def instance_tool(
         - enabled: Whether the vCDB is enabled or not.
         - content_type: The content type of the vcdb.
         - vcdb_restart: Indicates whether the Engine should automatically restart...
-        - tags: 
+        - tags:
         - invoke_datapatch: Indicates whether datapatch should be invoked.
         - node_listeners: The list of node listeners for this VCDB.
         - instance_name: The instance name of this single instance VCDB.
         - instance_number: The instance number of this single instance VCDB.
-        - instances: 
-        - oracle_services: 
+        - instances:
+        - oracle_services:
         - repository_id: The repository id of this Virtual CDB.
-        - containerization_state: 
+        - containerization_state:
         - tde_key_identifier: ID of the key created by Delphix, as recorded in v$encryp...
-        - tde_keystore_config_type: 
+        - tde_keystore_config_type:
         - is_tde_keystore_password_set: True if TDE keystore password is set for this container d...
         - database_unique_name: The unique name of the database.
         - db_username: The user name of the database.
         - redo_log_groups: Number of Online Redo Log Groups.
         - redo_log_size_in_mb: Online Redo Log size in MB.
         - config_params: Database configuration parameter overrides.
-        - custom_env_vars: 
-        - active_instances: 
+        - custom_env_vars:
+        - active_instances:
         - nfs_version: The NFS version that was last used to mount this source."
-        - nfs_version_reason: 
+        - nfs_version_reason:
         - nfs_encryption_enabled: Flag indicating whether the data transfer is encrypted or...
         - environment_user_ref: The environment user reference.
         - db_template_id: The database template ID for this Virtual CDB.
         - db_template_name: Name of the Database Template.
         - okv_client_id: The id of the OKV client used for TDE keystore access.
-    
+
     Filter Syntax:
         Operators: EQ, NE, GT, GE, LT, LE, CONTAINS, IN, NOT_IN
         Combine: AND, OR
         Example: "name CONTAINS 'prod' AND status EQ 'RUNNING'"
-    
+
     Example:
         >>> instance_tool(action='search_vcdbs', limit=..., cursor=..., sort=..., filter_expression="name CONTAINS 'test'")
-    
+
     ACTION: get_vcdb
     ----------------------------------------
     Summary: Get a vCDB by ID (Oracle only).
     Method: GET
     Endpoint: /vcdbs/{vcdbId}
     Required Parameters: vcdb_id
-    
+
     Example:
         >>> instance_tool(action='get_vcdb', vcdb_id='example-vcdb-123')
-    
+
     ACTION: update_vcdb
     ----------------------------------------
     Summary: Update a VCDB.
@@ -393,10 +421,10 @@ def instance_tool(
     Endpoint: /vcdbs/{vcdbId}/update
     Required Parameters: vcdb_id
     Key Parameters (provide as applicable): oracle_services, tde_keystore_password, tde_keystore_config_type, description, environment_user_id, db_username, db_password, okv_client_id, instance_name, instance_number, instances, node_listeners, invoke_datapatch, tde_key_identifier, auto_restart, config_params, custom_env_vars, custom_env_files, oracle_rac_custom_env_files, oracle_rac_custom_env_vars, db_template_id
-    
+
     Example:
         >>> instance_tool(action='update_vcdb', oracle_services=..., tde_keystore_password=..., tde_keystore_config_type=..., description=..., environment_user_id='example-environment_user-123', db_username=..., db_password=..., okv_client_id='example-okv_client-123', instance_name=..., instance_number=..., instances=..., vcdb_id='example-vcdb-123', node_listeners=..., invoke_datapatch=..., tde_key_identifier=..., auto_restart=..., config_params=..., custom_env_vars=..., custom_env_files=..., oracle_rac_custom_env_files=..., oracle_rac_custom_env_vars=..., db_template_id='example-db_template-123')
-    
+
     ACTION: delete_vcdb
     ----------------------------------------
     Summary: Delete a vCDB.
@@ -404,10 +432,10 @@ def instance_tool(
     Endpoint: /vcdbs/{vcdbId}/delete
     Required Parameters: vcdb_id
     Key Parameters (provide as applicable): force, delete_all_dependent_datasets
-    
+
     Example:
         >>> instance_tool(action='delete_vcdb', force=..., delete_all_dependent_datasets=..., vcdb_id='example-vcdb-123')
-    
+
     ACTION: enable_vcdb
     ----------------------------------------
     Summary: Enable a vCDB.
@@ -415,10 +443,10 @@ def instance_tool(
     Endpoint: /vcdbs/{vcdbId}/enable
     Required Parameters: vcdb_id
     Key Parameters (provide as applicable): attempt_start
-    
+
     Example:
         >>> instance_tool(action='enable_vcdb', attempt_start=..., vcdb_id='example-vcdb-123')
-    
+
     ACTION: disable_vcdb
     ----------------------------------------
     Summary: Disable a vCDB.
@@ -426,10 +454,10 @@ def instance_tool(
     Endpoint: /vcdbs/{vcdbId}/disable
     Required Parameters: vcdb_id
     Key Parameters (provide as applicable): attempt_cleanup
-    
+
     Example:
         >>> instance_tool(action='disable_vcdb', attempt_cleanup=..., vcdb_id='example-vcdb-123')
-    
+
     ACTION: start_vcdb
     ----------------------------------------
     Summary: Start a vCDB.
@@ -437,10 +465,10 @@ def instance_tool(
     Endpoint: /vcdbs/{vcdbId}/start
     Required Parameters: vcdb_id
     Key Parameters (provide as applicable): instances
-    
+
     Example:
         >>> instance_tool(action='start_vcdb', instances=..., vcdb_id='example-vcdb-123')
-    
+
     ACTION: stop_vcdb
     ----------------------------------------
     Summary: Stop a vCDB.
@@ -448,30 +476,30 @@ def instance_tool(
     Endpoint: /vcdbs/{vcdbId}/stop
     Required Parameters: vcdb_id
     Key Parameters (provide as applicable): instances, abort
-    
+
     Example:
         >>> instance_tool(action='stop_vcdb', instances=..., vcdb_id='example-vcdb-123', abort=...)
-    
+
     ACTION: get_vcdb_tags
     ----------------------------------------
     Summary: Get tags for a vCDB.
     Method: GET
     Endpoint: /vcdbs/{vcdbId}/tags
     Required Parameters: vcdb_id
-    
+
     Example:
         >>> instance_tool(action='get_vcdb_tags', vcdb_id='example-vcdb-123')
-    
+
     ACTION: add_vcdb_tags
     ----------------------------------------
     Summary: Create tags for a vCDB.
     Method: POST
     Endpoint: /vcdbs/{vcdbId}/tags
     Required Parameters: tags, vcdb_id
-    
+
     Example:
         >>> instance_tool(action='add_vcdb_tags', tags=..., vcdb_id='example-vcdb-123')
-    
+
     ACTION: delete_vcdb_tags
     ----------------------------------------
     Summary: Delete tags for a vCDB.
@@ -479,17 +507,17 @@ def instance_tool(
     Endpoint: /vcdbs/{vcdbId}/tags/delete
     Required Parameters: vcdb_id
     Key Parameters (provide as applicable): tags, key, value
-    
+
     Example:
         >>> instance_tool(action='delete_vcdb_tags', tags=..., key=..., value=..., vcdb_id='example-vcdb-123')
-    
+
     ======================================================================
     PARAMETERS
     ======================================================================
-    
+
     Args:
         action (str): The operation to perform. One of: search_cdbs, get_cdb, update_cdb, delete_cdb, enable_cdb, disable_cdb, get_cdb_tags, add_cdb_tags, delete_cdb_tags, search_vcdbs, get_vcdb, update_vcdb, delete_vcdb, enable_vcdb, disable_vcdb, start_vcdb, stop_vcdb, get_vcdb_tags, add_vcdb_tags, delete_vcdb_tags
-    
+
       -- General parameters (all database types) --
         abort (bool): Whether to issue 'shutdown abort' to shutdown Virtual Container DB instances....
             [Optional for all actions]
@@ -591,210 +619,516 @@ def instance_tool(
             [Optional for all actions]
         vcdb_id (str): The unique identifier for the vcdb.
             [Required for: get_vcdb, update_vcdb, delete_vcdb, enable_vcdb, disable_vcdb, start_vcdb, stop_vcdb, get_vcdb_tags, add_vcdb_tags, delete_vcdb_tags]
-    
+
     Returns:
         Dict[str, Any]: The API response containing operation results
-    
+
     Raises:
         Returns error dict if required parameters are missing for the action
     """
     # Route to appropriate API based on action
-    if action == 'search_cdbs':
+    if action == "search_cdbs":
         params = build_params(limit=limit, cursor=cursor, sort=sort)
-        body = {'filter_expression': filter_expression} if filter_expression else {}
-        conf = check_confirmation('POST', '/cdbs/search', action, 'instance_tool', confirmed or False, request_params=params, request_body=body)
+        body = {"filter_expression": filter_expression} if filter_expression else {}
+        conf = check_confirmation(
+            "POST",
+            "/cdbs/search",
+            action,
+            "instance_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', '/cdbs/search', params=params, json_body=body)
-    elif action == 'get_cdb':
+        return make_api_request("POST", "/cdbs/search", params=params, json_body=body)
+    elif action == "get_cdb":
         if cdb_id is None:
-            return {'error': 'Missing required parameter: cdb_id for action get_cdb'}
-        endpoint = f'/cdbs/{cdb_id}'
+            return {"error": "Missing required parameter: cdb_id for action get_cdb"}
+        endpoint = f"/cdbs/{cdb_id}"
         params = build_params()
-        conf = check_confirmation('GET', endpoint, action, 'instance_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            endpoint,
+            action,
+            "instance_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', endpoint, params=params)
-    elif action == 'update_cdb':
+        return make_api_request("GET", endpoint, params=params)
+    elif action == "update_cdb":
         if cdb_id is None:
-            return {'error': 'Missing required parameter: cdb_id for action update_cdb'}
-        endpoint = f'/cdbs/{cdb_id}/update'
+            return {"error": "Missing required parameter: cdb_id for action update_cdb"}
+        endpoint = f"/cdbs/{cdb_id}/update"
         params = build_params()
-        if not environment_user_id:
-            environment_user_id = environment_user_ref or environment_user
-        body = {k: v for k, v in {'oracle_services': oracle_services, 'logsync_enabled': logsync_enabled, 'logsync_mode': logsync_mode, 'logsync_interval': logsync_interval, 'tde_keystore_password': tde_keystore_password, 'tde_keystore_config_type': tde_keystore_config_type, 'tde_kms_pkcs11_config_path': tde_kms_pkcs11_config_path, 'description': description, 'diagnose_no_logging_faults': diagnose_no_logging_faults, 'environment_user_id': environment_user_id, 'rman_channels': rman_channels, 'files_per_set': files_per_set, 'encrypted_linking_enabled': encrypted_linking_enabled, 'compressed_linking_enabled': compressed_linking_enabled, 'bandwidth_limit': bandwidth_limit, 'number_of_connections': number_of_connections, 'backup_level_enabled': backup_level_enabled, 'check_logical': check_logical, 'db_username': db_username, 'db_password': db_password, 'non_sys_username': non_sys_username, 'non_sys_password': non_sys_password, 'okv_client_id': okv_client_id, 'instance_name': instance_name, 'instance_number': instance_number, 'instances': instances}.items() if v is not None}
-        conf = check_confirmation('PATCH', endpoint, action, 'instance_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "oracle_services": oracle_services,
+                "logsync_enabled": logsync_enabled,
+                "logsync_mode": logsync_mode,
+                "logsync_interval": logsync_interval,
+                "tde_keystore_password": tde_keystore_password,
+                "tde_keystore_config_type": tde_keystore_config_type,
+                "tde_kms_pkcs11_config_path": tde_kms_pkcs11_config_path,
+                "description": description,
+                "diagnose_no_logging_faults": diagnose_no_logging_faults,
+                "environment_user_id": environment_user_id,
+                "rman_channels": rman_channels,
+                "files_per_set": files_per_set,
+                "encrypted_linking_enabled": encrypted_linking_enabled,
+                "compressed_linking_enabled": compressed_linking_enabled,
+                "bandwidth_limit": bandwidth_limit,
+                "number_of_connections": number_of_connections,
+                "backup_level_enabled": backup_level_enabled,
+                "check_logical": check_logical,
+                "db_username": db_username,
+                "db_password": db_password,
+                "non_sys_username": non_sys_username,
+                "non_sys_password": non_sys_password,
+                "okv_client_id": okv_client_id,
+                "instance_name": instance_name,
+                "instance_number": instance_number,
+                "instances": instances,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "PATCH",
+            endpoint,
+            action,
+            "instance_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('PATCH', endpoint, params=params, json_body=body if body else None)
-    elif action == 'delete_cdb':
+        return make_api_request(
+            "PATCH", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "delete_cdb":
         if cdb_id is None:
-            return {'error': 'Missing required parameter: cdb_id for action delete_cdb'}
-        endpoint = f'/cdbs/{cdb_id}/delete'
+            return {"error": "Missing required parameter: cdb_id for action delete_cdb"}
+        endpoint = f"/cdbs/{cdb_id}/delete"
         params = build_params()
-        body = {k: v for k, v in {'force': force, 'delete_all_dependent_datasets': delete_all_dependent_datasets}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'instance_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "force": force,
+                "delete_all_dependent_datasets": delete_all_dependent_datasets,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "instance_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'enable_cdb':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "enable_cdb":
         if cdb_id is None:
-            return {'error': 'Missing required parameter: cdb_id for action enable_cdb'}
-        endpoint = f'/cdbs/{cdb_id}/enable'
+            return {"error": "Missing required parameter: cdb_id for action enable_cdb"}
+        endpoint = f"/cdbs/{cdb_id}/enable"
         params = build_params()
-        body = {k: v for k, v in {'attempt_start': attempt_start}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'instance_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v for k, v in {"attempt_start": attempt_start}.items() if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "instance_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'disable_cdb':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "disable_cdb":
         if cdb_id is None:
-            return {'error': 'Missing required parameter: cdb_id for action disable_cdb'}
-        endpoint = f'/cdbs/{cdb_id}/disable'
+            return {
+                "error": "Missing required parameter: cdb_id for action disable_cdb"
+            }
+        endpoint = f"/cdbs/{cdb_id}/disable"
         params = build_params()
-        body = {k: v for k, v in {'attempt_cleanup': attempt_cleanup}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'instance_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {"attempt_cleanup": attempt_cleanup}.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "instance_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'get_cdb_tags':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "get_cdb_tags":
         if cdb_id is None:
-            return {'error': 'Missing required parameter: cdb_id for action get_cdb_tags'}
-        endpoint = f'/cdbs/{cdb_id}/tags'
+            return {
+                "error": "Missing required parameter: cdb_id for action get_cdb_tags"
+            }
+        endpoint = f"/cdbs/{cdb_id}/tags"
         params = build_params()
-        conf = check_confirmation('GET', endpoint, action, 'instance_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            endpoint,
+            action,
+            "instance_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', endpoint, params=params)
-    elif action == 'add_cdb_tags':
+        return make_api_request("GET", endpoint, params=params)
+    elif action == "add_cdb_tags":
         if cdb_id is None:
-            return {'error': 'Missing required parameter: cdb_id for action add_cdb_tags'}
-        endpoint = f'/cdbs/{cdb_id}/tags'
+            return {
+                "error": "Missing required parameter: cdb_id for action add_cdb_tags"
+            }
+        endpoint = f"/cdbs/{cdb_id}/tags"
         params = build_params(tags=tags)
-        body = {k: v for k, v in {'tags': tags}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'instance_tool', confirmed or False, request_params=params, request_body=body)
+        body = {k: v for k, v in {"tags": tags}.items() if v is not None}
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "instance_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'delete_cdb_tags':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "delete_cdb_tags":
         if cdb_id is None:
-            return {'error': 'Missing required parameter: cdb_id for action delete_cdb_tags'}
-        endpoint = f'/cdbs/{cdb_id}/tags/delete'
+            return {
+                "error": "Missing required parameter: cdb_id for action delete_cdb_tags"
+            }
+        endpoint = f"/cdbs/{cdb_id}/tags/delete"
         params = build_params()
-        body = {k: v for k, v in {'key': key, 'value': value, 'tags': tags}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'instance_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {"key": key, "value": value, "tags": tags}.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "instance_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'search_vcdbs':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "search_vcdbs":
         params = build_params(limit=limit, cursor=cursor, sort=sort)
-        body = {'filter_expression': filter_expression} if filter_expression else {}
-        conf = check_confirmation('POST', '/vcdbs/search', action, 'instance_tool', confirmed or False, request_params=params, request_body=body)
+        body = {"filter_expression": filter_expression} if filter_expression else {}
+        conf = check_confirmation(
+            "POST",
+            "/vcdbs/search",
+            action,
+            "instance_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', '/vcdbs/search', params=params, json_body=body)
-    elif action == 'get_vcdb':
+        return make_api_request("POST", "/vcdbs/search", params=params, json_body=body)
+    elif action == "get_vcdb":
         if vcdb_id is None:
-            return {'error': 'Missing required parameter: vcdb_id for action get_vcdb'}
-        endpoint = f'/vcdbs/{vcdb_id}'
+            return {"error": "Missing required parameter: vcdb_id for action get_vcdb"}
+        endpoint = f"/vcdbs/{vcdb_id}"
         params = build_params()
-        conf = check_confirmation('GET', endpoint, action, 'instance_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            endpoint,
+            action,
+            "instance_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', endpoint, params=params)
-    elif action == 'update_vcdb':
+        return make_api_request("GET", endpoint, params=params)
+    elif action == "update_vcdb":
         if vcdb_id is None:
-            return {'error': 'Missing required parameter: vcdb_id for action update_vcdb'}
-        endpoint = f'/vcdbs/{vcdb_id}/update'
+            return {
+                "error": "Missing required parameter: vcdb_id for action update_vcdb"
+            }
+        endpoint = f"/vcdbs/{vcdb_id}/update"
         params = build_params()
-        if not environment_user_id:
-            environment_user_id = environment_user_ref or environment_user
-        body = {k: v for k, v in {'oracle_services': oracle_services, 'okv_client_id': okv_client_id, 'instance_name': instance_name, 'instance_number': instance_number, 'instances': instances, 'node_listeners': node_listeners, 'invoke_datapatch': invoke_datapatch, 'tde_keystore_password': tde_keystore_password, 'tde_keystore_config_type': tde_keystore_config_type, 'tde_key_identifier': tde_key_identifier, 'db_username': db_username, 'db_password': db_password, 'auto_restart': auto_restart, 'environment_user_id': environment_user_id, 'config_params': config_params, 'custom_env_vars': custom_env_vars, 'custom_env_files': custom_env_files, 'oracle_rac_custom_env_files': oracle_rac_custom_env_files, 'oracle_rac_custom_env_vars': oracle_rac_custom_env_vars, 'description': description, 'db_template_id': db_template_id}.items() if v is not None}
-        conf = check_confirmation('PATCH', endpoint, action, 'instance_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "oracle_services": oracle_services,
+                "okv_client_id": okv_client_id,
+                "instance_name": instance_name,
+                "instance_number": instance_number,
+                "instances": instances,
+                "node_listeners": node_listeners,
+                "invoke_datapatch": invoke_datapatch,
+                "tde_keystore_password": tde_keystore_password,
+                "tde_keystore_config_type": tde_keystore_config_type,
+                "tde_key_identifier": tde_key_identifier,
+                "db_username": db_username,
+                "db_password": db_password,
+                "auto_restart": auto_restart,
+                "environment_user_id": environment_user_id,
+                "config_params": config_params,
+                "custom_env_vars": custom_env_vars,
+                "custom_env_files": custom_env_files,
+                "oracle_rac_custom_env_files": oracle_rac_custom_env_files,
+                "oracle_rac_custom_env_vars": oracle_rac_custom_env_vars,
+                "description": description,
+                "db_template_id": db_template_id,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "PATCH",
+            endpoint,
+            action,
+            "instance_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('PATCH', endpoint, params=params, json_body=body if body else None)
-    elif action == 'delete_vcdb':
+        return make_api_request(
+            "PATCH", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "delete_vcdb":
         if vcdb_id is None:
-            return {'error': 'Missing required parameter: vcdb_id for action delete_vcdb'}
-        endpoint = f'/vcdbs/{vcdb_id}/delete'
+            return {
+                "error": "Missing required parameter: vcdb_id for action delete_vcdb"
+            }
+        endpoint = f"/vcdbs/{vcdb_id}/delete"
         params = build_params()
-        body = {k: v for k, v in {'force': force, 'delete_all_dependent_datasets': delete_all_dependent_datasets}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'instance_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "force": force,
+                "delete_all_dependent_datasets": delete_all_dependent_datasets,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "instance_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'enable_vcdb':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "enable_vcdb":
         if vcdb_id is None:
-            return {'error': 'Missing required parameter: vcdb_id for action enable_vcdb'}
-        endpoint = f'/vcdbs/{vcdb_id}/enable'
+            return {
+                "error": "Missing required parameter: vcdb_id for action enable_vcdb"
+            }
+        endpoint = f"/vcdbs/{vcdb_id}/enable"
         params = build_params()
-        body = {k: v for k, v in {'attempt_start': attempt_start}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'instance_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v for k, v in {"attempt_start": attempt_start}.items() if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "instance_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'disable_vcdb':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "disable_vcdb":
         if vcdb_id is None:
-            return {'error': 'Missing required parameter: vcdb_id for action disable_vcdb'}
-        endpoint = f'/vcdbs/{vcdb_id}/disable'
+            return {
+                "error": "Missing required parameter: vcdb_id for action disable_vcdb"
+            }
+        endpoint = f"/vcdbs/{vcdb_id}/disable"
         params = build_params()
-        body = {k: v for k, v in {'attempt_cleanup': attempt_cleanup}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'instance_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {"attempt_cleanup": attempt_cleanup}.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "instance_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'start_vcdb':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "start_vcdb":
         if vcdb_id is None:
-            return {'error': 'Missing required parameter: vcdb_id for action start_vcdb'}
-        endpoint = f'/vcdbs/{vcdb_id}/start'
+            return {
+                "error": "Missing required parameter: vcdb_id for action start_vcdb"
+            }
+        endpoint = f"/vcdbs/{vcdb_id}/start"
         params = build_params()
-        body = {k: v for k, v in {'instances': instances}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'instance_tool', confirmed or False, request_params=params, request_body=body)
+        body = {k: v for k, v in {"instances": instances}.items() if v is not None}
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "instance_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'stop_vcdb':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "stop_vcdb":
         if vcdb_id is None:
-            return {'error': 'Missing required parameter: vcdb_id for action stop_vcdb'}
-        endpoint = f'/vcdbs/{vcdb_id}/stop'
+            return {"error": "Missing required parameter: vcdb_id for action stop_vcdb"}
+        endpoint = f"/vcdbs/{vcdb_id}/stop"
         params = build_params()
-        body = {k: v for k, v in {'instances': instances, 'abort': abort}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'instance_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {"instances": instances, "abort": abort}.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "instance_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'get_vcdb_tags':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "get_vcdb_tags":
         if vcdb_id is None:
-            return {'error': 'Missing required parameter: vcdb_id for action get_vcdb_tags'}
-        endpoint = f'/vcdbs/{vcdb_id}/tags'
+            return {
+                "error": "Missing required parameter: vcdb_id for action get_vcdb_tags"
+            }
+        endpoint = f"/vcdbs/{vcdb_id}/tags"
         params = build_params()
-        conf = check_confirmation('GET', endpoint, action, 'instance_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            endpoint,
+            action,
+            "instance_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', endpoint, params=params)
-    elif action == 'add_vcdb_tags':
+        return make_api_request("GET", endpoint, params=params)
+    elif action == "add_vcdb_tags":
         if vcdb_id is None:
-            return {'error': 'Missing required parameter: vcdb_id for action add_vcdb_tags'}
-        endpoint = f'/vcdbs/{vcdb_id}/tags'
+            return {
+                "error": "Missing required parameter: vcdb_id for action add_vcdb_tags"
+            }
+        endpoint = f"/vcdbs/{vcdb_id}/tags"
         params = build_params(tags=tags)
-        body = {k: v for k, v in {'tags': tags}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'instance_tool', confirmed or False, request_params=params, request_body=body)
+        body = {k: v for k, v in {"tags": tags}.items() if v is not None}
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "instance_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'delete_vcdb_tags':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "delete_vcdb_tags":
         if vcdb_id is None:
-            return {'error': 'Missing required parameter: vcdb_id for action delete_vcdb_tags'}
-        endpoint = f'/vcdbs/{vcdb_id}/tags/delete'
+            return {
+                "error": "Missing required parameter: vcdb_id for action delete_vcdb_tags"
+            }
+        endpoint = f"/vcdbs/{vcdb_id}/tags/delete"
         params = build_params()
-        body = {k: v for k, v in {'key': key, 'value': value, 'tags': tags}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'instance_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {"key": key, "value": value, "tags": tags}.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "instance_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
     else:
-        return {'error': f'Unknown action: {action}. Valid actions: search_cdbs, get_cdb, update_cdb, delete_cdb, enable_cdb, disable_cdb, get_cdb_tags, add_cdb_tags, delete_cdb_tags, search_vcdbs, get_vcdb, update_vcdb, delete_vcdb, enable_vcdb, disable_vcdb, start_vcdb, stop_vcdb, get_vcdb_tags, add_vcdb_tags, delete_vcdb_tags'}
+        return {
+            "error": f"Unknown action: {action}. Valid actions: search_cdbs, get_cdb, update_cdb, delete_cdb, enable_cdb, disable_cdb, get_cdb_tags, add_cdb_tags, delete_cdb_tags, search_vcdbs, get_vcdb, update_vcdb, delete_vcdb, enable_vcdb, disable_vcdb, start_vcdb, stop_vcdb, get_vcdb_tags, add_vcdb_tags, delete_vcdb_tags"
+        }
+
 
 @log_tool_execution
 def staging_source_tool(
@@ -812,23 +1146,23 @@ def staging_source_tool(
 ) -> Dict[str, Any]:
     """
     Unified tool for STAGING SOURCE operations.
-    
+
     This tool supports 7 actions: list, search, get, update, get_tags, add_tags, delete_tags
-    
+
     ======================================================================
     ACTION REFERENCE
     ======================================================================
-    
+
     ACTION: list
     ----------------------------------------
     Summary: List all staging sources.
     Method: GET
     Endpoint: /staging-sources
     Required Parameters: limit, cursor, sort
-    
+
     Example:
         >>> staging_source_tool(action='list', limit=..., cursor=..., sort=...)
-    
+
     ACTION: search
     ----------------------------------------
     Summary: Search for Staging Sources.
@@ -836,7 +1170,7 @@ def staging_source_tool(
     Endpoint: /staging-sources/search
     Required Parameters: limit, cursor, sort
     Key Parameters (provide as applicable): filter_expression
-    
+
     Filterable Fields:
         - id: The Staging Source object entity ID.
         - name: The name of this staging source database.
@@ -849,11 +1183,11 @@ def staging_source_tool(
         - fqdn: The FQDN of the staging source's host.
         - repository: The repository id for this staging source.
         - type: The type of source configuration for this staging source.
-        - oracle_config_type: 
+        - oracle_config_type:
         - cdb_type: The cdb type for this staging source. (Oracle only)
         - dsource_id: The dsource_id associated with this staging source.
-        - tags: 
-        - oracle_services: 
+        - tags:
+        - oracle_services:
         - environment_user_ref: The environment user reference.
         - recovery_model: Recovery model of the source database.
         - mount_base: The base mount point for the NFS or iSCSI LUN mounts.
@@ -863,29 +1197,29 @@ def staging_source_tool(
         - database_unique_name: The unique name of the database.
         - instance_name: The instance name of this staging database.
         - size: The total size of this Staging database, in bytes.
-        - custom_env_vars: 
+        - custom_env_vars:
         - nfs_version: The NFS version that was last used to mount this source."
-        - nfs_version_reason: 
+        - nfs_version_reason:
         - nfs_encryption_enabled: Flag indicating whether the data transfer is encrypted or...
-    
+
     Filter Syntax:
         Operators: EQ, NE, GT, GE, LT, LE, CONTAINS, IN, NOT_IN
         Combine: AND, OR
         Example: "name CONTAINS 'prod' AND status EQ 'RUNNING'"
-    
+
     Example:
         >>> staging_source_tool(action='search', limit=..., cursor=..., sort=..., filter_expression="name CONTAINS 'test'")
-    
+
     ACTION: get
     ----------------------------------------
     Summary: Get a staging source by ID.
     Method: GET
     Endpoint: /staging-sources/{stagingSourceId}
     Required Parameters: staging_source_id
-    
+
     Example:
         >>> staging_source_tool(action='get', staging_source_id='example-staging_source-123')
-    
+
     ACTION: update
     ----------------------------------------
     Summary: Update a Staging Source.
@@ -893,30 +1227,30 @@ def staging_source_tool(
     Endpoint: /staging-sources/{stagingSourceId}/update
     Required Parameters: staging_source_id
     Key Parameters (provide as applicable): oracle_services
-    
+
     Example:
         >>> staging_source_tool(action='update', staging_source_id='example-staging_source-123', oracle_services=...)
-    
+
     ACTION: get_tags
     ----------------------------------------
     Summary: Get tags for a Staging Source.
     Method: GET
     Endpoint: /staging-sources/{stagingSourceId}/tags
     Required Parameters: staging_source_id
-    
+
     Example:
         >>> staging_source_tool(action='get_tags', staging_source_id='example-staging_source-123')
-    
+
     ACTION: add_tags
     ----------------------------------------
     Summary: Create tags for a Staging Source.
     Method: POST
     Endpoint: /staging-sources/{stagingSourceId}/tags
     Required Parameters: staging_source_id, tags
-    
+
     Example:
         >>> staging_source_tool(action='add_tags', staging_source_id='example-staging_source-123', tags=...)
-    
+
     ACTION: delete_tags
     ----------------------------------------
     Summary: Delete tags for a Staging Source.
@@ -924,17 +1258,17 @@ def staging_source_tool(
     Endpoint: /staging-sources/{stagingSourceId}/tags/delete
     Required Parameters: staging_source_id
     Key Parameters (provide as applicable): tags, key, value
-    
+
     Example:
         >>> staging_source_tool(action='delete_tags', staging_source_id='example-staging_source-123', tags=..., key=..., value=...)
-    
+
     ======================================================================
     PARAMETERS
     ======================================================================
-    
+
     Args:
         action (str): The operation to perform. One of: list, search, get, update, get_tags, add_tags, delete_tags
-    
+
       -- General parameters (all database types) --
         cursor (str): Cursor to fetch the next or previous page of results. The value of this prope...
             [Required for: list, search]
@@ -954,77 +1288,162 @@ def staging_source_tool(
             [Required for: add_tags]
         value (str): Value of the tag
             [Optional for all actions]
-    
+
     Returns:
         Dict[str, Any]: The API response containing operation results
-    
+
     Raises:
         Returns error dict if required parameters are missing for the action
     """
     # Route to appropriate API based on action
-    if action == 'list':
+    if action == "list":
         params = build_params(limit=limit, cursor=cursor, sort=sort)
-        conf = check_confirmation('GET', '/staging-sources', action, 'staging_source_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            "/staging-sources",
+            action,
+            "staging_source_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', '/staging-sources', params=params)
-    elif action == 'search':
+        return make_api_request("GET", "/staging-sources", params=params)
+    elif action == "search":
         params = build_params(limit=limit, cursor=cursor, sort=sort)
-        body = {'filter_expression': filter_expression} if filter_expression else {}
-        conf = check_confirmation('POST', '/staging-sources/search', action, 'staging_source_tool', confirmed or False, request_params=params, request_body=body)
+        body = {"filter_expression": filter_expression} if filter_expression else {}
+        conf = check_confirmation(
+            "POST",
+            "/staging-sources/search",
+            action,
+            "staging_source_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', '/staging-sources/search', params=params, json_body=body)
-    elif action == 'get':
+        return make_api_request(
+            "POST", "/staging-sources/search", params=params, json_body=body
+        )
+    elif action == "get":
         if staging_source_id is None:
-            return {'error': 'Missing required parameter: staging_source_id for action get'}
-        endpoint = f'/staging-sources/{staging_source_id}'
+            return {
+                "error": "Missing required parameter: staging_source_id for action get"
+            }
+        endpoint = f"/staging-sources/{staging_source_id}"
         params = build_params()
-        conf = check_confirmation('GET', endpoint, action, 'staging_source_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            endpoint,
+            action,
+            "staging_source_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', endpoint, params=params)
-    elif action == 'update':
+        return make_api_request("GET", endpoint, params=params)
+    elif action == "update":
         if staging_source_id is None:
-            return {'error': 'Missing required parameter: staging_source_id for action update'}
-        endpoint = f'/staging-sources/{staging_source_id}/update'
+            return {
+                "error": "Missing required parameter: staging_source_id for action update"
+            }
+        endpoint = f"/staging-sources/{staging_source_id}/update"
         params = build_params()
-        body = {k: v for k, v in {'oracle_services': oracle_services}.items() if v is not None}
-        conf = check_confirmation('PATCH', endpoint, action, 'staging_source_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {"oracle_services": oracle_services}.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "PATCH",
+            endpoint,
+            action,
+            "staging_source_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('PATCH', endpoint, params=params, json_body=body if body else None)
-    elif action == 'get_tags':
+        return make_api_request(
+            "PATCH", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "get_tags":
         if staging_source_id is None:
-            return {'error': 'Missing required parameter: staging_source_id for action get_tags'}
-        endpoint = f'/staging-sources/{staging_source_id}/tags'
+            return {
+                "error": "Missing required parameter: staging_source_id for action get_tags"
+            }
+        endpoint = f"/staging-sources/{staging_source_id}/tags"
         params = build_params()
-        conf = check_confirmation('GET', endpoint, action, 'staging_source_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            endpoint,
+            action,
+            "staging_source_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', endpoint, params=params)
-    elif action == 'add_tags':
+        return make_api_request("GET", endpoint, params=params)
+    elif action == "add_tags":
         if staging_source_id is None:
-            return {'error': 'Missing required parameter: staging_source_id for action add_tags'}
-        endpoint = f'/staging-sources/{staging_source_id}/tags'
+            return {
+                "error": "Missing required parameter: staging_source_id for action add_tags"
+            }
+        endpoint = f"/staging-sources/{staging_source_id}/tags"
         params = build_params(tags=tags)
-        body = {k: v for k, v in {'tags': tags}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'staging_source_tool', confirmed or False, request_params=params, request_body=body)
+        body = {k: v for k, v in {"tags": tags}.items() if v is not None}
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "staging_source_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'delete_tags':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "delete_tags":
         if staging_source_id is None:
-            return {'error': 'Missing required parameter: staging_source_id for action delete_tags'}
-        endpoint = f'/staging-sources/{staging_source_id}/tags/delete'
+            return {
+                "error": "Missing required parameter: staging_source_id for action delete_tags"
+            }
+        endpoint = f"/staging-sources/{staging_source_id}/tags/delete"
         params = build_params()
-        body = {k: v for k, v in {'key': key, 'value': value, 'tags': tags}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'staging_source_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {"key": key, "value": value, "tags": tags}.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "staging_source_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
     else:
-        return {'error': f'Unknown action: {action}. Valid actions: list, search, get, update, get_tags, add_tags, delete_tags'}
+        return {
+            "error": f"Unknown action: {action}. Valid actions: list, search, get, update, get_tags, add_tags, delete_tags"
+        }
+
 
 @log_tool_execution
 def staging_cdb_tool(
@@ -1064,23 +1483,23 @@ def staging_cdb_tool(
 ) -> Dict[str, Any]:
     """
     Unified tool for STAGING CDB operations.
-    
+
     This tool supports 11 actions: list, search, get, update, delete, enable, disable, upgrade, get_tags, add_tags, delete_tags
-    
+
     ======================================================================
     ACTION REFERENCE
     ======================================================================
-    
+
     ACTION: list
     ----------------------------------------
     Summary: List all Staging CDBs.
     Method: GET
     Endpoint: /staging-cdbs
     Required Parameters: limit, cursor, sort
-    
+
     Example:
         >>> staging_cdb_tool(action='list', limit=..., cursor=..., sort=...)
-    
+
     ACTION: search
     ----------------------------------------
     Summary: Search for Staging CDBs.
@@ -1088,7 +1507,7 @@ def staging_cdb_tool(
     Endpoint: /staging-cdbs/search
     Required Parameters: limit, cursor, sort
     Key Parameters (provide as applicable): filter_expression
-    
+
     Filterable Fields:
         - id: The Staging CDB object entity ID.
         - name: The name of this Staging CDB.
@@ -1100,15 +1519,15 @@ def staging_cdb_tool(
         - size: The total size of the data files used by this Staging CDB...
         - jdbc_connection_string: The JDBC connection URL for this Staging CDB.
         - engine_id: A reference to the Engine that this Staging CDB belongs to.
-        - tags: 
+        - tags:
         - group_name: The name of the group containing this Staging CDB.
         - status: The runtime status of the Staging CDB.
         - enabled: Whether the Staging CDB is enabled or not.
         - instance_name: The instance name of this single instance Staging CDB.
         - instance_number: The instance number of this single instance Staging CDB.
-        - oracle_services: 
+        - oracle_services:
         - repository_id: The repository id of this Staging CDB.
-        - tde_keystore_config_type: 
+        - tde_keystore_config_type:
         - database_name: The database name of this Staging CDB.
         - database_unique_name: The unique name of the Staging CDB.
         - tde_kms_pkcs11_config_path: The path to the TDE KMS PKC11 configuration file.
@@ -1120,9 +1539,9 @@ def staging_cdb_tool(
         - mount_base: The base mount point for the NFS mount on the staging env...
         - datafile_mount_path: The datafile mount point for the NFS mount on the staging...
         - archive_mount_path: The archive mount point for the NFS mount on the staging ...
-        - custom_env_vars: 
+        - custom_env_vars:
         - nfs_version: The NFS version that was last used to mount this source."
-        - nfs_version_reason: 
+        - nfs_version_reason:
         - nfs_encryption_enabled: Flag indicating whether the data transfer is encrypted or...
         - logsync_enabled: Whether logsync is enabled for this Staging CDB.
         - description: Description of this Staging CDB.
@@ -1131,25 +1550,25 @@ def staging_cdb_tool(
         - db_template_name: Name of the Database Template.
         - environment_user_ref: The environment user reference.
         - okv_client_id: The id of the OKV client used for TDE keystore access.
-    
+
     Filter Syntax:
         Operators: EQ, NE, GT, GE, LT, LE, CONTAINS, IN, NOT_IN
         Combine: AND, OR
         Example: "name CONTAINS 'prod' AND status EQ 'RUNNING'"
-    
+
     Example:
         >>> staging_cdb_tool(action='search', limit=..., cursor=..., sort=..., filter_expression="name CONTAINS 'test'")
-    
+
     ACTION: get
     ----------------------------------------
     Summary: Get a Staging CDB by ID.
     Method: GET
     Endpoint: /staging-cdbs/{stagingCdbId}
     Required Parameters: staging_cdb_id
-    
+
     Example:
         >>> staging_cdb_tool(action='get', staging_cdb_id='example-staging_cdb-123')
-    
+
     ACTION: update
     ----------------------------------------
     Summary: Update a Staging CDB.
@@ -1157,10 +1576,10 @@ def staging_cdb_tool(
     Endpoint: /staging-cdbs/{stagingCdbId}
     Required Parameters: staging_cdb_id
     Key Parameters (provide as applicable): oracle_services, logsync_enabled, tde_keystore_password, tde_keystore_config_type, tde_kms_pkcs11_config_path, allow_auto_staging_restart_on_host_reboot, physical_standby, validate_snapshot_by_opening_db_in_read_mode, custom_env_variables_pairs, custom_env_variables_paths, environment_id, repository_id, environment_user_id, description, config_params, db_template_id, okv_client_id, instance_name, instance_number
-    
+
     Example:
         >>> staging_cdb_tool(action='update', staging_cdb_id='example-staging_cdb-123', oracle_services=..., logsync_enabled=..., tde_keystore_password=..., tde_keystore_config_type=..., tde_kms_pkcs11_config_path=..., allow_auto_staging_restart_on_host_reboot=..., physical_standby=..., validate_snapshot_by_opening_db_in_read_mode=..., custom_env_variables_pairs=..., custom_env_variables_paths=..., environment_id='example-environment-123', repository_id='example-repository-123', environment_user_id='example-environment_user-123', description=..., config_params=..., db_template_id='example-db_template-123', okv_client_id='example-okv_client-123', instance_name=..., instance_number=...)
-    
+
     ACTION: delete
     ----------------------------------------
     Summary: Delete a staging CDB.
@@ -1168,10 +1587,10 @@ def staging_cdb_tool(
     Endpoint: /staging-cdbs/{stagingCdbId}/delete
     Required Parameters: staging_cdb_id
     Key Parameters (provide as applicable): force, delete_all_dependent_datasets
-    
+
     Example:
         >>> staging_cdb_tool(action='delete', staging_cdb_id='example-staging_cdb-123', force=..., delete_all_dependent_datasets=...)
-    
+
     ACTION: enable
     ----------------------------------------
     Summary: Enable a staging CDB.
@@ -1179,10 +1598,10 @@ def staging_cdb_tool(
     Endpoint: /staging-cdbs/{stagingCdbId}/enable
     Required Parameters: staging_cdb_id
     Key Parameters (provide as applicable): attempt_start
-    
+
     Example:
         >>> staging_cdb_tool(action='enable', staging_cdb_id='example-staging_cdb-123', attempt_start=...)
-    
+
     ACTION: disable
     ----------------------------------------
     Summary: Disable a staging CDB.
@@ -1190,40 +1609,40 @@ def staging_cdb_tool(
     Endpoint: /staging-cdbs/{stagingCdbId}/disable
     Required Parameters: staging_cdb_id
     Key Parameters (provide as applicable): attempt_cleanup
-    
+
     Example:
         >>> staging_cdb_tool(action='disable', staging_cdb_id='example-staging_cdb-123', attempt_cleanup=...)
-    
+
     ACTION: upgrade
     ----------------------------------------
     Summary: Upgrade Oracle staging CDB.
     Method: POST
     Endpoint: /staging-cdbs/{stagingCdbId}/upgrade
     Required Parameters: staging_cdb_id, repository_id, environment_user_id
-    
+
     Example:
         >>> staging_cdb_tool(action='upgrade', staging_cdb_id='example-staging_cdb-123', repository_id='example-repository-123', environment_user_id='example-environment_user-123')
-    
+
     ACTION: get_tags
     ----------------------------------------
     Summary: Get tags for a staging CDB.
     Method: GET
     Endpoint: /staging-cdbs/{stagingCdbId}/tags
     Required Parameters: staging_cdb_id
-    
+
     Example:
         >>> staging_cdb_tool(action='get_tags', staging_cdb_id='example-staging_cdb-123')
-    
+
     ACTION: add_tags
     ----------------------------------------
     Summary: Create tags for a staging CDB.
     Method: POST
     Endpoint: /staging-cdbs/{stagingCdbId}/tags
     Required Parameters: staging_cdb_id, tags
-    
+
     Example:
         >>> staging_cdb_tool(action='add_tags', staging_cdb_id='example-staging_cdb-123', tags=...)
-    
+
     ACTION: delete_tags
     ----------------------------------------
     Summary: Delete tags for a staging CDB.
@@ -1231,17 +1650,17 @@ def staging_cdb_tool(
     Endpoint: /staging-cdbs/{stagingCdbId}/tags/delete
     Required Parameters: staging_cdb_id
     Key Parameters (provide as applicable): tags, key, value
-    
+
     Example:
         >>> staging_cdb_tool(action='delete_tags', staging_cdb_id='example-staging_cdb-123', tags=..., key=..., value=...)
-    
+
     ======================================================================
     PARAMETERS
     ======================================================================
-    
+
     Args:
         action (str): The operation to perform. One of: list, search, get, update, delete, enable, disable, upgrade, get_tags, add_tags, delete_tags
-    
+
       -- General parameters (all database types) --
         allow_auto_staging_restart_on_host_reboot (bool): Whether to automatically restart staging operations on host reboot.
             [Optional for all actions]
@@ -1305,121 +1724,290 @@ def staging_cdb_tool(
             [Optional for all actions]
         value (str): Value of the tag
             [Optional for all actions]
-    
+
     Returns:
         Dict[str, Any]: The API response containing operation results
-    
+
     Raises:
         Returns error dict if required parameters are missing for the action
     """
     # Route to appropriate API based on action
-    if action == 'list':
+    if action == "list":
         params = build_params(limit=limit, cursor=cursor, sort=sort)
-        conf = check_confirmation('GET', '/staging-cdbs', action, 'staging_cdb_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            "/staging-cdbs",
+            action,
+            "staging_cdb_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', '/staging-cdbs', params=params)
-    elif action == 'search':
+        return make_api_request("GET", "/staging-cdbs", params=params)
+    elif action == "search":
         params = build_params(limit=limit, cursor=cursor, sort=sort)
-        body = {'filter_expression': filter_expression} if filter_expression else {}
-        conf = check_confirmation('POST', '/staging-cdbs/search', action, 'staging_cdb_tool', confirmed or False, request_params=params, request_body=body)
+        body = {"filter_expression": filter_expression} if filter_expression else {}
+        conf = check_confirmation(
+            "POST",
+            "/staging-cdbs/search",
+            action,
+            "staging_cdb_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', '/staging-cdbs/search', params=params, json_body=body)
-    elif action == 'get':
+        return make_api_request(
+            "POST", "/staging-cdbs/search", params=params, json_body=body
+        )
+    elif action == "get":
         if staging_cdb_id is None:
-            return {'error': 'Missing required parameter: staging_cdb_id for action get'}
-        endpoint = f'/staging-cdbs/{staging_cdb_id}'
+            return {
+                "error": "Missing required parameter: staging_cdb_id for action get"
+            }
+        endpoint = f"/staging-cdbs/{staging_cdb_id}"
         params = build_params()
-        conf = check_confirmation('GET', endpoint, action, 'staging_cdb_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            endpoint,
+            action,
+            "staging_cdb_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', endpoint, params=params)
-    elif action == 'update':
+        return make_api_request("GET", endpoint, params=params)
+    elif action == "update":
         if staging_cdb_id is None:
-            return {'error': 'Missing required parameter: staging_cdb_id for action update'}
-        endpoint = f'/staging-cdbs/{staging_cdb_id}'
+            return {
+                "error": "Missing required parameter: staging_cdb_id for action update"
+            }
+        endpoint = f"/staging-cdbs/{staging_cdb_id}"
         params = build_params()
-        if not environment_user_id:
-            environment_user_id = environment_user_ref or environment_user
-        body = {k: v for k, v in {'oracle_services': oracle_services, 'logsync_enabled': logsync_enabled, 'tde_keystore_password': tde_keystore_password, 'tde_keystore_config_type': tde_keystore_config_type, 'tde_kms_pkcs11_config_path': tde_kms_pkcs11_config_path, 'allow_auto_staging_restart_on_host_reboot': allow_auto_staging_restart_on_host_reboot, 'physical_standby': physical_standby, 'validate_snapshot_by_opening_db_in_read_mode': validate_snapshot_by_opening_db_in_read_mode, 'custom_env_variables_pairs': custom_env_variables_pairs, 'custom_env_variables_paths': custom_env_variables_paths, 'environment_id': environment_id, 'repository_id': repository_id, 'environment_user_id': environment_user_id, 'description': description, 'config_params': config_params, 'db_template_id': db_template_id, 'okv_client_id': okv_client_id, 'instance_name': instance_name, 'instance_number': instance_number}.items() if v is not None}
-        conf = check_confirmation('PATCH', endpoint, action, 'staging_cdb_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "oracle_services": oracle_services,
+                "logsync_enabled": logsync_enabled,
+                "tde_keystore_password": tde_keystore_password,
+                "tde_keystore_config_type": tde_keystore_config_type,
+                "tde_kms_pkcs11_config_path": tde_kms_pkcs11_config_path,
+                "allow_auto_staging_restart_on_host_reboot": allow_auto_staging_restart_on_host_reboot,
+                "physical_standby": physical_standby,
+                "validate_snapshot_by_opening_db_in_read_mode": validate_snapshot_by_opening_db_in_read_mode,
+                "custom_env_variables_pairs": custom_env_variables_pairs,
+                "custom_env_variables_paths": custom_env_variables_paths,
+                "environment_id": environment_id,
+                "repository_id": repository_id,
+                "environment_user_id": environment_user_id,
+                "description": description,
+                "config_params": config_params,
+                "db_template_id": db_template_id,
+                "okv_client_id": okv_client_id,
+                "instance_name": instance_name,
+                "instance_number": instance_number,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "PATCH",
+            endpoint,
+            action,
+            "staging_cdb_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('PATCH', endpoint, params=params, json_body=body if body else None)
-    elif action == 'delete':
+        return make_api_request(
+            "PATCH", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "delete":
         if staging_cdb_id is None:
-            return {'error': 'Missing required parameter: staging_cdb_id for action delete'}
-        endpoint = f'/staging-cdbs/{staging_cdb_id}/delete'
+            return {
+                "error": "Missing required parameter: staging_cdb_id for action delete"
+            }
+        endpoint = f"/staging-cdbs/{staging_cdb_id}/delete"
         params = build_params()
-        body = {k: v for k, v in {'force': force, 'delete_all_dependent_datasets': delete_all_dependent_datasets}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'staging_cdb_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "force": force,
+                "delete_all_dependent_datasets": delete_all_dependent_datasets,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "staging_cdb_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'enable':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "enable":
         if staging_cdb_id is None:
-            return {'error': 'Missing required parameter: staging_cdb_id for action enable'}
-        endpoint = f'/staging-cdbs/{staging_cdb_id}/enable'
+            return {
+                "error": "Missing required parameter: staging_cdb_id for action enable"
+            }
+        endpoint = f"/staging-cdbs/{staging_cdb_id}/enable"
         params = build_params()
-        body = {k: v for k, v in {'attempt_start': attempt_start}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'staging_cdb_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v for k, v in {"attempt_start": attempt_start}.items() if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "staging_cdb_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'disable':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "disable":
         if staging_cdb_id is None:
-            return {'error': 'Missing required parameter: staging_cdb_id for action disable'}
-        endpoint = f'/staging-cdbs/{staging_cdb_id}/disable'
+            return {
+                "error": "Missing required parameter: staging_cdb_id for action disable"
+            }
+        endpoint = f"/staging-cdbs/{staging_cdb_id}/disable"
         params = build_params()
-        body = {k: v for k, v in {'attempt_cleanup': attempt_cleanup}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'staging_cdb_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {"attempt_cleanup": attempt_cleanup}.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "staging_cdb_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'upgrade':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "upgrade":
         if staging_cdb_id is None:
-            return {'error': 'Missing required parameter: staging_cdb_id for action upgrade'}
-        endpoint = f'/staging-cdbs/{staging_cdb_id}/upgrade'
+            return {
+                "error": "Missing required parameter: staging_cdb_id for action upgrade"
+            }
+        endpoint = f"/staging-cdbs/{staging_cdb_id}/upgrade"
         params = build_params()
-        if not environment_user_id:
-            environment_user_id = environment_user_ref or environment_user
-        body = {k: v for k, v in {'repository_id': repository_id, 'environment_user_id': environment_user_id}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'staging_cdb_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "repository_id": repository_id,
+                "environment_user_id": environment_user_id,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "staging_cdb_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'get_tags':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "get_tags":
         if staging_cdb_id is None:
-            return {'error': 'Missing required parameter: staging_cdb_id for action get_tags'}
-        endpoint = f'/staging-cdbs/{staging_cdb_id}/tags'
+            return {
+                "error": "Missing required parameter: staging_cdb_id for action get_tags"
+            }
+        endpoint = f"/staging-cdbs/{staging_cdb_id}/tags"
         params = build_params()
-        conf = check_confirmation('GET', endpoint, action, 'staging_cdb_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            endpoint,
+            action,
+            "staging_cdb_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', endpoint, params=params)
-    elif action == 'add_tags':
+        return make_api_request("GET", endpoint, params=params)
+    elif action == "add_tags":
         if staging_cdb_id is None:
-            return {'error': 'Missing required parameter: staging_cdb_id for action add_tags'}
-        endpoint = f'/staging-cdbs/{staging_cdb_id}/tags'
+            return {
+                "error": "Missing required parameter: staging_cdb_id for action add_tags"
+            }
+        endpoint = f"/staging-cdbs/{staging_cdb_id}/tags"
         params = build_params(tags=tags)
-        body = {k: v for k, v in {'tags': tags}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'staging_cdb_tool', confirmed or False, request_params=params, request_body=body)
+        body = {k: v for k, v in {"tags": tags}.items() if v is not None}
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "staging_cdb_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'delete_tags':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "delete_tags":
         if staging_cdb_id is None:
-            return {'error': 'Missing required parameter: staging_cdb_id for action delete_tags'}
-        endpoint = f'/staging-cdbs/{staging_cdb_id}/tags/delete'
+            return {
+                "error": "Missing required parameter: staging_cdb_id for action delete_tags"
+            }
+        endpoint = f"/staging-cdbs/{staging_cdb_id}/tags/delete"
         params = build_params()
-        body = {k: v for k, v in {'key': key, 'value': value, 'tags': tags}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'staging_cdb_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {"key": key, "value": value, "tags": tags}.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "staging_cdb_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
     else:
-        return {'error': f'Unknown action: {action}. Valid actions: list, search, get, update, delete, enable, disable, upgrade, get_tags, add_tags, delete_tags'}
+        return {
+            "error": f"Unknown action: {action}. Valid actions: list, search, get, update, delete, enable, disable, upgrade, get_tags, add_tags, delete_tags"
+        }
+
 
 @log_tool_execution
 def cdb_dsource_tool(
@@ -1455,23 +2043,23 @@ def cdb_dsource_tool(
 ) -> Dict[str, Any]:
     """
     Unified tool for CDB DSOURCE operations.
-    
+
     This tool supports 9 actions: list, search, get, attach_cdb, detach_cdb, enable, disable, delete, upgrade
-    
+
     ======================================================================
     ACTION REFERENCE
     ======================================================================
-    
+
     ACTION: list
     ----------------------------------------
     Summary: List all CDB dSources (Oracle only).
     Method: GET
     Endpoint: /cdb-dsources
     Required Parameters: limit, cursor, sort
-    
+
     Example:
         >>> cdb_dsource_tool(action='list', limit=..., cursor=..., sort=...)
-    
+
     ACTION: search
     ----------------------------------------
     Summary: Search for CDB dSources (Oracle only).
@@ -1479,7 +2067,7 @@ def cdb_dsource_tool(
     Endpoint: /cdb-dsources/search
     Required Parameters: limit, cursor, sort
     Key Parameters (provide as applicable): filter_expression
-    
+
     Filterable Fields:
         - id: The CDB object entity ID.
         - engine_id: A reference to the Engine that this CDB belongs to.
@@ -1490,7 +2078,7 @@ def cdb_dsource_tool(
         - cdb_source_id: The container description of this Linked CDB.
         - is_detached: Is this a detached CDB container.
         - logsync_enabled: True if LogSync is enabled for this dSource.
-        - logsync_mode: 
+        - logsync_mode:
         - logsync_interval: Interval between LogSync requests, in seconds.
         - size: The total size of the data files used by this CDB, in bytes.
         - namespace_id: The namespace id of this CDB.
@@ -1506,46 +2094,46 @@ def cdb_dsource_tool(
         - number_of_connections: Total number of transport connections to use during SnapS...
         - backup_level_enabled: Boolean value indicates whether LEVEL-based incremental b...
         - check_logical: True if extended block checking should be used for this l...
-        - tags: 
-    
+        - tags:
+
     Filter Syntax:
         Operators: EQ, NE, GT, GE, LT, LE, CONTAINS, IN, NOT_IN
         Combine: AND, OR
         Example: "name CONTAINS 'prod' AND status EQ 'RUNNING'"
-    
+
     Example:
         >>> cdb_dsource_tool(action='search', limit=..., cursor=..., sort=..., filter_expression="name CONTAINS 'test'")
-    
+
     ACTION: get
     ----------------------------------------
     Summary: Get a CDB dSource by ID (Oracle only).
     Method: GET
     Endpoint: /cdb-dsources/{cdbDSourceId}
     Required Parameters: cdb_d_source_id
-    
+
     Example:
         >>> cdb_dsource_tool(action='get', cdb_d_source_id='example-cdb_d_source-123')
-    
+
     ACTION: attach_cdb
     ----------------------------------------
     Summary: Attaches an Oracle CDB to an Oracle database.
     Method: POST
     Endpoint: /cdb-dsources/{cdbDSourceId}/attach-cdb
     Required Parameters: cdb_d_source_id, source_id
-    
+
     Example:
         >>> cdb_dsource_tool(action='attach_cdb', cdb_d_source_id='example-cdb_d_source-123', source_id='example-source-123')
-    
+
     ACTION: detach_cdb
     ----------------------------------------
     Summary: Detaches an Oracle CDB from an Oracle database.
     Method: POST
     Endpoint: /cdb-dsources/{cdbDSourceId}/detach-cdb
     Required Parameters: cdb_d_source_id
-    
+
     Example:
         >>> cdb_dsource_tool(action='detach_cdb', cdb_d_source_id='example-cdb_d_source-123')
-    
+
     ACTION: enable
     ----------------------------------------
     Summary: Enable a CDB dSource.
@@ -1553,10 +2141,10 @@ def cdb_dsource_tool(
     Endpoint: /cdb-dsources/{cdbDSourceId}/enable
     Required Parameters: cdb_d_source_id
     Key Parameters (provide as applicable): attempt_start
-    
+
     Example:
         >>> cdb_dsource_tool(action='enable', cdb_d_source_id='example-cdb_d_source-123', attempt_start=...)
-    
+
     ACTION: disable
     ----------------------------------------
     Summary: Disable a CDB dSource.
@@ -1564,10 +2152,10 @@ def cdb_dsource_tool(
     Endpoint: /cdb-dsources/{cdbDSourceId}/disable
     Required Parameters: cdb_d_source_id
     Key Parameters (provide as applicable): attempt_cleanup
-    
+
     Example:
         >>> cdb_dsource_tool(action='disable', cdb_d_source_id='example-cdb_d_source-123', attempt_cleanup=...)
-    
+
     ACTION: delete
     ----------------------------------------
     Summary: Delete a CDB dSource.
@@ -1575,27 +2163,27 @@ def cdb_dsource_tool(
     Endpoint: /cdb-dsources/{cdbDSourceId}/delete
     Required Parameters: cdb_d_source_id
     Key Parameters (provide as applicable): force, delete_all_dependent_datasets
-    
+
     Example:
         >>> cdb_dsource_tool(action='delete', cdb_d_source_id='example-cdb_d_source-123', force=..., delete_all_dependent_datasets=...)
-    
+
     ACTION: upgrade
     ----------------------------------------
     Summary: Upgrade Oracle CDB dSource
     Method: POST
     Endpoint: /cdb-dsources/{cdbDSourceId}/upgrade
     Required Parameters: cdb_d_source_id, repository_id, environment_user_id
-    
+
     Example:
         >>> cdb_dsource_tool(action='upgrade', cdb_d_source_id='example-cdb_d_source-123', repository_id='example-repository-123', environment_user_id='example-environment_user-123')
-    
+
     ======================================================================
     PARAMETERS
     ======================================================================
-    
+
     Args:
         action (str): The operation to perform. One of: list, search, get, attach_cdb, detach_cdb, enable, disable, delete, upgrade
-    
+
       -- General parameters (all database types) --
         attempt_cleanup (bool): Whether to attempt a cleanup of the CDB before the disable. (Default: True)
             [Optional for all actions]
@@ -1651,99 +2239,240 @@ def cdb_dsource_tool(
             [Required for: list, search]
         source_id (str): Id of the source to attach.
             [Required for: attach_cdb]
-    
+
     Returns:
         Dict[str, Any]: The API response containing operation results
-    
+
     Raises:
         Returns error dict if required parameters are missing for the action
     """
     # Route to appropriate API based on action
-    if action == 'list':
+    if action == "list":
         params = build_params(limit=limit, cursor=cursor, sort=sort)
-        conf = check_confirmation('GET', '/cdb-dsources', action, 'cdb_dsource_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            "/cdb-dsources",
+            action,
+            "cdb_dsource_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', '/cdb-dsources', params=params)
-    elif action == 'search':
+        return make_api_request("GET", "/cdb-dsources", params=params)
+    elif action == "search":
         params = build_params(limit=limit, cursor=cursor, sort=sort)
-        body = {'filter_expression': filter_expression} if filter_expression else {}
-        conf = check_confirmation('POST', '/cdb-dsources/search', action, 'cdb_dsource_tool', confirmed or False, request_params=params, request_body=body)
+        body = {"filter_expression": filter_expression} if filter_expression else {}
+        conf = check_confirmation(
+            "POST",
+            "/cdb-dsources/search",
+            action,
+            "cdb_dsource_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', '/cdb-dsources/search', params=params, json_body=body)
-    elif action == 'get':
+        return make_api_request(
+            "POST", "/cdb-dsources/search", params=params, json_body=body
+        )
+    elif action == "get":
         if cdb_d_source_id is None:
-            return {'error': 'Missing required parameter: cdb_d_source_id for action get'}
-        endpoint = f'/cdb-dsources/{cdb_d_source_id}'
+            return {
+                "error": "Missing required parameter: cdb_d_source_id for action get"
+            }
+        endpoint = f"/cdb-dsources/{cdb_d_source_id}"
         params = build_params()
-        conf = check_confirmation('GET', endpoint, action, 'cdb_dsource_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            endpoint,
+            action,
+            "cdb_dsource_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', endpoint, params=params)
-    elif action == 'attach_cdb':
+        return make_api_request("GET", endpoint, params=params)
+    elif action == "attach_cdb":
         if cdb_d_source_id is None:
-            return {'error': 'Missing required parameter: cdb_d_source_id for action attach_cdb'}
-        endpoint = f'/cdb-dsources/{cdb_d_source_id}/attach-cdb'
+            return {
+                "error": "Missing required parameter: cdb_d_source_id for action attach_cdb"
+            }
+        endpoint = f"/cdb-dsources/{cdb_d_source_id}/attach-cdb"
         params = build_params()
-        body = {k: v for k, v in {'backup_level_enabled': backup_level_enabled, 'bandwidth_limit': bandwidth_limit, 'check_logical': check_logical, 'compressed_linking_enabled': compressed_linking_enabled, 'double_sync': double_sync, 'encrypted_linking_enabled': encrypted_linking_enabled, 'environment_user': environment_user, 'external_file_path': external_file_path, 'files_per_set': files_per_set, 'force': force, 'link_now': link_now, 'number_of_connections': number_of_connections, 'operations': operations, 'oracle_fallback_user': oracle_fallback_user, 'oracle_fallback_credentials': oracle_fallback_credentials, 'rman_channels': rman_channels, 'source_id': source_id}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'cdb_dsource_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "backup_level_enabled": backup_level_enabled,
+                "bandwidth_limit": bandwidth_limit,
+                "check_logical": check_logical,
+                "compressed_linking_enabled": compressed_linking_enabled,
+                "double_sync": double_sync,
+                "encrypted_linking_enabled": encrypted_linking_enabled,
+                "environment_user": environment_user,
+                "external_file_path": external_file_path,
+                "files_per_set": files_per_set,
+                "force": force,
+                "link_now": link_now,
+                "number_of_connections": number_of_connections,
+                "operations": operations,
+                "oracle_fallback_user": oracle_fallback_user,
+                "oracle_fallback_credentials": oracle_fallback_credentials,
+                "rman_channels": rman_channels,
+                "source_id": source_id,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "cdb_dsource_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'detach_cdb':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "detach_cdb":
         if cdb_d_source_id is None:
-            return {'error': 'Missing required parameter: cdb_d_source_id for action detach_cdb'}
-        endpoint = f'/cdb-dsources/{cdb_d_source_id}/detach-cdb'
+            return {
+                "error": "Missing required parameter: cdb_d_source_id for action detach_cdb"
+            }
+        endpoint = f"/cdb-dsources/{cdb_d_source_id}/detach-cdb"
         params = build_params()
-        conf = check_confirmation('POST', endpoint, action, 'cdb_dsource_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "cdb_dsource_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params)
-    elif action == 'enable':
+        return make_api_request("POST", endpoint, params=params)
+    elif action == "enable":
         if cdb_d_source_id is None:
-            return {'error': 'Missing required parameter: cdb_d_source_id for action enable'}
-        endpoint = f'/cdb-dsources/{cdb_d_source_id}/enable'
+            return {
+                "error": "Missing required parameter: cdb_d_source_id for action enable"
+            }
+        endpoint = f"/cdb-dsources/{cdb_d_source_id}/enable"
         params = build_params()
-        body = {k: v for k, v in {'attempt_start': attempt_start}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'cdb_dsource_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v for k, v in {"attempt_start": attempt_start}.items() if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "cdb_dsource_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'disable':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "disable":
         if cdb_d_source_id is None:
-            return {'error': 'Missing required parameter: cdb_d_source_id for action disable'}
-        endpoint = f'/cdb-dsources/{cdb_d_source_id}/disable'
+            return {
+                "error": "Missing required parameter: cdb_d_source_id for action disable"
+            }
+        endpoint = f"/cdb-dsources/{cdb_d_source_id}/disable"
         params = build_params()
-        body = {k: v for k, v in {'attempt_cleanup': attempt_cleanup}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'cdb_dsource_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {"attempt_cleanup": attempt_cleanup}.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "cdb_dsource_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'delete':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "delete":
         if cdb_d_source_id is None:
-            return {'error': 'Missing required parameter: cdb_d_source_id for action delete'}
-        endpoint = f'/cdb-dsources/{cdb_d_source_id}/delete'
+            return {
+                "error": "Missing required parameter: cdb_d_source_id for action delete"
+            }
+        endpoint = f"/cdb-dsources/{cdb_d_source_id}/delete"
         params = build_params()
-        body = {k: v for k, v in {'force': force, 'delete_all_dependent_datasets': delete_all_dependent_datasets}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'cdb_dsource_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "force": force,
+                "delete_all_dependent_datasets": delete_all_dependent_datasets,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "cdb_dsource_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'upgrade':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "upgrade":
         if cdb_d_source_id is None:
-            return {'error': 'Missing required parameter: cdb_d_source_id for action upgrade'}
-        endpoint = f'/cdb-dsources/{cdb_d_source_id}/upgrade'
+            return {
+                "error": "Missing required parameter: cdb_d_source_id for action upgrade"
+            }
+        endpoint = f"/cdb-dsources/{cdb_d_source_id}/upgrade"
         params = build_params()
-        if not environment_user_id:
-            environment_user_id = environment_user_ref or environment_user
-        body = {k: v for k, v in {'repository_id': repository_id, 'environment_user_id': environment_user_id}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'cdb_dsource_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "repository_id": repository_id,
+                "environment_user_id": environment_user_id,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "cdb_dsource_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
     else:
-        return {'error': f'Unknown action: {action}. Valid actions: list, search, get, attach_cdb, detach_cdb, enable, disable, delete, upgrade'}
+        return {
+            "error": f"Unknown action: {action}. Valid actions: list, search, get, attach_cdb, detach_cdb, enable, disable, delete, upgrade"
+        }
+
 
 @log_tool_execution
 def group_tool(
@@ -1757,23 +2486,23 @@ def group_tool(
 ) -> Dict[str, Any]:
     """
     Unified tool for GROUP operations.
-    
+
     This tool supports 3 actions: list, search, get
-    
+
     ======================================================================
     ACTION REFERENCE
     ======================================================================
-    
+
     ACTION: list
     ----------------------------------------
     Summary: List all dataset groups.
     Method: GET
     Endpoint: /groups
     Required Parameters: limit, cursor, sort
-    
+
     Example:
         >>> group_tool(action='list', limit=..., cursor=..., sort=...)
-    
+
     ACTION: search
     ----------------------------------------
     Summary: Search for dataset groups.
@@ -1781,7 +2510,7 @@ def group_tool(
     Endpoint: /groups/search
     Required Parameters: limit, cursor, sort
     Key Parameters (provide as applicable): filter_expression
-    
+
     Filterable Fields:
         - id: The dataset group ID.
         - name: The name of this dataset group.
@@ -1791,32 +2520,32 @@ def group_tool(
         - engine_id: Id of the Engine that this dataset group belongs to.
         - engine_name: Name of the Engine that this dataset group belongs to.
         - namespace: The namespace of this dataset group.
-    
+
     Filter Syntax:
         Operators: EQ, NE, GT, GE, LT, LE, CONTAINS, IN, NOT_IN
         Combine: AND, OR
         Example: "name CONTAINS 'prod' AND status EQ 'RUNNING'"
-    
+
     Example:
         >>> group_tool(action='search', limit=..., cursor=..., sort=..., filter_expression="name CONTAINS 'test'")
-    
+
     ACTION: get
     ----------------------------------------
     Summary: Get a dataset group by ID or Name.
     Method: GET
     Endpoint: /groups/{groupId}
     Required Parameters: group_id
-    
+
     Example:
         >>> group_tool(action='get', group_id='example-group-123')
-    
+
     ======================================================================
     PARAMETERS
     ======================================================================
-    
+
     Args:
         action (str): The operation to perform. One of: list, search, get
-    
+
       -- General parameters (all database types) --
         cursor (str): Cursor to fetch the next or previous page of results. The value of this prope...
             [Required for: list, search]
@@ -1828,38 +2557,63 @@ def group_tool(
             [Required for: list, search]
         sort (str): The field to sort results by. A property name with a prepended '-' signifies ...
             [Required for: list, search]
-    
+
     Returns:
         Dict[str, Any]: The API response containing operation results
-    
+
     Raises:
         Returns error dict if required parameters are missing for the action
     """
     # Route to appropriate API based on action
-    if action == 'list':
+    if action == "list":
         params = build_params(limit=limit, cursor=cursor, sort=sort)
-        conf = check_confirmation('GET', '/groups', action, 'group_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            "/groups",
+            action,
+            "group_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', '/groups', params=params)
-    elif action == 'search':
+        return make_api_request("GET", "/groups", params=params)
+    elif action == "search":
         params = build_params(limit=limit, cursor=cursor, sort=sort)
-        body = {'filter_expression': filter_expression} if filter_expression else {}
-        conf = check_confirmation('POST', '/groups/search', action, 'group_tool', confirmed or False, request_params=params, request_body=body)
+        body = {"filter_expression": filter_expression} if filter_expression else {}
+        conf = check_confirmation(
+            "POST",
+            "/groups/search",
+            action,
+            "group_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', '/groups/search', params=params, json_body=body)
-    elif action == 'get':
+        return make_api_request("POST", "/groups/search", params=params, json_body=body)
+    elif action == "get":
         if group_id is None:
-            return {'error': 'Missing required parameter: group_id for action get'}
-        endpoint = f'/groups/{group_id}'
+            return {"error": "Missing required parameter: group_id for action get"}
+        endpoint = f"/groups/{group_id}"
         params = build_params()
-        conf = check_confirmation('GET', endpoint, action, 'group_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            endpoint,
+            action,
+            "group_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', endpoint, params=params)
+        return make_api_request("GET", endpoint, params=params)
     else:
-        return {'error': f'Unknown action: {action}. Valid actions: list, search, get'}
+        return {"error": f"Unknown action: {action}. Valid actions: list, search, get"}
+
 
 @log_tool_execution
 def vault_tool(
@@ -1880,33 +2634,33 @@ def vault_tool(
 ) -> Dict[str, Any]:
     """
     Unified tool for VAULT operations.
-    
+
     This tool supports 11 actions: list_hashicorp_vaults, create_hashicorp_vault, search_hashicorp_vaults, get_hashicorp_vault, delete_hashicorp_vault, get_hashicorp_vault_tags, add_hashicorp_vault_tags, delete_hashicorp_vault_tags, list_kerberos_configs, search_kerberos_configs, get_kerberos_config
-    
+
     ======================================================================
     ACTION REFERENCE
     ======================================================================
-    
+
     ACTION: list_hashicorp_vaults
     ----------------------------------------
     Summary: Returns a list of configured Hashicorp vaults.
     Method: GET
     Endpoint: /management/vaults/hashicorp
     Required Parameters: limit, cursor, sort
-    
+
     Example:
         >>> vault_tool(action='list_hashicorp_vaults', limit=..., cursor=..., sort=...)
-    
+
     ACTION: create_hashicorp_vault
     ----------------------------------------
     Summary: Configure a new Hashicorp Vault
     Method: POST
     Endpoint: /management/vaults/hashicorp
     Key Parameters (provide as applicable): id, env_variables, login_command_args, tags
-    
+
     Example:
         >>> vault_tool(action='create_hashicorp_vault', id=..., env_variables=..., login_command_args=..., tags=...)
-    
+
     ACTION: search_hashicorp_vaults
     ----------------------------------------
     Summary: Search for configured Hashicorp vaults.
@@ -1914,61 +2668,61 @@ def vault_tool(
     Endpoint: /management/vaults/hashicorp/search
     Required Parameters: limit, cursor, sort
     Key Parameters (provide as applicable): filter_expression
-    
+
     Filterable Fields:
-        - id: 
+        - id:
         - env_variables: Environment variables to set when invoking the Vault CLI ...
         - login_command_args: Arguments to the "vault" CLI tool to be used to fetch a c...
-        - tags: 
-    
+        - tags:
+
     Filter Syntax:
         Operators: EQ, NE, GT, GE, LT, LE, CONTAINS, IN, NOT_IN
         Combine: AND, OR
         Example: "name CONTAINS 'prod' AND status EQ 'RUNNING'"
-    
+
     Example:
         >>> vault_tool(action='search_hashicorp_vaults', limit=..., cursor=..., sort=..., filter_expression="name CONTAINS 'test'")
-    
+
     ACTION: get_hashicorp_vault
     ----------------------------------------
     Summary: Get a Hashicorp vault by id
     Method: GET
     Endpoint: /management/vaults/hashicorp/{vaultId}
     Required Parameters: vault_id
-    
+
     Example:
         >>> vault_tool(action='get_hashicorp_vault', vault_id='example-vault-123')
-    
+
     ACTION: delete_hashicorp_vault
     ----------------------------------------
     Summary: Delete a Hashicorp vault by id
     Method: DELETE
     Endpoint: /management/vaults/hashicorp/{vaultId}
     Required Parameters: vault_id
-    
+
     Example:
         >>> vault_tool(action='delete_hashicorp_vault', vault_id='example-vault-123')
-    
+
     ACTION: get_hashicorp_vault_tags
     ----------------------------------------
     Summary: Get tags for a Hashicorp vault.
     Method: GET
     Endpoint: /management/vaults/hashicorp/{vaultId}/tags
     Required Parameters: vault_id
-    
+
     Example:
         >>> vault_tool(action='get_hashicorp_vault_tags', vault_id='example-vault-123')
-    
+
     ACTION: add_hashicorp_vault_tags
     ----------------------------------------
     Summary: Create tags for a Hashicorp vault.
     Method: POST
     Endpoint: /management/vaults/hashicorp/{vaultId}/tags
     Required Parameters: tags, vault_id
-    
+
     Example:
         >>> vault_tool(action='add_hashicorp_vault_tags', tags=..., vault_id='example-vault-123')
-    
+
     ACTION: delete_hashicorp_vault_tags
     ----------------------------------------
     Summary: Delete tags for a Hashicorp vault.
@@ -1976,20 +2730,20 @@ def vault_tool(
     Endpoint: /management/vaults/hashicorp/{vaultId}/tags/delete
     Required Parameters: vault_id
     Key Parameters (provide as applicable): tags, key, value
-    
+
     Example:
         >>> vault_tool(action='delete_hashicorp_vault_tags', tags=..., vault_id='example-vault-123', key=..., value=...)
-    
+
     ACTION: list_kerberos_configs
     ----------------------------------------
     Summary: List all kerberos configs.
     Method: GET
     Endpoint: /kerberos-configs
     Required Parameters: limit, cursor, sort
-    
+
     Example:
         >>> vault_tool(action='list_kerberos_configs', limit=..., cursor=..., sort=...)
-    
+
     ACTION: search_kerberos_configs
     ----------------------------------------
     Summary: Search for Kerberos Configs.
@@ -1997,7 +2751,7 @@ def vault_tool(
     Endpoint: /kerberos-configs/search
     Required Parameters: limit, cursor, sort
     Key Parameters (provide as applicable): filter_expression
-    
+
     Filterable Fields:
         - id: The kerberos config ID.
         - name: The name of the kerberos config object.
@@ -2011,32 +2765,32 @@ def vault_tool(
         - enabled: The kerberos is enabled or not.
         - keytab: Kerberos keytab.
         - kdc_servers: One of more KDC servers.
-    
+
     Filter Syntax:
         Operators: EQ, NE, GT, GE, LT, LE, CONTAINS, IN, NOT_IN
         Combine: AND, OR
         Example: "name CONTAINS 'prod' AND status EQ 'RUNNING'"
-    
+
     Example:
         >>> vault_tool(action='search_kerberos_configs', limit=..., cursor=..., sort=..., filter_expression="name CONTAINS 'test'")
-    
+
     ACTION: get_kerberos_config
     ----------------------------------------
     Summary: Get a kerberos config by ID or Name.
     Method: GET
     Endpoint: /kerberos-configs/{kerberosConfigId}
     Required Parameters: kerberos_config_id
-    
+
     Example:
         >>> vault_tool(action='get_kerberos_config', kerberos_config_id='example-kerberos_config-123')
-    
+
     ======================================================================
     PARAMETERS
     ======================================================================
-    
+
     Args:
         action (str): The operation to perform. One of: list_hashicorp_vaults, create_hashicorp_vault, search_hashicorp_vaults, get_hashicorp_vault, delete_hashicorp_vault, get_hashicorp_vault_tags, add_hashicorp_vault_tags, delete_hashicorp_vault_tags, list_kerberos_configs, search_kerberos_configs, get_kerberos_config
-    
+
       -- General parameters (all database types) --
         cursor (str): Cursor to fetch the next or previous page of results. The value of this prope...
             [Required for: list_hashicorp_vaults, search_hashicorp_vaults, list_kerberos_configs, search_kerberos_configs]
@@ -2062,105 +2816,234 @@ def vault_tool(
             [Optional for all actions]
         vault_id (str): The unique identifier for the vault.
             [Required for: get_hashicorp_vault, delete_hashicorp_vault, get_hashicorp_vault_tags, add_hashicorp_vault_tags, delete_hashicorp_vault_tags]
-    
+
     Returns:
         Dict[str, Any]: The API response containing operation results
-    
+
     Raises:
         Returns error dict if required parameters are missing for the action
     """
     # Route to appropriate API based on action
-    if action == 'list_hashicorp_vaults':
+    if action == "list_hashicorp_vaults":
         params = build_params(limit=limit, cursor=cursor, sort=sort)
-        conf = check_confirmation('GET', '/management/vaults/hashicorp', action, 'vault_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            "/management/vaults/hashicorp",
+            action,
+            "vault_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', '/management/vaults/hashicorp', params=params)
-    elif action == 'create_hashicorp_vault':
+        return make_api_request("GET", "/management/vaults/hashicorp", params=params)
+    elif action == "create_hashicorp_vault":
         params = build_params()
-        body = {k: v for k, v in {'id': id, 'env_variables': env_variables, 'login_command_args': login_command_args, 'tags': tags}.items() if v is not None}
-        conf = check_confirmation('POST', '/management/vaults/hashicorp', action, 'vault_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "id": id,
+                "env_variables": env_variables,
+                "login_command_args": login_command_args,
+                "tags": tags,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            "/management/vaults/hashicorp",
+            action,
+            "vault_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', '/management/vaults/hashicorp', params=params, json_body=body if body else None)
-    elif action == 'search_hashicorp_vaults':
+        return make_api_request(
+            "POST",
+            "/management/vaults/hashicorp",
+            params=params,
+            json_body=body if body else None,
+        )
+    elif action == "search_hashicorp_vaults":
         params = build_params(limit=limit, cursor=cursor, sort=sort)
-        body = {'filter_expression': filter_expression} if filter_expression else {}
-        conf = check_confirmation('POST', '/management/vaults/hashicorp/search', action, 'vault_tool', confirmed or False, request_params=params, request_body=body)
+        body = {"filter_expression": filter_expression} if filter_expression else {}
+        conf = check_confirmation(
+            "POST",
+            "/management/vaults/hashicorp/search",
+            action,
+            "vault_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', '/management/vaults/hashicorp/search', params=params, json_body=body)
-    elif action == 'get_hashicorp_vault':
+        return make_api_request(
+            "POST", "/management/vaults/hashicorp/search", params=params, json_body=body
+        )
+    elif action == "get_hashicorp_vault":
         if vault_id is None:
-            return {'error': 'Missing required parameter: vault_id for action get_hashicorp_vault'}
-        endpoint = f'/management/vaults/hashicorp/{vault_id}'
+            return {
+                "error": "Missing required parameter: vault_id for action get_hashicorp_vault"
+            }
+        endpoint = f"/management/vaults/hashicorp/{vault_id}"
         params = build_params()
-        conf = check_confirmation('GET', endpoint, action, 'vault_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            endpoint,
+            action,
+            "vault_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', endpoint, params=params)
-    elif action == 'delete_hashicorp_vault':
+        return make_api_request("GET", endpoint, params=params)
+    elif action == "delete_hashicorp_vault":
         if vault_id is None:
-            return {'error': 'Missing required parameter: vault_id for action delete_hashicorp_vault'}
-        endpoint = f'/management/vaults/hashicorp/{vault_id}'
+            return {
+                "error": "Missing required parameter: vault_id for action delete_hashicorp_vault"
+            }
+        endpoint = f"/management/vaults/hashicorp/{vault_id}"
         params = build_params()
-        conf = check_confirmation('DELETE', endpoint, action, 'vault_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "DELETE",
+            endpoint,
+            action,
+            "vault_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('DELETE', endpoint, params=params)
-    elif action == 'get_hashicorp_vault_tags':
+        return make_api_request("DELETE", endpoint, params=params)
+    elif action == "get_hashicorp_vault_tags":
         if vault_id is None:
-            return {'error': 'Missing required parameter: vault_id for action get_hashicorp_vault_tags'}
-        endpoint = f'/management/vaults/hashicorp/{vault_id}/tags'
+            return {
+                "error": "Missing required parameter: vault_id for action get_hashicorp_vault_tags"
+            }
+        endpoint = f"/management/vaults/hashicorp/{vault_id}/tags"
         params = build_params()
-        conf = check_confirmation('GET', endpoint, action, 'vault_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            endpoint,
+            action,
+            "vault_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', endpoint, params=params)
-    elif action == 'add_hashicorp_vault_tags':
+        return make_api_request("GET", endpoint, params=params)
+    elif action == "add_hashicorp_vault_tags":
         if vault_id is None:
-            return {'error': 'Missing required parameter: vault_id for action add_hashicorp_vault_tags'}
-        endpoint = f'/management/vaults/hashicorp/{vault_id}/tags'
+            return {
+                "error": "Missing required parameter: vault_id for action add_hashicorp_vault_tags"
+            }
+        endpoint = f"/management/vaults/hashicorp/{vault_id}/tags"
         params = build_params(tags=tags)
-        body = {k: v for k, v in {'tags': tags}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'vault_tool', confirmed or False, request_params=params, request_body=body)
+        body = {k: v for k, v in {"tags": tags}.items() if v is not None}
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "vault_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'delete_hashicorp_vault_tags':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "delete_hashicorp_vault_tags":
         if vault_id is None:
-            return {'error': 'Missing required parameter: vault_id for action delete_hashicorp_vault_tags'}
-        endpoint = f'/management/vaults/hashicorp/{vault_id}/tags/delete'
+            return {
+                "error": "Missing required parameter: vault_id for action delete_hashicorp_vault_tags"
+            }
+        endpoint = f"/management/vaults/hashicorp/{vault_id}/tags/delete"
         params = build_params()
-        body = {k: v for k, v in {'key': key, 'value': value, 'tags': tags}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'vault_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {"key": key, "value": value, "tags": tags}.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "vault_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'list_kerberos_configs':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "list_kerberos_configs":
         params = build_params(limit=limit, cursor=cursor, sort=sort)
-        conf = check_confirmation('GET', '/kerberos-configs', action, 'vault_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            "/kerberos-configs",
+            action,
+            "vault_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', '/kerberos-configs', params=params)
-    elif action == 'search_kerberos_configs':
+        return make_api_request("GET", "/kerberos-configs", params=params)
+    elif action == "search_kerberos_configs":
         params = build_params(limit=limit, cursor=cursor, sort=sort)
-        body = {'filter_expression': filter_expression} if filter_expression else {}
-        conf = check_confirmation('POST', '/kerberos-configs/search', action, 'vault_tool', confirmed or False, request_params=params, request_body=body)
+        body = {"filter_expression": filter_expression} if filter_expression else {}
+        conf = check_confirmation(
+            "POST",
+            "/kerberos-configs/search",
+            action,
+            "vault_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', '/kerberos-configs/search', params=params, json_body=body)
-    elif action == 'get_kerberos_config':
+        return make_api_request(
+            "POST", "/kerberos-configs/search", params=params, json_body=body
+        )
+    elif action == "get_kerberos_config":
         if kerberos_config_id is None:
-            return {'error': 'Missing required parameter: kerberos_config_id for action get_kerberos_config'}
-        endpoint = f'/kerberos-configs/{kerberos_config_id}'
+            return {
+                "error": "Missing required parameter: kerberos_config_id for action get_kerberos_config"
+            }
+        endpoint = f"/kerberos-configs/{kerberos_config_id}"
         params = build_params()
-        conf = check_confirmation('GET', endpoint, action, 'vault_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            endpoint,
+            action,
+            "vault_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', endpoint, params=params)
+        return make_api_request("GET", endpoint, params=params)
     else:
-        return {'error': f'Unknown action: {action}. Valid actions: list_hashicorp_vaults, create_hashicorp_vault, search_hashicorp_vaults, get_hashicorp_vault, delete_hashicorp_vault, get_hashicorp_vault_tags, add_hashicorp_vault_tags, delete_hashicorp_vault_tags, list_kerberos_configs, search_kerberos_configs, get_kerberos_config'}
+        return {
+            "error": f"Unknown action: {action}. Valid actions: list_hashicorp_vaults, create_hashicorp_vault, search_hashicorp_vaults, get_hashicorp_vault, delete_hashicorp_vault, get_hashicorp_vault_tags, add_hashicorp_vault_tags, delete_hashicorp_vault_tags, list_kerberos_configs, search_kerberos_configs, get_kerberos_config"
+        }
+
 
 @log_tool_execution
 def diagnostic_tool(
@@ -2223,13 +3106,13 @@ def diagnostic_tool(
 ) -> Dict[str, Any]:
     """
     Unified tool for DIAGNOSTIC operations.
-    
+
     This tool supports 14 actions: check_engine_connectivity, check_database_connectivity, check_netbackup_connectivity, check_commvault_connectivity, test_network_latency, get_network_latency_result, test_network_dsp, get_network_dsp_result, test_network_throughput, get_network_throughput_result, validate_file_mapping_by_snapshot, validate_file_mapping_by_location, validate_file_mapping_by_timestamp, validate_file_mapping_by_bookmark
-    
+
     ======================================================================
     ACTION REFERENCE
     ======================================================================
-    
+
     ACTION: check_engine_connectivity
     ----------------------------------------
     Summary: Checks connectivity between an engine and a remote host machine on a given port.
@@ -2237,10 +3120,10 @@ def diagnostic_tool(
     Endpoint: /connectivity/check
     Required Parameters: engine_id, host, port
     Key Parameters (provide as applicable): use_engine_public_key, os_name, staging_environment, username, password, vault_id, hashicorp_vault_engine, hashicorp_vault_secret_path, hashicorp_vault_username_key, hashicorp_vault_secret_key, azure_vault_name, azure_vault_username_key, azure_vault_secret_key, cyberark_vault_query_string, use_kerberos_authentication
-    
+
     Example:
         >>> diagnostic_tool(action='check_engine_connectivity', engine_id='example-engine-123', use_engine_public_key=..., os_name=..., staging_environment=..., host=..., port=..., username=..., password=..., vault_id='example-vault-123', hashicorp_vault_engine=..., hashicorp_vault_secret_path=..., hashicorp_vault_username_key=..., hashicorp_vault_secret_key=..., azure_vault_name=..., azure_vault_username_key=..., azure_vault_secret_key=..., cyberark_vault_query_string=..., use_kerberos_authentication=...)
-    
+
     ACTION: check_database_connectivity
     ----------------------------------------
     Summary: Tests the validity of the supplied database credentials, returning an error if unable to connect to the database.
@@ -2248,30 +3131,30 @@ def diagnostic_tool(
     Endpoint: /database/connectivity/check
     Required Parameters: credentials_type, source_id
     Key Parameters (provide as applicable): username, password, hashicorp_vault_engine, hashicorp_vault_secret_path, hashicorp_vault_username_key, hashicorp_vault_secret_key, azure_vault_name, azure_vault_username_key, azure_vault_secret_key, cyberark_vault_query_string, vault, environment_id, environment_user
-    
+
     Example:
         >>> diagnostic_tool(action='check_database_connectivity', username=..., password=..., hashicorp_vault_engine=..., hashicorp_vault_secret_path=..., hashicorp_vault_username_key=..., hashicorp_vault_secret_key=..., azure_vault_name=..., azure_vault_username_key=..., azure_vault_secret_key=..., cyberark_vault_query_string=..., credentials_type=..., source_id='example-source-123', vault=..., environment_id='example-environment-123', environment_user=...)
-    
+
     ACTION: check_netbackup_connectivity
     ----------------------------------------
     Summary: Checks whether the specified NetBackup master server and client are able to communicate on the given environment.
     Method: POST
     Endpoint: /netbackup/connectivity/check
     Required Parameters: environment_id, environment_user_id, master_server_name, source_client_name
-    
+
     Example:
         >>> diagnostic_tool(action='check_netbackup_connectivity', environment_id='example-environment-123', environment_user_id='example-environment_user-123', master_server_name=..., source_client_name=...)
-    
+
     ACTION: check_commvault_connectivity
     ----------------------------------------
     Summary: Tests whether the CommServe host is accessible from the given environment and Commvault agent.
     Method: POST
     Endpoint: /commvault/connectivity/check
     Required Parameters: environment_id, environment_user_id, source_client_name, commserve_host_name, staging_client_name
-    
+
     Example:
         >>> diagnostic_tool(action='check_commvault_connectivity', environment_id='example-environment-123', environment_user_id='example-environment_user-123', source_client_name=..., commserve_host_name=..., staging_client_name=...)
-    
+
     ACTION: test_network_latency
     ----------------------------------------
     Summary: Create Latency Network Performance Test
@@ -2279,20 +3162,20 @@ def diagnostic_tool(
     Endpoint: /network-performance/test/latency
     Required Parameters: engine_id, host_id
     Key Parameters (provide as applicable): request_count, request_size
-    
+
     Example:
         >>> diagnostic_tool(action='test_network_latency', engine_id='example-engine-123', host_id='example-host-123', request_count=..., request_size=...)
-    
+
     ACTION: get_network_latency_result
     ----------------------------------------
     Summary: Retrieve Network Latency Test Result
     Method: GET
     Endpoint: /network-performance/test/latency/{jobId}
     Required Parameters: job_id
-    
+
     Example:
         >>> diagnostic_tool(action='get_network_latency_result', job_id='example-job-123')
-    
+
     ACTION: test_network_dsp
     ----------------------------------------
     Summary: Create DSP Network Performance Test
@@ -2300,20 +3183,20 @@ def diagnostic_tool(
     Endpoint: /network-performance/test/dsp
     Required Parameters: engine_id
     Key Parameters (provide as applicable): host_id, direction, num_connections, duration, destination_type, compression, encryption, queue_depth, block_size, send_socket_buffer, receive_socket_buffer, xport_scheduler, target_engine_id, target_engine_address, target_engine_user, target_engine_password
-    
+
     Example:
         >>> diagnostic_tool(action='test_network_dsp', engine_id='example-engine-123', host_id='example-host-123', direction=..., num_connections=..., duration=..., destination_type=..., compression=..., encryption=..., queue_depth=..., block_size=..., send_socket_buffer=..., receive_socket_buffer=..., xport_scheduler=..., target_engine_id='example-target_engine-123', target_engine_address=..., target_engine_user=..., target_engine_password=...)
-    
+
     ACTION: get_network_dsp_result
     ----------------------------------------
     Summary: Retrieve Network DSP Test Result
     Method: GET
     Endpoint: /network-performance/test/dsp/{jobId}
     Required Parameters: job_id
-    
+
     Example:
         >>> diagnostic_tool(action='get_network_dsp_result', job_id='example-job-123')
-    
+
     ACTION: test_network_throughput
     ----------------------------------------
     Summary: Create Throughput Network Performance Test
@@ -2321,20 +3204,20 @@ def diagnostic_tool(
     Endpoint: /network-performance/test/throughput
     Required Parameters: engine_id, host_id
     Key Parameters (provide as applicable): port, direction, num_connections, duration, block_size, send_socket_buffer
-    
+
     Example:
         >>> diagnostic_tool(action='test_network_throughput', engine_id='example-engine-123', port=..., host_id='example-host-123', direction=..., num_connections=..., duration=..., block_size=..., send_socket_buffer=...)
-    
+
     ACTION: get_network_throughput_result
     ----------------------------------------
     Summary: Retrieve Network Throughput Test Result
     Method: GET
     Endpoint: /network-performance/test/throughput/{jobId}
     Required Parameters: job_id
-    
+
     Example:
         >>> diagnostic_tool(action='get_network_throughput_result', job_id='example-job-123')
-    
+
     ACTION: validate_file_mapping_by_snapshot
     ----------------------------------------
     Summary: Validate file mapping using snapshots
@@ -2342,10 +3225,10 @@ def diagnostic_tool(
     Endpoint: /file-mapping/validate-file-mapping-by-snapshot
     Required Parameters: snapshot_ids, file_mapping_rules
     Key Parameters (provide as applicable): file_system_layout
-    
+
     Example:
         >>> diagnostic_tool(action='validate_file_mapping_by_snapshot', snapshot_ids=..., file_mapping_rules=..., file_system_layout=...)
-    
+
     ACTION: validate_file_mapping_by_location
     ----------------------------------------
     Summary: Validate file mapping using location
@@ -2353,10 +3236,10 @@ def diagnostic_tool(
     Endpoint: /file-mapping/validate-file-mapping-by-location
     Required Parameters: file_mapping_rules, source_data_id, locations
     Key Parameters (provide as applicable): file_system_layout
-    
+
     Example:
         >>> diagnostic_tool(action='validate_file_mapping_by_location', file_mapping_rules=..., file_system_layout=..., source_data_id='example-source_data-123', locations=...)
-    
+
     ACTION: validate_file_mapping_by_timestamp
     ----------------------------------------
     Summary: Validate file mapping using timestamp
@@ -2364,10 +3247,10 @@ def diagnostic_tool(
     Endpoint: /file-mapping/validate-file-mapping-by-timestamp
     Required Parameters: file_mapping_rules, source_data_id, timestamps
     Key Parameters (provide as applicable): file_system_layout
-    
+
     Example:
         >>> diagnostic_tool(action='validate_file_mapping_by_timestamp', file_mapping_rules=..., file_system_layout=..., source_data_id='example-source_data-123', timestamps=...)
-    
+
     ACTION: validate_file_mapping_by_bookmark
     ----------------------------------------
     Summary: Validate file mapping using bookmark
@@ -2375,17 +3258,17 @@ def diagnostic_tool(
     Endpoint: /file-mapping/validate-file-mapping-by-bookmark
     Required Parameters: file_mapping_rules, bookmark_ids
     Key Parameters (provide as applicable): file_system_layout
-    
+
     Example:
         >>> diagnostic_tool(action='validate_file_mapping_by_bookmark', file_mapping_rules=..., file_system_layout=..., bookmark_ids=...)
-    
+
     ======================================================================
     PARAMETERS
     ======================================================================
-    
+
     Args:
         action (str): The operation to perform. One of: check_engine_connectivity, check_database_connectivity, check_netbackup_connectivity, check_commvault_connectivity, test_network_latency, get_network_latency_result, test_network_dsp, get_network_dsp_result, test_network_throughput, get_network_throughput_result, validate_file_mapping_by_snapshot, validate_file_mapping_by_location, validate_file_mapping_by_timestamp, validate_file_mapping_by_bookmark
-    
+
       -- General parameters (all database types) --
         azure_vault_name (str): Azure key vault name (ORACLE, ASE and MSSQL_DOMAIN_USER only).
             [Optional for all actions]
@@ -2495,145 +3378,470 @@ def diagnostic_tool(
             [Optional for all actions]
         xport_scheduler (str): The transport scheduler to use. Valid values: ROUND_ROBIN, LEAST_QUEUE. (Defa...
             [Optional for all actions]
-    
+
     Returns:
         Dict[str, Any]: The API response containing operation results
-    
+
     Raises:
         Returns error dict if required parameters are missing for the action
     """
     # Route to appropriate API based on action
-    if action == 'check_engine_connectivity':
+    if action == "check_engine_connectivity":
         params = build_params(host=host, port=port)
-        body = {k: v for k, v in {'engine_id': engine_id, 'use_engine_public_key': use_engine_public_key, 'os_name': os_name, 'staging_environment': staging_environment, 'host': host, 'port': port, 'username': username, 'password': password, 'vault_id': vault_id, 'hashicorp_vault_engine': hashicorp_vault_engine, 'hashicorp_vault_secret_path': hashicorp_vault_secret_path, 'hashicorp_vault_username_key': hashicorp_vault_username_key, 'hashicorp_vault_secret_key': hashicorp_vault_secret_key, 'azure_vault_name': azure_vault_name, 'azure_vault_username_key': azure_vault_username_key, 'azure_vault_secret_key': azure_vault_secret_key, 'cyberark_vault_query_string': cyberark_vault_query_string, 'use_kerberos_authentication': use_kerberos_authentication}.items() if v is not None}
-        conf = check_confirmation('POST', '/connectivity/check', action, 'diagnostic_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "engine_id": engine_id,
+                "use_engine_public_key": use_engine_public_key,
+                "os_name": os_name,
+                "staging_environment": staging_environment,
+                "host": host,
+                "port": port,
+                "username": username,
+                "password": password,
+                "vault_id": vault_id,
+                "hashicorp_vault_engine": hashicorp_vault_engine,
+                "hashicorp_vault_secret_path": hashicorp_vault_secret_path,
+                "hashicorp_vault_username_key": hashicorp_vault_username_key,
+                "hashicorp_vault_secret_key": hashicorp_vault_secret_key,
+                "azure_vault_name": azure_vault_name,
+                "azure_vault_username_key": azure_vault_username_key,
+                "azure_vault_secret_key": azure_vault_secret_key,
+                "cyberark_vault_query_string": cyberark_vault_query_string,
+                "use_kerberos_authentication": use_kerberos_authentication,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            "/connectivity/check",
+            action,
+            "diagnostic_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', '/connectivity/check', params=params, json_body=body if body else None)
-    elif action == 'check_database_connectivity':
+        return make_api_request(
+            "POST",
+            "/connectivity/check",
+            params=params,
+            json_body=body if body else None,
+        )
+    elif action == "check_database_connectivity":
         params = build_params(credentials_type=credentials_type)
-        body = {k: v for k, v in {'credentials_type': credentials_type, 'source_id': source_id, 'username': username, 'password': password, 'vault': vault, 'hashicorp_vault_engine': hashicorp_vault_engine, 'hashicorp_vault_secret_path': hashicorp_vault_secret_path, 'hashicorp_vault_username_key': hashicorp_vault_username_key, 'hashicorp_vault_secret_key': hashicorp_vault_secret_key, 'azure_vault_name': azure_vault_name, 'azure_vault_username_key': azure_vault_username_key, 'azure_vault_secret_key': azure_vault_secret_key, 'cyberark_vault_query_string': cyberark_vault_query_string, 'environment_id': environment_id, 'environment_user': environment_user}.items() if v is not None}
-        conf = check_confirmation('POST', '/database/connectivity/check', action, 'diagnostic_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "credentials_type": credentials_type,
+                "source_id": source_id,
+                "username": username,
+                "password": password,
+                "vault": vault,
+                "hashicorp_vault_engine": hashicorp_vault_engine,
+                "hashicorp_vault_secret_path": hashicorp_vault_secret_path,
+                "hashicorp_vault_username_key": hashicorp_vault_username_key,
+                "hashicorp_vault_secret_key": hashicorp_vault_secret_key,
+                "azure_vault_name": azure_vault_name,
+                "azure_vault_username_key": azure_vault_username_key,
+                "azure_vault_secret_key": azure_vault_secret_key,
+                "cyberark_vault_query_string": cyberark_vault_query_string,
+                "environment_id": environment_id,
+                "environment_user": environment_user,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            "/database/connectivity/check",
+            action,
+            "diagnostic_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', '/database/connectivity/check', params=params, json_body=body if body else None)
-    elif action == 'check_netbackup_connectivity':
-        params = build_params(master_server_name=master_server_name, source_client_name=source_client_name)
-        if not environment_user_id:
-            environment_user_id = environment_user_ref or environment_user
-        body = {k: v for k, v in {'environment_id': environment_id, 'environment_user_id': environment_user_id, 'master_server_name': master_server_name, 'source_client_name': source_client_name}.items() if v is not None}
-        conf = check_confirmation('POST', '/netbackup/connectivity/check', action, 'diagnostic_tool', confirmed or False, request_params=params, request_body=body)
+        return make_api_request(
+            "POST",
+            "/database/connectivity/check",
+            params=params,
+            json_body=body if body else None,
+        )
+    elif action == "check_netbackup_connectivity":
+        params = build_params(
+            master_server_name=master_server_name, source_client_name=source_client_name
+        )
+        body = {
+            k: v
+            for k, v in {
+                "environment_id": environment_id,
+                "environment_user_id": environment_user_id,
+                "master_server_name": master_server_name,
+                "source_client_name": source_client_name,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            "/netbackup/connectivity/check",
+            action,
+            "diagnostic_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', '/netbackup/connectivity/check', params=params, json_body=body if body else None)
-    elif action == 'check_commvault_connectivity':
-        params = build_params(source_client_name=source_client_name, commserve_host_name=commserve_host_name, staging_client_name=staging_client_name)
-        if not environment_user_id:
-            environment_user_id = environment_user_ref or environment_user
-        body = {k: v for k, v in {'environment_id': environment_id, 'environment_user_id': environment_user_id, 'commserve_host_name': commserve_host_name, 'source_client_name': source_client_name, 'staging_client_name': staging_client_name}.items() if v is not None}
-        conf = check_confirmation('POST', '/commvault/connectivity/check', action, 'diagnostic_tool', confirmed or False, request_params=params, request_body=body)
+        return make_api_request(
+            "POST",
+            "/netbackup/connectivity/check",
+            params=params,
+            json_body=body if body else None,
+        )
+    elif action == "check_commvault_connectivity":
+        params = build_params(
+            source_client_name=source_client_name,
+            commserve_host_name=commserve_host_name,
+            staging_client_name=staging_client_name,
+        )
+        body = {
+            k: v
+            for k, v in {
+                "environment_id": environment_id,
+                "environment_user_id": environment_user_id,
+                "commserve_host_name": commserve_host_name,
+                "source_client_name": source_client_name,
+                "staging_client_name": staging_client_name,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            "/commvault/connectivity/check",
+            action,
+            "diagnostic_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', '/commvault/connectivity/check', params=params, json_body=body if body else None)
-    elif action == 'test_network_latency':
+        return make_api_request(
+            "POST",
+            "/commvault/connectivity/check",
+            params=params,
+            json_body=body if body else None,
+        )
+    elif action == "test_network_latency":
         params = build_params()
-        body = {k: v for k, v in {'engine_id': engine_id, 'host_id': host_id, 'request_count': request_count, 'request_size': request_size}.items() if v is not None}
-        conf = check_confirmation('POST', '/network-performance/test/latency', action, 'diagnostic_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "engine_id": engine_id,
+                "host_id": host_id,
+                "request_count": request_count,
+                "request_size": request_size,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            "/network-performance/test/latency",
+            action,
+            "diagnostic_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', '/network-performance/test/latency', params=params, json_body=body if body else None)
-    elif action == 'get_network_latency_result':
+        return make_api_request(
+            "POST",
+            "/network-performance/test/latency",
+            params=params,
+            json_body=body if body else None,
+        )
+    elif action == "get_network_latency_result":
         if job_id is None:
-            return {'error': 'Missing required parameter: job_id for action get_network_latency_result'}
-        endpoint = f'/network-performance/test/latency/{job_id}'
+            return {
+                "error": "Missing required parameter: job_id for action get_network_latency_result"
+            }
+        endpoint = f"/network-performance/test/latency/{job_id}"
         params = build_params()
-        conf = check_confirmation('GET', endpoint, action, 'diagnostic_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            endpoint,
+            action,
+            "diagnostic_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', endpoint, params=params)
-    elif action == 'test_network_dsp':
+        return make_api_request("GET", endpoint, params=params)
+    elif action == "test_network_dsp":
         params = build_params()
-        body = {k: v for k, v in {'engine_id': engine_id, 'host_id': host_id, 'direction': direction, 'num_connections': num_connections, 'duration': duration, 'destination_type': destination_type, 'compression': compression, 'encryption': encryption, 'queue_depth': queue_depth, 'block_size': block_size, 'send_socket_buffer': send_socket_buffer, 'receive_socket_buffer': receive_socket_buffer, 'xport_scheduler': xport_scheduler, 'target_engine_id': target_engine_id, 'target_engine_address': target_engine_address, 'target_engine_user': target_engine_user, 'target_engine_password': target_engine_password}.items() if v is not None}
-        conf = check_confirmation('POST', '/network-performance/test/dsp', action, 'diagnostic_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "engine_id": engine_id,
+                "host_id": host_id,
+                "direction": direction,
+                "num_connections": num_connections,
+                "duration": duration,
+                "destination_type": destination_type,
+                "compression": compression,
+                "encryption": encryption,
+                "queue_depth": queue_depth,
+                "block_size": block_size,
+                "send_socket_buffer": send_socket_buffer,
+                "receive_socket_buffer": receive_socket_buffer,
+                "xport_scheduler": xport_scheduler,
+                "target_engine_id": target_engine_id,
+                "target_engine_address": target_engine_address,
+                "target_engine_user": target_engine_user,
+                "target_engine_password": target_engine_password,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            "/network-performance/test/dsp",
+            action,
+            "diagnostic_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', '/network-performance/test/dsp', params=params, json_body=body if body else None)
-    elif action == 'get_network_dsp_result':
+        return make_api_request(
+            "POST",
+            "/network-performance/test/dsp",
+            params=params,
+            json_body=body if body else None,
+        )
+    elif action == "get_network_dsp_result":
         if job_id is None:
-            return {'error': 'Missing required parameter: job_id for action get_network_dsp_result'}
-        endpoint = f'/network-performance/test/dsp/{job_id}'
+            return {
+                "error": "Missing required parameter: job_id for action get_network_dsp_result"
+            }
+        endpoint = f"/network-performance/test/dsp/{job_id}"
         params = build_params()
-        conf = check_confirmation('GET', endpoint, action, 'diagnostic_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            endpoint,
+            action,
+            "diagnostic_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', endpoint, params=params)
-    elif action == 'test_network_throughput':
+        return make_api_request("GET", endpoint, params=params)
+    elif action == "test_network_throughput":
         params = build_params()
-        body = {k: v for k, v in {'engine_id': engine_id, 'host_id': host_id, 'direction': direction, 'num_connections': num_connections, 'duration': duration, 'port': port, 'block_size': block_size, 'send_socket_buffer': send_socket_buffer}.items() if v is not None}
-        conf = check_confirmation('POST', '/network-performance/test/throughput', action, 'diagnostic_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "engine_id": engine_id,
+                "host_id": host_id,
+                "direction": direction,
+                "num_connections": num_connections,
+                "duration": duration,
+                "port": port,
+                "block_size": block_size,
+                "send_socket_buffer": send_socket_buffer,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            "/network-performance/test/throughput",
+            action,
+            "diagnostic_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', '/network-performance/test/throughput', params=params, json_body=body if body else None)
-    elif action == 'get_network_throughput_result':
+        return make_api_request(
+            "POST",
+            "/network-performance/test/throughput",
+            params=params,
+            json_body=body if body else None,
+        )
+    elif action == "get_network_throughput_result":
         if job_id is None:
-            return {'error': 'Missing required parameter: job_id for action get_network_throughput_result'}
-        endpoint = f'/network-performance/test/throughput/{job_id}'
+            return {
+                "error": "Missing required parameter: job_id for action get_network_throughput_result"
+            }
+        endpoint = f"/network-performance/test/throughput/{job_id}"
         params = build_params()
-        conf = check_confirmation('GET', endpoint, action, 'diagnostic_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            endpoint,
+            action,
+            "diagnostic_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', endpoint, params=params)
-    elif action == 'validate_file_mapping_by_snapshot':
-        params = build_params(snapshot_ids=snapshot_ids, file_mapping_rules=file_mapping_rules)
-        body = {k: v for k, v in {'snapshot_ids': snapshot_ids, 'file_mapping_rules': file_mapping_rules, 'file_system_layout': file_system_layout}.items() if v is not None}
-        conf = check_confirmation('POST', '/file-mapping/validate-file-mapping-by-snapshot', action, 'diagnostic_tool', confirmed or False, request_params=params, request_body=body)
+        return make_api_request("GET", endpoint, params=params)
+    elif action == "validate_file_mapping_by_snapshot":
+        params = build_params(
+            snapshot_ids=snapshot_ids, file_mapping_rules=file_mapping_rules
+        )
+        body = {
+            k: v
+            for k, v in {
+                "snapshot_ids": snapshot_ids,
+                "file_mapping_rules": file_mapping_rules,
+                "file_system_layout": file_system_layout,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            "/file-mapping/validate-file-mapping-by-snapshot",
+            action,
+            "diagnostic_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', '/file-mapping/validate-file-mapping-by-snapshot', params=params, json_body=body if body else None)
-    elif action == 'validate_file_mapping_by_location':
-        params = build_params(file_mapping_rules=file_mapping_rules, locations=locations)
-        body = {k: v for k, v in {'source_data_id': source_data_id, 'locations': locations, 'file_mapping_rules': file_mapping_rules, 'file_system_layout': file_system_layout}.items() if v is not None}
-        conf = check_confirmation('POST', '/file-mapping/validate-file-mapping-by-location', action, 'diagnostic_tool', confirmed or False, request_params=params, request_body=body)
+        return make_api_request(
+            "POST",
+            "/file-mapping/validate-file-mapping-by-snapshot",
+            params=params,
+            json_body=body if body else None,
+        )
+    elif action == "validate_file_mapping_by_location":
+        params = build_params(
+            file_mapping_rules=file_mapping_rules, locations=locations
+        )
+        body = {
+            k: v
+            for k, v in {
+                "source_data_id": source_data_id,
+                "locations": locations,
+                "file_mapping_rules": file_mapping_rules,
+                "file_system_layout": file_system_layout,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            "/file-mapping/validate-file-mapping-by-location",
+            action,
+            "diagnostic_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', '/file-mapping/validate-file-mapping-by-location', params=params, json_body=body if body else None)
-    elif action == 'validate_file_mapping_by_timestamp':
-        params = build_params(file_mapping_rules=file_mapping_rules, timestamps=timestamps)
-        body = {k: v for k, v in {'source_data_id': source_data_id, 'timestamps': timestamps, 'file_mapping_rules': file_mapping_rules, 'file_system_layout': file_system_layout}.items() if v is not None}
-        conf = check_confirmation('POST', '/file-mapping/validate-file-mapping-by-timestamp', action, 'diagnostic_tool', confirmed or False, request_params=params, request_body=body)
+        return make_api_request(
+            "POST",
+            "/file-mapping/validate-file-mapping-by-location",
+            params=params,
+            json_body=body if body else None,
+        )
+    elif action == "validate_file_mapping_by_timestamp":
+        params = build_params(
+            file_mapping_rules=file_mapping_rules, timestamps=timestamps
+        )
+        body = {
+            k: v
+            for k, v in {
+                "source_data_id": source_data_id,
+                "timestamps": timestamps,
+                "file_mapping_rules": file_mapping_rules,
+                "file_system_layout": file_system_layout,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            "/file-mapping/validate-file-mapping-by-timestamp",
+            action,
+            "diagnostic_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', '/file-mapping/validate-file-mapping-by-timestamp', params=params, json_body=body if body else None)
-    elif action == 'validate_file_mapping_by_bookmark':
-        params = build_params(file_mapping_rules=file_mapping_rules, bookmark_ids=bookmark_ids)
-        body = {k: v for k, v in {'bookmark_ids': bookmark_ids, 'file_mapping_rules': file_mapping_rules, 'file_system_layout': file_system_layout}.items() if v is not None}
-        conf = check_confirmation('POST', '/file-mapping/validate-file-mapping-by-bookmark', action, 'diagnostic_tool', confirmed or False, request_params=params, request_body=body)
+        return make_api_request(
+            "POST",
+            "/file-mapping/validate-file-mapping-by-timestamp",
+            params=params,
+            json_body=body if body else None,
+        )
+    elif action == "validate_file_mapping_by_bookmark":
+        params = build_params(
+            file_mapping_rules=file_mapping_rules, bookmark_ids=bookmark_ids
+        )
+        body = {
+            k: v
+            for k, v in {
+                "bookmark_ids": bookmark_ids,
+                "file_mapping_rules": file_mapping_rules,
+                "file_system_layout": file_system_layout,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            "/file-mapping/validate-file-mapping-by-bookmark",
+            action,
+            "diagnostic_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', '/file-mapping/validate-file-mapping-by-bookmark', params=params, json_body=body if body else None)
+        return make_api_request(
+            "POST",
+            "/file-mapping/validate-file-mapping-by-bookmark",
+            params=params,
+            json_body=body if body else None,
+        )
     else:
-        return {'error': f'Unknown action: {action}. Valid actions: check_engine_connectivity, check_database_connectivity, check_netbackup_connectivity, check_commvault_connectivity, test_network_latency, get_network_latency_result, test_network_dsp, get_network_dsp_result, test_network_throughput, get_network_throughput_result, validate_file_mapping_by_snapshot, validate_file_mapping_by_location, validate_file_mapping_by_timestamp, validate_file_mapping_by_bookmark'}
+        return {
+            "error": f"Unknown action: {action}. Valid actions: check_engine_connectivity, check_database_connectivity, check_netbackup_connectivity, check_commvault_connectivity, test_network_latency, get_network_latency_result, test_network_dsp, get_network_dsp_result, test_network_throughput, get_network_throughput_result, validate_file_mapping_by_snapshot, validate_file_mapping_by_location, validate_file_mapping_by_timestamp, validate_file_mapping_by_bookmark"
+        }
 
 
 def register_tools(app, dct_client):
     global client
     client = dct_client
-    logger.info(f'Registering tools for misc_endpoints...')
+    logger.info("Registering tools for misc_endpoints...")
     try:
-        logger.info(f'  Registering tool function: instance_tool')
+        logger.info("  Registering tool function: instance_tool")
         app.add_tool(instance_tool, name="instance_tool")
-        logger.info(f'  Registering tool function: staging_source_tool')
+        logger.info("  Registering tool function: staging_source_tool")
         app.add_tool(staging_source_tool, name="staging_source_tool")
-        logger.info(f'  Registering tool function: staging_cdb_tool')
+        logger.info("  Registering tool function: staging_cdb_tool")
         app.add_tool(staging_cdb_tool, name="staging_cdb_tool")
-        logger.info(f'  Registering tool function: cdb_dsource_tool')
+        logger.info("  Registering tool function: cdb_dsource_tool")
         app.add_tool(cdb_dsource_tool, name="cdb_dsource_tool")
-        logger.info(f'  Registering tool function: group_tool')
+        logger.info("  Registering tool function: group_tool")
         app.add_tool(group_tool, name="group_tool")
-        logger.info(f'  Registering tool function: vault_tool')
+        logger.info("  Registering tool function: vault_tool")
         app.add_tool(vault_tool, name="vault_tool")
-        logger.info(f'  Registering tool function: diagnostic_tool')
+        logger.info("  Registering tool function: diagnostic_tool")
         app.add_tool(diagnostic_tool, name="diagnostic_tool")
     except Exception as e:
-        logger.error(f'Error registering tools for misc_endpoints: {e}')
-    logger.info(f'Tools registration finished for misc_endpoints.')
+        logger.error(f"Error registering tools for misc_endpoints: {e}")
+    logger.info("Tools registration finished for misc_endpoints.")

--- a/src/dct_mcp_server/tools/policy_endpoints_tool.py
+++ b/src/dct_mcp_server/tools/policy_endpoints_tool.py
@@ -1,7 +1,6 @@
-from mcp.server.fastmcp import FastMCP
-from typing import Dict,Any,Optional
+from typing import Dict, Any, Optional
 from dct_mcp_server.core.decorators import log_tool_execution
-from dct_mcp_server.config import get_confirmation_for_operation, requires_confirmation
+from dct_mcp_server.config import get_confirmation_for_operation
 import asyncio
 import logging
 import threading
@@ -29,7 +28,16 @@ logger = logging.getLogger(__name__)
 #       }
 # =============================================================================
 
-def check_confirmation(method: str, api_path: str, action: str, tool_name: str, confirmed: bool = False, request_params: Optional[Dict[str, Any]] = None, request_body: Optional[Dict[str, Any]] = None) -> Optional[Dict[str, Any]]:
+
+def check_confirmation(
+    method: str,
+    api_path: str,
+    action: str,
+    tool_name: str,
+    confirmed: bool = False,
+    request_params: Optional[Dict[str, Any]] = None,
+    request_body: Optional[Dict[str, Any]] = None,
+) -> Optional[Dict[str, Any]]:
     """Check if operation requires confirmation. Returns confirmation response or None if confirmed/not needed."""
     confirmation = get_confirmation_for_operation(method, api_path)
     if confirmation["level"] != "none" and not confirmed:
@@ -41,7 +49,11 @@ def check_confirmation(method: str, api_path: str, action: str, tool_name: str, 
             review.update(request_params)
         if request_body:
             review.update(request_body)
-        is_review_critical = action.startswith("provision_") or action.startswith("dsource_link_") or action == "dsource_create_snapshot"
+        is_review_critical = (
+            action.startswith("provision_")
+            or action.startswith("dsource_link_")
+            or action == "dsource_create_snapshot"
+        )
         instructions = (
             "STOP: You MUST display the confirmation_message to the user and wait for their EXPLICIT "
             "approval before re-calling with confirmed=True. Do NOT proceed without user consent."
@@ -56,7 +68,9 @@ def check_confirmation(method: str, api_path: str, action: str, tool_name: str, 
         return {
             "status": "confirmation_required",
             "confirmation_level": confirmation["level"],
-            "confirmation_message": confirmation.get("message", "Please confirm this operation."),
+            "confirmation_message": confirmation.get(
+                "message", "Please confirm this operation."
+            ),
             "action": action,
             "tool": tool_name,
             "api_path": api_path,
@@ -66,8 +80,10 @@ def check_confirmation(method: str, api_path: str, action: str, tool_name: str, 
         }
     return None
 
+
 def async_to_sync(async_func):
     """Utility decorator to convert async functions to sync with proper event loop handling."""
+
     @wraps(async_func)
     def wrapper(*args, **kwargs):
         try:
@@ -76,12 +92,14 @@ def async_to_sync(async_func):
                 # Create a task and run it synchronously
                 result = None
                 exception = None
+
                 def run_in_thread():
                     nonlocal result, exception
                     try:
                         result = asyncio.run(async_func(*args, **kwargs))
                     except Exception as e:
                         exception = e
+
                 thread = threading.Thread(target=run_in_thread)
                 thread.start()
                 thread.join()
@@ -92,18 +110,28 @@ def async_to_sync(async_func):
                 return loop.run_until_complete(async_func(*args, **kwargs))
         except RuntimeError:
             return asyncio.run(async_func(*args, **kwargs))
+
     return wrapper
 
-def make_api_request(method: str, endpoint: str, params: dict = None, json_body: dict = None):
+
+def make_api_request(
+    method: str, endpoint: str, params: dict = None, json_body: dict = None
+):
     """Utility function to make API requests with consistent parameter handling."""
+
     @async_to_sync
     async def _make_request():
-        return await client.make_request(method, endpoint, params=params or {}, json=json_body)
+        return await client.make_request(
+            method, endpoint, params=params or {}, json=json_body
+        )
+
     return _make_request()
+
 
 def build_params(**kwargs):
     """Build parameters dictionary excluding None and empty string values."""
-    return {k: v for k, v in kwargs.items() if v is not None and v != ''}
+    return {k: v for k, v in kwargs.items() if v is not None and v != ""}
+
 
 @log_tool_execution
 def virtualization_policy_tool(
@@ -138,13 +166,13 @@ def virtualization_policy_tool(
 ) -> Dict[str, Any]:
     """
     Unified tool for VIRTUALIZATION POLICY operations.
-    
+
     This tool supports 11 actions: search, get, create, update, delete, apply, unapply, search_targets, get_tags, add_tags, delete_tags
-    
+
     ======================================================================
     ACTION REFERENCE
     ======================================================================
-    
+
     ACTION: search
     ----------------------------------------
     Summary: Search Virtualization Policies.
@@ -152,21 +180,21 @@ def virtualization_policy_tool(
     Endpoint: /virtualization-policies/search
     Required Parameters: limit, cursor, sort
     Key Parameters (provide as applicable): filter_expression
-    
+
     Filterable Fields:
-        - id: 
-        - name: 
+        - id:
+        - name:
         - dct_managed: Whether this virtualization policy is managed by DCT or b...
         - create_user: The user who created this virtualization policy.
         - create_timestamp: The time this virtualization policy was created.
-        - namespace: 
+        - namespace:
         - namespace_id: The namespace id of this virtualization policy.
         - namespace_name: The namespace name of this virtualization policy.
         - is_replica: Is this a replicated object.
-        - engine_id: 
+        - engine_id:
         - engine_name: The name of the engine the policy belongs to.
-        - policy_type: 
-        - timezone_id: 
+        - policy_type:
+        - timezone_id:
         - default_policy: True if this is the default policy created when the syste...
         - effective_type: Whether this policy has been directly applied or inherite...
         - data_duration: Amount of time to keep source data [Retention Policy].
@@ -180,31 +208,31 @@ def virtualization_policy_tool(
         - day_of_month: Day of month upon which to enforce monthly snapshot reten...
         - num_of_yearly: Number of yearly snapshots to keep [Retention Policy].
         - day_of_year: Day of year upon which to enforce yearly snapshot retenti...
-        - schedules: 
-        - provision_source: 
+        - schedules:
+        - provision_source:
         - size: Size of the quota, in bytes. (QUOTA_POLICY only).
         - tags: The tags that are applied to this VirtualizationPolicy.
         - num_targets: The number of target dSources or VDBs to which this polic...
         - customized: True if this policy is customized specifically for one ob...
-    
+
     Filter Syntax:
         Operators: EQ, NE, GT, GE, LT, LE, CONTAINS, IN, NOT_IN
         Combine: AND, OR
         Example: "name CONTAINS 'prod' AND status EQ 'RUNNING'"
-    
+
     Example:
         >>> virtualization_policy_tool(action='search', limit=..., cursor=..., sort=..., filter_expression="name CONTAINS 'test'")
-    
+
     ACTION: get
     ----------------------------------------
     Summary: Fetch a virtualization policy by Id.
     Method: GET
     Endpoint: /virtualization-policies/{policyId}
     Required Parameters: policy_id
-    
+
     Example:
         >>> virtualization_policy_tool(action='get', policy_id='example-policy-123')
-    
+
     ACTION: create
     ----------------------------------------
     Summary: Create a VirtualizationPolicy.
@@ -212,10 +240,10 @@ def virtualization_policy_tool(
     Endpoint: /virtualization-policies
     Required Parameters: name, policy_type
     Key Parameters (provide as applicable): policy_targets, provision_source, timezone_id, data_duration, data_unit, log_duration, log_unit, num_of_daily, num_of_weekly, day_of_week, num_of_monthly, day_of_month, num_of_yearly, day_of_year, schedules, size, tags
-    
+
     Example:
         >>> virtualization_policy_tool(action='create', name=..., policy_type=..., policy_targets=..., provision_source=..., timezone_id='example-timezone-123', data_duration=..., data_unit=..., log_duration=..., log_unit=..., num_of_daily=..., num_of_weekly=..., day_of_week=..., num_of_monthly=..., day_of_month=..., num_of_yearly=..., day_of_year=..., schedules=..., size=..., tags=...)
-    
+
     ACTION: update
     ----------------------------------------
     Summary: Update a VirtualizationPolicy.
@@ -223,40 +251,40 @@ def virtualization_policy_tool(
     Endpoint: /virtualization-policies/{policyId}
     Required Parameters: policy_id
     Key Parameters (provide as applicable): name, provision_source, timezone_id, data_duration, data_unit, log_duration, log_unit, num_of_daily, num_of_weekly, day_of_week, num_of_monthly, day_of_month, num_of_yearly, day_of_year, schedules, size
-    
+
     Example:
         >>> virtualization_policy_tool(action='update', policy_id='example-policy-123', name=..., provision_source=..., timezone_id='example-timezone-123', data_duration=..., data_unit=..., log_duration=..., log_unit=..., num_of_daily=..., num_of_weekly=..., day_of_week=..., num_of_monthly=..., day_of_month=..., num_of_yearly=..., day_of_year=..., schedules=..., size=...)
-    
+
     ACTION: delete
     ----------------------------------------
     Summary: Delete a VirtualizationPolicy.
     Method: DELETE
     Endpoint: /virtualization-policies/{policyId}
     Required Parameters: policy_id
-    
+
     Example:
         >>> virtualization_policy_tool(action='delete', policy_id='example-policy-123')
-    
+
     ACTION: apply
     ----------------------------------------
     Summary: Apply a virtualization policy to the given list of objects.
     Method: POST
     Endpoint: /virtualization-policies/{policyId}/apply
     Required Parameters: policy_id
-    
+
     Example:
         >>> virtualization_policy_tool(action='apply', policy_id='example-policy-123')
-    
+
     ACTION: unapply
     ----------------------------------------
     Summary: Unapply a virtualization policy to the given list of objects.
     Method: POST
     Endpoint: /virtualization-policies/{policyId}/unapply
     Required Parameters: policy_id
-    
+
     Example:
         >>> virtualization_policy_tool(action='unapply', policy_id='example-policy-123')
-    
+
     ACTION: search_targets
     ----------------------------------------
     Summary: Search Virtualization Policy Target Objects.
@@ -264,44 +292,44 @@ def virtualization_policy_tool(
     Endpoint: /virtualization-policies/targets/search
     Required Parameters: limit, cursor, sort
     Key Parameters (provide as applicable): filter_expression
-    
+
     Filterable Fields:
         - id: A unique ID for this VirtualizationPolicyTarget.
         - policy_id: The DCT ID of the policy.
         - target_id: The DCT ID of the target the policy is applied to.
         - engine_id: The ID of the engine hosting the policy and target.
-        - policy_type: 
-        - target_type: 
+        - policy_type:
+        - target_type:
         - target_name: The name of the target object.
-    
+
     Filter Syntax:
         Operators: EQ, NE, GT, GE, LT, LE, CONTAINS, IN, NOT_IN
         Combine: AND, OR
         Example: "name CONTAINS 'prod' AND status EQ 'RUNNING'"
-    
+
     Example:
         >>> virtualization_policy_tool(action='search_targets', limit=..., cursor=..., sort=..., filter_expression="name CONTAINS 'test'")
-    
+
     ACTION: get_tags
     ----------------------------------------
     Summary: Get tags for a VirtualizationPolicy.
     Method: GET
     Endpoint: /virtualization-policies/{policyId}/tags
     Required Parameters: policy_id
-    
+
     Example:
         >>> virtualization_policy_tool(action='get_tags', policy_id='example-policy-123')
-    
+
     ACTION: add_tags
     ----------------------------------------
     Summary: Create tags for a VirtualizationPolicy.
     Method: POST
     Endpoint: /virtualization-policies/{policyId}/tags
     Required Parameters: policy_id, tags
-    
+
     Example:
         >>> virtualization_policy_tool(action='add_tags', policy_id='example-policy-123', tags=...)
-    
+
     ACTION: delete_tags
     ----------------------------------------
     Summary: Delete tags for a VirtualizationPolicy.
@@ -309,17 +337,17 @@ def virtualization_policy_tool(
     Endpoint: /virtualization-policies/{policyId}/tags/delete
     Required Parameters: policy_id
     Key Parameters (provide as applicable): tags, key, value
-    
+
     Example:
         >>> virtualization_policy_tool(action='delete_tags', policy_id='example-policy-123', tags=..., key=..., value=...)
-    
+
     ======================================================================
     PARAMETERS
     ======================================================================
-    
+
     Args:
         action (str): The operation to perform. One of: search, get, create, update, delete, apply, unapply, search_targets, get_tags, add_tags, delete_tags
-    
+
       -- General parameters (all database types) --
         cursor (str): Cursor to fetch the next or previous page of results. The value of this prope...
             [Required for: search, search_targets]
@@ -373,112 +401,276 @@ def virtualization_policy_tool(
             [Optional for all actions]
         value (str): Value of the tag
             [Optional for all actions]
-    
+
     Returns:
         Dict[str, Any]: The API response containing operation results
-    
+
     Raises:
         Returns error dict if required parameters are missing for the action
     """
     # Route to appropriate API based on action
-    if action == 'search':
+    if action == "search":
         params = build_params(limit=limit, cursor=cursor, sort=sort)
-        body = {'filter_expression': filter_expression} if filter_expression else {}
-        conf = check_confirmation('POST', '/virtualization-policies/search', action, 'virtualization_policy_tool', confirmed or False, request_params=params, request_body=body)
+        body = {"filter_expression": filter_expression} if filter_expression else {}
+        conf = check_confirmation(
+            "POST",
+            "/virtualization-policies/search",
+            action,
+            "virtualization_policy_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', '/virtualization-policies/search', params=params, json_body=body)
-    elif action == 'get':
+        return make_api_request(
+            "POST", "/virtualization-policies/search", params=params, json_body=body
+        )
+    elif action == "get":
         if policy_id is None:
-            return {'error': 'Missing required parameter: policy_id for action get'}
-        endpoint = f'/virtualization-policies/{policy_id}'
+            return {"error": "Missing required parameter: policy_id for action get"}
+        endpoint = f"/virtualization-policies/{policy_id}"
         params = build_params()
-        conf = check_confirmation('GET', endpoint, action, 'virtualization_policy_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            endpoint,
+            action,
+            "virtualization_policy_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', endpoint, params=params)
-    elif action == 'create':
+        return make_api_request("GET", endpoint, params=params)
+    elif action == "create":
         params = build_params(name=name, policy_type=policy_type)
-        body = {k: v for k, v in {'name': name, 'policy_type': policy_type, 'policy_targets': policy_targets, 'provision_source': provision_source, 'timezone_id': timezone_id, 'data_duration': data_duration, 'data_unit': data_unit, 'log_duration': log_duration, 'log_unit': log_unit, 'num_of_daily': num_of_daily, 'num_of_weekly': num_of_weekly, 'day_of_week': day_of_week, 'num_of_monthly': num_of_monthly, 'day_of_month': day_of_month, 'num_of_yearly': num_of_yearly, 'day_of_year': day_of_year, 'schedules': schedules, 'size': size, 'tags': tags}.items() if v is not None}
-        conf = check_confirmation('POST', '/virtualization-policies', action, 'virtualization_policy_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "name": name,
+                "policy_type": policy_type,
+                "policy_targets": policy_targets,
+                "provision_source": provision_source,
+                "timezone_id": timezone_id,
+                "data_duration": data_duration,
+                "data_unit": data_unit,
+                "log_duration": log_duration,
+                "log_unit": log_unit,
+                "num_of_daily": num_of_daily,
+                "num_of_weekly": num_of_weekly,
+                "day_of_week": day_of_week,
+                "num_of_monthly": num_of_monthly,
+                "day_of_month": day_of_month,
+                "num_of_yearly": num_of_yearly,
+                "day_of_year": day_of_year,
+                "schedules": schedules,
+                "size": size,
+                "tags": tags,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            "/virtualization-policies",
+            action,
+            "virtualization_policy_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', '/virtualization-policies', params=params, json_body=body if body else None)
-    elif action == 'update':
+        return make_api_request(
+            "POST",
+            "/virtualization-policies",
+            params=params,
+            json_body=body if body else None,
+        )
+    elif action == "update":
         if policy_id is None:
-            return {'error': 'Missing required parameter: policy_id for action update'}
-        endpoint = f'/virtualization-policies/{policy_id}'
+            return {"error": "Missing required parameter: policy_id for action update"}
+        endpoint = f"/virtualization-policies/{policy_id}"
         params = build_params()
-        body = {k: v for k, v in {'name': name, 'timezone_id': timezone_id, 'data_duration': data_duration, 'data_unit': data_unit, 'log_duration': log_duration, 'log_unit': log_unit, 'num_of_daily': num_of_daily, 'num_of_weekly': num_of_weekly, 'day_of_week': day_of_week, 'num_of_monthly': num_of_monthly, 'day_of_month': day_of_month, 'num_of_yearly': num_of_yearly, 'day_of_year': day_of_year, 'schedules': schedules, 'size': size, 'provision_source': provision_source}.items() if v is not None}
-        conf = check_confirmation('PATCH', endpoint, action, 'virtualization_policy_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "name": name,
+                "timezone_id": timezone_id,
+                "data_duration": data_duration,
+                "data_unit": data_unit,
+                "log_duration": log_duration,
+                "log_unit": log_unit,
+                "num_of_daily": num_of_daily,
+                "num_of_weekly": num_of_weekly,
+                "day_of_week": day_of_week,
+                "num_of_monthly": num_of_monthly,
+                "day_of_month": day_of_month,
+                "num_of_yearly": num_of_yearly,
+                "day_of_year": day_of_year,
+                "schedules": schedules,
+                "size": size,
+                "provision_source": provision_source,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "PATCH",
+            endpoint,
+            action,
+            "virtualization_policy_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('PATCH', endpoint, params=params, json_body=body if body else None)
-    elif action == 'delete':
+        return make_api_request(
+            "PATCH", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "delete":
         if policy_id is None:
-            return {'error': 'Missing required parameter: policy_id for action delete'}
-        endpoint = f'/virtualization-policies/{policy_id}'
+            return {"error": "Missing required parameter: policy_id for action delete"}
+        endpoint = f"/virtualization-policies/{policy_id}"
         params = build_params()
-        conf = check_confirmation('DELETE', endpoint, action, 'virtualization_policy_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "DELETE",
+            endpoint,
+            action,
+            "virtualization_policy_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('DELETE', endpoint, params=params)
-    elif action == 'apply':
+        return make_api_request("DELETE", endpoint, params=params)
+    elif action == "apply":
         if policy_id is None:
-            return {'error': 'Missing required parameter: policy_id for action apply'}
-        endpoint = f'/virtualization-policies/{policy_id}/apply'
+            return {"error": "Missing required parameter: policy_id for action apply"}
+        endpoint = f"/virtualization-policies/{policy_id}/apply"
         params = build_params()
-        conf = check_confirmation('POST', endpoint, action, 'virtualization_policy_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "virtualization_policy_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params)
-    elif action == 'unapply':
+        return make_api_request("POST", endpoint, params=params)
+    elif action == "unapply":
         if policy_id is None:
-            return {'error': 'Missing required parameter: policy_id for action unapply'}
-        endpoint = f'/virtualization-policies/{policy_id}/unapply'
+            return {"error": "Missing required parameter: policy_id for action unapply"}
+        endpoint = f"/virtualization-policies/{policy_id}/unapply"
         params = build_params()
-        conf = check_confirmation('POST', endpoint, action, 'virtualization_policy_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "virtualization_policy_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params)
-    elif action == 'search_targets':
+        return make_api_request("POST", endpoint, params=params)
+    elif action == "search_targets":
         params = build_params(limit=limit, cursor=cursor, sort=sort)
-        body = {'filter_expression': filter_expression} if filter_expression else {}
-        conf = check_confirmation('POST', '/virtualization-policies/targets/search', action, 'virtualization_policy_tool', confirmed or False, request_params=params, request_body=body)
+        body = {"filter_expression": filter_expression} if filter_expression else {}
+        conf = check_confirmation(
+            "POST",
+            "/virtualization-policies/targets/search",
+            action,
+            "virtualization_policy_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', '/virtualization-policies/targets/search', params=params, json_body=body)
-    elif action == 'get_tags':
+        return make_api_request(
+            "POST",
+            "/virtualization-policies/targets/search",
+            params=params,
+            json_body=body,
+        )
+    elif action == "get_tags":
         if policy_id is None:
-            return {'error': 'Missing required parameter: policy_id for action get_tags'}
-        endpoint = f'/virtualization-policies/{policy_id}/tags'
+            return {
+                "error": "Missing required parameter: policy_id for action get_tags"
+            }
+        endpoint = f"/virtualization-policies/{policy_id}/tags"
         params = build_params()
-        conf = check_confirmation('GET', endpoint, action, 'virtualization_policy_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            endpoint,
+            action,
+            "virtualization_policy_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', endpoint, params=params)
-    elif action == 'add_tags':
+        return make_api_request("GET", endpoint, params=params)
+    elif action == "add_tags":
         if policy_id is None:
-            return {'error': 'Missing required parameter: policy_id for action add_tags'}
-        endpoint = f'/virtualization-policies/{policy_id}/tags'
+            return {
+                "error": "Missing required parameter: policy_id for action add_tags"
+            }
+        endpoint = f"/virtualization-policies/{policy_id}/tags"
         params = build_params(tags=tags)
-        body = {k: v for k, v in {'tags': tags}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'virtualization_policy_tool', confirmed or False, request_params=params, request_body=body)
+        body = {k: v for k, v in {"tags": tags}.items() if v is not None}
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "virtualization_policy_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'delete_tags':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "delete_tags":
         if policy_id is None:
-            return {'error': 'Missing required parameter: policy_id for action delete_tags'}
-        endpoint = f'/virtualization-policies/{policy_id}/tags/delete'
+            return {
+                "error": "Missing required parameter: policy_id for action delete_tags"
+            }
+        endpoint = f"/virtualization-policies/{policy_id}/tags/delete"
         params = build_params()
-        body = {k: v for k, v in {'key': key, 'value': value, 'tags': tags}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'virtualization_policy_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {"key": key, "value": value, "tags": tags}.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "virtualization_policy_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
     else:
-        return {'error': f'Unknown action: {action}. Valid actions: search, get, create, update, delete, apply, unapply, search_targets, get_tags, add_tags, delete_tags'}
+        return {
+            "error": f"Unknown action: {action}. Valid actions: search, get, create, update, delete, apply, unapply, search_targets, get_tags, add_tags, delete_tags"
+        }
+
 
 @log_tool_execution
 def replication_tool(
@@ -520,13 +712,13 @@ def replication_tool(
 ) -> Dict[str, Any]:
     """
     Unified tool for REPLICATION operations.
-    
+
     This tool supports 22 actions: search, get, create, update, delete, execute, enable_tag_replication, disable_tag_replication, get_tags, add_tags, delete_tags, list_namespaces, search_namespaces, get_namespace, update_namespace, delete_namespace, failover_namespace, commit_failover_namespace, failback_namespace, discard_namespace, get_heldspace_deletion_dependencies, delete_heldspace
-    
+
     ======================================================================
     ACTION REFERENCE
     ======================================================================
-    
+
     ACTION: search
     ----------------------------------------
     Summary: Search for ReplicationProfiles.
@@ -534,7 +726,7 @@ def replication_tool(
     Endpoint: /replication-profiles/search
     Required Parameters: limit, cursor, sort
     Key Parameters (provide as applicable): filter_expression
-    
+
     Filterable Fields:
         - id: The ReplicationProfile ID.
         - name: The ReplicationProfile name.
@@ -568,25 +760,25 @@ def replication_tool(
         - last_send_timestamp: The timestamp of the last successful offline send operati...
         - last_offline_serialization_point_id: The ID of the last offline serialization point sent. This...
         - last_offline_receive_data_dir: The relative path of the directory containing the most re...
-    
+
     Filter Syntax:
         Operators: EQ, NE, GT, GE, LT, LE, CONTAINS, IN, NOT_IN
         Combine: AND, OR
         Example: "name CONTAINS 'prod' AND status EQ 'RUNNING'"
-    
+
     Example:
         >>> replication_tool(action='search', limit=..., cursor=..., sort=..., filter_expression="name CONTAINS 'test'")
-    
+
     ACTION: get
     ----------------------------------------
     Summary: Get a ReplicationProfile by ID.
     Method: GET
     Endpoint: /replication-profiles/{replicationProfileId}
     Required Parameters: replication_profile_id
-    
+
     Example:
         >>> replication_tool(action='get', replication_profile_id='example-replication_profile-123')
-    
+
     ACTION: create
     ----------------------------------------
     Summary: Create a ReplicationProfile.
@@ -594,10 +786,10 @@ def replication_tool(
     Endpoint: /replication-profiles
     Required Parameters: replication_mode, engine_id
     Key Parameters (provide as applicable): name, target_engine_id, target_host, target_port, nfs_share, offline_send_profile_tag, description, schedule, tags, enable_tag_replication, bandwidth_limit, number_of_connections, encrypted, automatic_replication, use_system_socks_setting, vdb_ids, dsource_ids, cdb_ids, vcdb_ids, group_ids, replicate_entire_engine
-    
+
     Example:
         >>> replication_tool(action='create', name=..., replication_mode=..., engine_id='example-engine-123', target_engine_id='example-target_engine-123', target_host=..., target_port=..., nfs_share=..., offline_send_profile_tag=..., description=..., schedule=..., tags=..., enable_tag_replication=..., bandwidth_limit=..., number_of_connections=..., encrypted=..., automatic_replication=..., use_system_socks_setting=..., vdb_ids=..., dsource_ids=..., cdb_ids=..., vcdb_ids=..., group_ids=..., replicate_entire_engine=...)
-    
+
     ACTION: update
     ----------------------------------------
     Summary: Update a ReplicationProfile.
@@ -605,70 +797,70 @@ def replication_tool(
     Endpoint: /replication-profiles/{replicationProfileId}
     Required Parameters: replication_profile_id
     Key Parameters (provide as applicable): name, replication_mode, target_engine_id, target_host, target_port, nfs_share, description, schedule, enable_tag_replication, bandwidth_limit, number_of_connections, encrypted, automatic_replication, use_system_socks_setting, vdb_ids, dsource_ids, cdb_ids, vcdb_ids, group_ids, replicate_entire_engine
-    
+
     Example:
         >>> replication_tool(action='update', replication_profile_id='example-replication_profile-123', name=..., replication_mode=..., target_engine_id='example-target_engine-123', target_host=..., target_port=..., nfs_share=..., description=..., schedule=..., enable_tag_replication=..., bandwidth_limit=..., number_of_connections=..., encrypted=..., automatic_replication=..., use_system_socks_setting=..., vdb_ids=..., dsource_ids=..., cdb_ids=..., vcdb_ids=..., group_ids=..., replicate_entire_engine=...)
-    
+
     ACTION: delete
     ----------------------------------------
     Summary: Delete a ReplicationProfile.
     Method: DELETE
     Endpoint: /replication-profiles/{replicationProfileId}
     Required Parameters: replication_profile_id
-    
+
     Example:
         >>> replication_tool(action='delete', replication_profile_id='example-replication_profile-123')
-    
+
     ACTION: execute
     ----------------------------------------
     Summary: Execute a ReplicationProfile.
     Method: POST
     Endpoint: /replication-profiles/{replicationProfileId}/execute
     Required Parameters: replication_profile_id
-    
+
     Example:
         >>> replication_tool(action='execute', replication_profile_id='example-replication_profile-123')
-    
+
     ACTION: enable_tag_replication
     ----------------------------------------
     Summary: Enable tag replication for given ReplicationProfile.
     Method: POST
     Endpoint: /replication-profiles/{replicationProfileId}/enable-tag-replication
     Required Parameters: replication_profile_id
-    
+
     Example:
         >>> replication_tool(action='enable_tag_replication', replication_profile_id='example-replication_profile-123')
-    
+
     ACTION: disable_tag_replication
     ----------------------------------------
     Summary: Disable tag replication for given ReplicationProfile.
     Method: POST
     Endpoint: /replication-profiles/{replicationProfileId}/disable-tag-replication
     Required Parameters: replication_profile_id
-    
+
     Example:
         >>> replication_tool(action='disable_tag_replication', replication_profile_id='example-replication_profile-123')
-    
+
     ACTION: get_tags
     ----------------------------------------
     Summary: Get tags for a ReplicationProfile.
     Method: GET
     Endpoint: /replication-profiles/{replicationProfileId}/tags
     Required Parameters: replication_profile_id
-    
+
     Example:
         >>> replication_tool(action='get_tags', replication_profile_id='example-replication_profile-123')
-    
+
     ACTION: add_tags
     ----------------------------------------
     Summary: Create tags for a ReplicationProfile.
     Method: POST
     Endpoint: /replication-profiles/{replicationProfileId}/tags
     Required Parameters: replication_profile_id, tags
-    
+
     Example:
         >>> replication_tool(action='add_tags', replication_profile_id='example-replication_profile-123', tags=...)
-    
+
     ACTION: delete_tags
     ----------------------------------------
     Summary: Delete tags for a ReplicationProfile.
@@ -676,20 +868,20 @@ def replication_tool(
     Endpoint: /replication-profiles/{replicationProfileId}/tags/delete
     Required Parameters: replication_profile_id
     Key Parameters (provide as applicable): tags, key, value
-    
+
     Example:
         >>> replication_tool(action='delete_tags', replication_profile_id='example-replication_profile-123', tags=..., key=..., value=...)
-    
+
     ACTION: list_namespaces
     ----------------------------------------
     Summary: List all namespaces.
     Method: GET
     Endpoint: /namespaces
     Required Parameters: limit, cursor, sort
-    
+
     Example:
         >>> replication_tool(action='list_namespaces', limit=..., cursor=..., sort=...)
-    
+
     ACTION: search_namespaces
     ----------------------------------------
     Summary: Search Namespaces.
@@ -697,7 +889,7 @@ def replication_tool(
     Endpoint: /namespaces/search
     Required Parameters: limit, cursor, sort
     Key Parameters (provide as applicable): filter_expression
-    
+
     Filterable Fields:
         - id: The Namespace ID.
         - name: The Namespace name.
@@ -716,25 +908,25 @@ def replication_tool(
         - last_execution_status_timestamp: The timestamp of the last execution status of the Replica...
         - source_engine_id: The ID of the source engine that the ReplicationProfile t...
         - source_engine_name: The name of the source engine that the ReplicationProfile...
-    
+
     Filter Syntax:
         Operators: EQ, NE, GT, GE, LT, LE, CONTAINS, IN, NOT_IN
         Combine: AND, OR
         Example: "name CONTAINS 'prod' AND status EQ 'RUNNING'"
-    
+
     Example:
         >>> replication_tool(action='search_namespaces', limit=..., cursor=..., sort=..., filter_expression="name CONTAINS 'test'")
-    
+
     ACTION: get_namespace
     ----------------------------------------
     Summary: Get a namespace.
     Method: GET
     Endpoint: /namespace/{namespaceId}
     Required Parameters: namespace_id
-    
+
     Example:
         >>> replication_tool(action='get_namespace', namespace_id='example-namespace-123')
-    
+
     ACTION: update_namespace
     ----------------------------------------
     Summary: Update a Namespace.
@@ -742,20 +934,20 @@ def replication_tool(
     Endpoint: /namespace/{namespaceId}
     Required Parameters: namespace_id
     Key Parameters (provide as applicable): name, description
-    
+
     Example:
         >>> replication_tool(action='update_namespace', name=..., description=..., namespace_id='example-namespace-123')
-    
+
     ACTION: delete_namespace
     ----------------------------------------
     Summary: Delete a Namespace.
     Method: DELETE
     Endpoint: /namespace/{namespaceId}
     Required Parameters: namespace_id
-    
+
     Example:
         >>> replication_tool(action='delete_namespace', namespace_id='example-namespace-123')
-    
+
     ACTION: failover_namespace
     ----------------------------------------
     Summary: Initiates failover for the given namespace.
@@ -763,67 +955,67 @@ def replication_tool(
     Endpoint: /namespace/{namespaceId}/failover
     Required Parameters: namespace_id
     Key Parameters (provide as applicable): enable_failback
-    
+
     Example:
         >>> replication_tool(action='failover_namespace', namespace_id='example-namespace-123', enable_failback=...)
-    
+
     ACTION: commit_failover_namespace
     ----------------------------------------
     Summary: Commits the failover of a given namespace and discards the failback state.
     Method: POST
     Endpoint: /namespace/{namespaceId}/commitFailover
     Required Parameters: namespace_id
-    
+
     Example:
         >>> replication_tool(action='commit_failover_namespace', namespace_id='example-namespace-123')
-    
+
     ACTION: failback_namespace
     ----------------------------------------
     Summary: Initiates failback for the given namespace.
     Method: POST
     Endpoint: /namespace/{namespaceId}/failback
     Required Parameters: namespace_id
-    
+
     Example:
         >>> replication_tool(action='failback_namespace', namespace_id='example-namespace-123')
-    
+
     ACTION: discard_namespace
     ----------------------------------------
     Summary: Discards any partial receive state for the given namespace.
     Method: POST
     Endpoint: /namespace/{namespaceId}/discard
     Required Parameters: namespace_id
-    
+
     Example:
         >>> replication_tool(action='discard_namespace', namespace_id='example-namespace-123')
-    
+
     ACTION: get_heldspace_deletion_dependencies
     ----------------------------------------
     Summary: Get heldspace deletion dependencies.
     Method: GET
     Endpoint: /heldspace/{heldspaceId}/deletion-dependencies
     Required Parameters: heldspace_id
-    
+
     Example:
         >>> replication_tool(action='get_heldspace_deletion_dependencies', heldspace_id='example-heldspace-123')
-    
+
     ACTION: delete_heldspace
     ----------------------------------------
     Summary: Delete a HeldSpace.
     Method: POST
     Endpoint: /heldspace/{heldspaceId}/delete
     Required Parameters: heldspace_id
-    
+
     Example:
         >>> replication_tool(action='delete_heldspace', heldspace_id='example-heldspace-123')
-    
+
     ======================================================================
     PARAMETERS
     ======================================================================
-    
+
     Args:
         action (str): The operation to perform. One of: search, get, create, update, delete, execute, enable_tag_replication, disable_tag_replication, get_tags, add_tags, delete_tags, list_namespaces, search_namespaces, get_namespace, update_namespace, delete_namespace, failover_namespace, commit_failover_namespace, failback_namespace, discard_namespace, get_heldspace_deletion_dependencies, delete_heldspace
-    
+
       -- General parameters (all database types) --
         automatic_replication (bool): Indication whether the replication spec schedule is enabled or not. (Default:...
             [Optional for all actions]
@@ -891,221 +1083,523 @@ def replication_tool(
             [Optional for all actions]
         vdb_ids (list): The VDBs that are replicated by this ReplicationProfile. (Pass as JSON array)
             [Optional for all actions]
-    
+
     Returns:
         Dict[str, Any]: The API response containing operation results
-    
+
     Raises:
         Returns error dict if required parameters are missing for the action
     """
     # Route to appropriate API based on action
-    if action == 'search':
+    if action == "search":
         params = build_params(limit=limit, cursor=cursor, sort=sort)
-        body = {'filter_expression': filter_expression} if filter_expression else {}
-        conf = check_confirmation('POST', '/replication-profiles/search', action, 'replication_tool', confirmed or False, request_params=params, request_body=body)
+        body = {"filter_expression": filter_expression} if filter_expression else {}
+        conf = check_confirmation(
+            "POST",
+            "/replication-profiles/search",
+            action,
+            "replication_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', '/replication-profiles/search', params=params, json_body=body)
-    elif action == 'get':
+        return make_api_request(
+            "POST", "/replication-profiles/search", params=params, json_body=body
+        )
+    elif action == "get":
         if replication_profile_id is None:
-            return {'error': 'Missing required parameter: replication_profile_id for action get'}
-        endpoint = f'/replication-profiles/{replication_profile_id}'
+            return {
+                "error": "Missing required parameter: replication_profile_id for action get"
+            }
+        endpoint = f"/replication-profiles/{replication_profile_id}"
         params = build_params()
-        conf = check_confirmation('GET', endpoint, action, 'replication_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            endpoint,
+            action,
+            "replication_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', endpoint, params=params)
-    elif action == 'create':
+        return make_api_request("GET", endpoint, params=params)
+    elif action == "create":
         params = build_params(replication_mode=replication_mode)
-        body = {k: v for k, v in {'name': name, 'replication_mode': replication_mode, 'engine_id': engine_id, 'target_engine_id': target_engine_id, 'target_host': target_host, 'target_port': target_port, 'nfs_share': nfs_share, 'offline_send_profile_tag': offline_send_profile_tag, 'description': description, 'schedule': schedule, 'tags': tags, 'enable_tag_replication': enable_tag_replication, 'bandwidth_limit': bandwidth_limit, 'number_of_connections': number_of_connections, 'encrypted': encrypted, 'automatic_replication': automatic_replication, 'use_system_socks_setting': use_system_socks_setting, 'vdb_ids': vdb_ids, 'dsource_ids': dsource_ids, 'cdb_ids': cdb_ids, 'vcdb_ids': vcdb_ids, 'group_ids': group_ids, 'replicate_entire_engine': replicate_entire_engine}.items() if v is not None}
-        conf = check_confirmation('POST', '/replication-profiles', action, 'replication_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "name": name,
+                "replication_mode": replication_mode,
+                "engine_id": engine_id,
+                "target_engine_id": target_engine_id,
+                "target_host": target_host,
+                "target_port": target_port,
+                "nfs_share": nfs_share,
+                "offline_send_profile_tag": offline_send_profile_tag,
+                "description": description,
+                "schedule": schedule,
+                "tags": tags,
+                "enable_tag_replication": enable_tag_replication,
+                "bandwidth_limit": bandwidth_limit,
+                "number_of_connections": number_of_connections,
+                "encrypted": encrypted,
+                "automatic_replication": automatic_replication,
+                "use_system_socks_setting": use_system_socks_setting,
+                "vdb_ids": vdb_ids,
+                "dsource_ids": dsource_ids,
+                "cdb_ids": cdb_ids,
+                "vcdb_ids": vcdb_ids,
+                "group_ids": group_ids,
+                "replicate_entire_engine": replicate_entire_engine,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            "/replication-profiles",
+            action,
+            "replication_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', '/replication-profiles', params=params, json_body=body if body else None)
-    elif action == 'update':
+        return make_api_request(
+            "POST",
+            "/replication-profiles",
+            params=params,
+            json_body=body if body else None,
+        )
+    elif action == "update":
         if replication_profile_id is None:
-            return {'error': 'Missing required parameter: replication_profile_id for action update'}
-        endpoint = f'/replication-profiles/{replication_profile_id}'
+            return {
+                "error": "Missing required parameter: replication_profile_id for action update"
+            }
+        endpoint = f"/replication-profiles/{replication_profile_id}"
         params = build_params()
-        body = {k: v for k, v in {'name': name, 'description': description, 'target_engine_id': target_engine_id, 'target_host': target_host, 'target_port': target_port, 'nfs_share': nfs_share, 'replication_mode': replication_mode, 'schedule': schedule, 'vdb_ids': vdb_ids, 'dsource_ids': dsource_ids, 'cdb_ids': cdb_ids, 'vcdb_ids': vcdb_ids, 'group_ids': group_ids, 'enable_tag_replication': enable_tag_replication, 'replicate_entire_engine': replicate_entire_engine, 'bandwidth_limit': bandwidth_limit, 'number_of_connections': number_of_connections, 'encrypted': encrypted, 'automatic_replication': automatic_replication, 'use_system_socks_setting': use_system_socks_setting}.items() if v is not None}
-        conf = check_confirmation('PATCH', endpoint, action, 'replication_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "name": name,
+                "description": description,
+                "target_engine_id": target_engine_id,
+                "target_host": target_host,
+                "target_port": target_port,
+                "nfs_share": nfs_share,
+                "replication_mode": replication_mode,
+                "schedule": schedule,
+                "vdb_ids": vdb_ids,
+                "dsource_ids": dsource_ids,
+                "cdb_ids": cdb_ids,
+                "vcdb_ids": vcdb_ids,
+                "group_ids": group_ids,
+                "enable_tag_replication": enable_tag_replication,
+                "replicate_entire_engine": replicate_entire_engine,
+                "bandwidth_limit": bandwidth_limit,
+                "number_of_connections": number_of_connections,
+                "encrypted": encrypted,
+                "automatic_replication": automatic_replication,
+                "use_system_socks_setting": use_system_socks_setting,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "PATCH",
+            endpoint,
+            action,
+            "replication_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('PATCH', endpoint, params=params, json_body=body if body else None)
-    elif action == 'delete':
+        return make_api_request(
+            "PATCH", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "delete":
         if replication_profile_id is None:
-            return {'error': 'Missing required parameter: replication_profile_id for action delete'}
-        endpoint = f'/replication-profiles/{replication_profile_id}'
+            return {
+                "error": "Missing required parameter: replication_profile_id for action delete"
+            }
+        endpoint = f"/replication-profiles/{replication_profile_id}"
         params = build_params()
-        conf = check_confirmation('DELETE', endpoint, action, 'replication_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "DELETE",
+            endpoint,
+            action,
+            "replication_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('DELETE', endpoint, params=params)
-    elif action == 'execute':
+        return make_api_request("DELETE", endpoint, params=params)
+    elif action == "execute":
         if replication_profile_id is None:
-            return {'error': 'Missing required parameter: replication_profile_id for action execute'}
-        endpoint = f'/replication-profiles/{replication_profile_id}/execute'
+            return {
+                "error": "Missing required parameter: replication_profile_id for action execute"
+            }
+        endpoint = f"/replication-profiles/{replication_profile_id}/execute"
         params = build_params()
-        conf = check_confirmation('POST', endpoint, action, 'replication_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "replication_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params)
-    elif action == 'enable_tag_replication':
+        return make_api_request("POST", endpoint, params=params)
+    elif action == "enable_tag_replication":
         if replication_profile_id is None:
-            return {'error': 'Missing required parameter: replication_profile_id for action enable_tag_replication'}
-        endpoint = f'/replication-profiles/{replication_profile_id}/enable-tag-replication'
+            return {
+                "error": "Missing required parameter: replication_profile_id for action enable_tag_replication"
+            }
+        endpoint = (
+            f"/replication-profiles/{replication_profile_id}/enable-tag-replication"
+        )
         params = build_params()
-        conf = check_confirmation('POST', endpoint, action, 'replication_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "replication_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params)
-    elif action == 'disable_tag_replication':
+        return make_api_request("POST", endpoint, params=params)
+    elif action == "disable_tag_replication":
         if replication_profile_id is None:
-            return {'error': 'Missing required parameter: replication_profile_id for action disable_tag_replication'}
-        endpoint = f'/replication-profiles/{replication_profile_id}/disable-tag-replication'
+            return {
+                "error": "Missing required parameter: replication_profile_id for action disable_tag_replication"
+            }
+        endpoint = (
+            f"/replication-profiles/{replication_profile_id}/disable-tag-replication"
+        )
         params = build_params()
-        conf = check_confirmation('POST', endpoint, action, 'replication_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "replication_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params)
-    elif action == 'get_tags':
+        return make_api_request("POST", endpoint, params=params)
+    elif action == "get_tags":
         if replication_profile_id is None:
-            return {'error': 'Missing required parameter: replication_profile_id for action get_tags'}
-        endpoint = f'/replication-profiles/{replication_profile_id}/tags'
+            return {
+                "error": "Missing required parameter: replication_profile_id for action get_tags"
+            }
+        endpoint = f"/replication-profiles/{replication_profile_id}/tags"
         params = build_params()
-        conf = check_confirmation('GET', endpoint, action, 'replication_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            endpoint,
+            action,
+            "replication_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', endpoint, params=params)
-    elif action == 'add_tags':
+        return make_api_request("GET", endpoint, params=params)
+    elif action == "add_tags":
         if replication_profile_id is None:
-            return {'error': 'Missing required parameter: replication_profile_id for action add_tags'}
-        endpoint = f'/replication-profiles/{replication_profile_id}/tags'
+            return {
+                "error": "Missing required parameter: replication_profile_id for action add_tags"
+            }
+        endpoint = f"/replication-profiles/{replication_profile_id}/tags"
         params = build_params(tags=tags)
-        body = {k: v for k, v in {'tags': tags}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'replication_tool', confirmed or False, request_params=params, request_body=body)
+        body = {k: v for k, v in {"tags": tags}.items() if v is not None}
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "replication_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'delete_tags':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "delete_tags":
         if replication_profile_id is None:
-            return {'error': 'Missing required parameter: replication_profile_id for action delete_tags'}
-        endpoint = f'/replication-profiles/{replication_profile_id}/tags/delete'
+            return {
+                "error": "Missing required parameter: replication_profile_id for action delete_tags"
+            }
+        endpoint = f"/replication-profiles/{replication_profile_id}/tags/delete"
         params = build_params()
-        body = {k: v for k, v in {'key': key, 'value': value, 'tags': tags}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'replication_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {"key": key, "value": value, "tags": tags}.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "replication_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'list_namespaces':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "list_namespaces":
         params = build_params(limit=limit, cursor=cursor, sort=sort)
-        conf = check_confirmation('GET', '/namespaces', action, 'replication_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            "/namespaces",
+            action,
+            "replication_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', '/namespaces', params=params)
-    elif action == 'search_namespaces':
+        return make_api_request("GET", "/namespaces", params=params)
+    elif action == "search_namespaces":
         params = build_params(limit=limit, cursor=cursor, sort=sort)
-        body = {'filter_expression': filter_expression} if filter_expression else {}
-        conf = check_confirmation('POST', '/namespaces/search', action, 'replication_tool', confirmed or False, request_params=params, request_body=body)
+        body = {"filter_expression": filter_expression} if filter_expression else {}
+        conf = check_confirmation(
+            "POST",
+            "/namespaces/search",
+            action,
+            "replication_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', '/namespaces/search', params=params, json_body=body)
-    elif action == 'get_namespace':
+        return make_api_request(
+            "POST", "/namespaces/search", params=params, json_body=body
+        )
+    elif action == "get_namespace":
         if namespace_id is None:
-            return {'error': 'Missing required parameter: namespace_id for action get_namespace'}
-        endpoint = f'/namespace/{namespace_id}'
+            return {
+                "error": "Missing required parameter: namespace_id for action get_namespace"
+            }
+        endpoint = f"/namespace/{namespace_id}"
         params = build_params()
-        conf = check_confirmation('GET', endpoint, action, 'replication_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            endpoint,
+            action,
+            "replication_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', endpoint, params=params)
-    elif action == 'update_namespace':
+        return make_api_request("GET", endpoint, params=params)
+    elif action == "update_namespace":
         if namespace_id is None:
-            return {'error': 'Missing required parameter: namespace_id for action update_namespace'}
-        endpoint = f'/namespace/{namespace_id}'
+            return {
+                "error": "Missing required parameter: namespace_id for action update_namespace"
+            }
+        endpoint = f"/namespace/{namespace_id}"
         params = build_params()
-        body = {k: v for k, v in {'name': name, 'description': description}.items() if v is not None}
-        conf = check_confirmation('PATCH', endpoint, action, 'replication_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {"name": name, "description": description}.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "PATCH",
+            endpoint,
+            action,
+            "replication_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('PATCH', endpoint, params=params, json_body=body if body else None)
-    elif action == 'delete_namespace':
+        return make_api_request(
+            "PATCH", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "delete_namespace":
         if namespace_id is None:
-            return {'error': 'Missing required parameter: namespace_id for action delete_namespace'}
-        endpoint = f'/namespace/{namespace_id}'
+            return {
+                "error": "Missing required parameter: namespace_id for action delete_namespace"
+            }
+        endpoint = f"/namespace/{namespace_id}"
         params = build_params()
-        conf = check_confirmation('DELETE', endpoint, action, 'replication_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "DELETE",
+            endpoint,
+            action,
+            "replication_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('DELETE', endpoint, params=params)
-    elif action == 'failover_namespace':
+        return make_api_request("DELETE", endpoint, params=params)
+    elif action == "failover_namespace":
         if namespace_id is None:
-            return {'error': 'Missing required parameter: namespace_id for action failover_namespace'}
-        endpoint = f'/namespace/{namespace_id}/failover'
+            return {
+                "error": "Missing required parameter: namespace_id for action failover_namespace"
+            }
+        endpoint = f"/namespace/{namespace_id}/failover"
         params = build_params()
-        body = {k: v for k, v in {'enable_failback': enable_failback}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'replication_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {"enable_failback": enable_failback}.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "replication_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'commit_failover_namespace':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "commit_failover_namespace":
         if namespace_id is None:
-            return {'error': 'Missing required parameter: namespace_id for action commit_failover_namespace'}
-        endpoint = f'/namespace/{namespace_id}/commitFailover'
+            return {
+                "error": "Missing required parameter: namespace_id for action commit_failover_namespace"
+            }
+        endpoint = f"/namespace/{namespace_id}/commitFailover"
         params = build_params()
-        conf = check_confirmation('POST', endpoint, action, 'replication_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "replication_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params)
-    elif action == 'failback_namespace':
+        return make_api_request("POST", endpoint, params=params)
+    elif action == "failback_namespace":
         if namespace_id is None:
-            return {'error': 'Missing required parameter: namespace_id for action failback_namespace'}
-        endpoint = f'/namespace/{namespace_id}/failback'
+            return {
+                "error": "Missing required parameter: namespace_id for action failback_namespace"
+            }
+        endpoint = f"/namespace/{namespace_id}/failback"
         params = build_params()
-        conf = check_confirmation('POST', endpoint, action, 'replication_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "replication_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params)
-    elif action == 'discard_namespace':
+        return make_api_request("POST", endpoint, params=params)
+    elif action == "discard_namespace":
         if namespace_id is None:
-            return {'error': 'Missing required parameter: namespace_id for action discard_namespace'}
-        endpoint = f'/namespace/{namespace_id}/discard'
+            return {
+                "error": "Missing required parameter: namespace_id for action discard_namespace"
+            }
+        endpoint = f"/namespace/{namespace_id}/discard"
         params = build_params()
-        conf = check_confirmation('POST', endpoint, action, 'replication_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "replication_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params)
-    elif action == 'get_heldspace_deletion_dependencies':
+        return make_api_request("POST", endpoint, params=params)
+    elif action == "get_heldspace_deletion_dependencies":
         if heldspace_id is None:
-            return {'error': 'Missing required parameter: heldspace_id for action get_heldspace_deletion_dependencies'}
-        endpoint = f'/heldspace/{heldspace_id}/deletion-dependencies'
+            return {
+                "error": "Missing required parameter: heldspace_id for action get_heldspace_deletion_dependencies"
+            }
+        endpoint = f"/heldspace/{heldspace_id}/deletion-dependencies"
         params = build_params()
-        conf = check_confirmation('GET', endpoint, action, 'replication_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            endpoint,
+            action,
+            "replication_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', endpoint, params=params)
-    elif action == 'delete_heldspace':
+        return make_api_request("GET", endpoint, params=params)
+    elif action == "delete_heldspace":
         if heldspace_id is None:
-            return {'error': 'Missing required parameter: heldspace_id for action delete_heldspace'}
-        endpoint = f'/heldspace/{heldspace_id}/delete'
+            return {
+                "error": "Missing required parameter: heldspace_id for action delete_heldspace"
+            }
+        endpoint = f"/heldspace/{heldspace_id}/delete"
         params = build_params()
-        conf = check_confirmation('POST', endpoint, action, 'replication_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "replication_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params)
+        return make_api_request("POST", endpoint, params=params)
     else:
-        return {'error': f'Unknown action: {action}. Valid actions: search, get, create, update, delete, execute, enable_tag_replication, disable_tag_replication, get_tags, add_tags, delete_tags, list_namespaces, search_namespaces, get_namespace, update_namespace, delete_namespace, failover_namespace, commit_failover_namespace, failback_namespace, discard_namespace, get_heldspace_deletion_dependencies, delete_heldspace'}
+        return {
+            "error": f"Unknown action: {action}. Valid actions: search, get, create, update, delete, execute, enable_tag_replication, disable_tag_replication, get_tags, add_tags, delete_tags, list_namespaces, search_namespaces, get_namespace, update_namespace, delete_namespace, failover_namespace, commit_failover_namespace, failback_namespace, discard_namespace, get_heldspace_deletion_dependencies, delete_heldspace"
+        }
 
 
 def register_tools(app, dct_client):
     global client
     client = dct_client
-    logger.info(f'Registering tools for policy_endpoints...')
+    logger.info("Registering tools for policy_endpoints...")
     try:
-        logger.info(f'  Registering tool function: virtualization_policy_tool')
+        logger.info("  Registering tool function: virtualization_policy_tool")
         app.add_tool(virtualization_policy_tool, name="virtualization_policy_tool")
-        logger.info(f'  Registering tool function: replication_tool')
+        logger.info("  Registering tool function: replication_tool")
         app.add_tool(replication_tool, name="replication_tool")
     except Exception as e:
-        logger.error(f'Error registering tools for policy_endpoints: {e}')
-    logger.info(f'Tools registration finished for policy_endpoints.')
+        logger.error(f"Error registering tools for policy_endpoints: {e}")
+    logger.info("Tools registration finished for policy_endpoints.")

--- a/src/dct_mcp_server/tools/reports_endpoints_tool.py
+++ b/src/dct_mcp_server/tools/reports_endpoints_tool.py
@@ -1,7 +1,6 @@
-from mcp.server.fastmcp import FastMCP
-from typing import Dict,Any,Optional
+from typing import Dict, Any, Optional
 from dct_mcp_server.core.decorators import log_tool_execution
-from dct_mcp_server.config import get_confirmation_for_operation, requires_confirmation
+from dct_mcp_server.config import get_confirmation_for_operation
 import asyncio
 import logging
 import threading
@@ -29,7 +28,16 @@ logger = logging.getLogger(__name__)
 #       }
 # =============================================================================
 
-def check_confirmation(method: str, api_path: str, action: str, tool_name: str, confirmed: bool = False, request_params: Optional[Dict[str, Any]] = None, request_body: Optional[Dict[str, Any]] = None) -> Optional[Dict[str, Any]]:
+
+def check_confirmation(
+    method: str,
+    api_path: str,
+    action: str,
+    tool_name: str,
+    confirmed: bool = False,
+    request_params: Optional[Dict[str, Any]] = None,
+    request_body: Optional[Dict[str, Any]] = None,
+) -> Optional[Dict[str, Any]]:
     """Check if operation requires confirmation. Returns confirmation response or None if confirmed/not needed."""
     confirmation = get_confirmation_for_operation(method, api_path)
     if confirmation["level"] != "none" and not confirmed:
@@ -41,7 +49,11 @@ def check_confirmation(method: str, api_path: str, action: str, tool_name: str, 
             review.update(request_params)
         if request_body:
             review.update(request_body)
-        is_review_critical = action.startswith("provision_") or action.startswith("dsource_link_") or action == "dsource_create_snapshot"
+        is_review_critical = (
+            action.startswith("provision_")
+            or action.startswith("dsource_link_")
+            or action == "dsource_create_snapshot"
+        )
         instructions = (
             "STOP: You MUST display the confirmation_message to the user and wait for their EXPLICIT "
             "approval before re-calling with confirmed=True. Do NOT proceed without user consent."
@@ -56,7 +68,9 @@ def check_confirmation(method: str, api_path: str, action: str, tool_name: str, 
         return {
             "status": "confirmation_required",
             "confirmation_level": confirmation["level"],
-            "confirmation_message": confirmation.get("message", "Please confirm this operation."),
+            "confirmation_message": confirmation.get(
+                "message", "Please confirm this operation."
+            ),
             "action": action,
             "tool": tool_name,
             "api_path": api_path,
@@ -66,8 +80,10 @@ def check_confirmation(method: str, api_path: str, action: str, tool_name: str, 
         }
     return None
 
+
 def async_to_sync(async_func):
     """Utility decorator to convert async functions to sync with proper event loop handling."""
+
     @wraps(async_func)
     def wrapper(*args, **kwargs):
         try:
@@ -76,12 +92,14 @@ def async_to_sync(async_func):
                 # Create a task and run it synchronously
                 result = None
                 exception = None
+
                 def run_in_thread():
                     nonlocal result, exception
                     try:
                         result = asyncio.run(async_func(*args, **kwargs))
                     except Exception as e:
                         exception = e
+
                 thread = threading.Thread(target=run_in_thread)
                 thread.start()
                 thread.join()
@@ -92,18 +110,28 @@ def async_to_sync(async_func):
                 return loop.run_until_complete(async_func(*args, **kwargs))
         except RuntimeError:
             return asyncio.run(async_func(*args, **kwargs))
+
     return wrapper
 
-def make_api_request(method: str, endpoint: str, params: dict = None, json_body: dict = None):
+
+def make_api_request(
+    method: str, endpoint: str, params: dict = None, json_body: dict = None
+):
     """Utility function to make API requests with consistent parameter handling."""
+
     @async_to_sync
     async def _make_request():
-        return await client.make_request(method, endpoint, params=params or {}, json=json_body)
+        return await client.make_request(
+            method, endpoint, params=params or {}, json=json_body
+        )
+
     return _make_request()
+
 
 def build_params(**kwargs):
     """Build parameters dictionary excluding None and empty string values."""
-    return {k: v for k, v in kwargs.items() if v is not None and v != ''}
+    return {k: v for k, v in kwargs.items() if v is not None and v != ""}
+
 
 @log_tool_execution
 def reporting_tool(
@@ -137,13 +165,13 @@ def reporting_tool(
 ) -> Dict[str, Any]:
     """
     Unified tool for REPORTING operations.
-    
+
     This tool supports 19 actions: search_storage_savings_report, search_vdb_inventory_report, get_dataset_performance_analytics, search_scheduled_reports, get_scheduled_report, create_scheduled_report, delete_scheduled_report, get_license, get_virtualization_jobs_history, search_virtualization_jobs_history, get_virtualization_actions_history, search_virtualization_actions_history, get_virtualization_faults_history, search_virtualization_faults_history, resolve_or_ignore_faults, resolve_all_engine_faults, resolve_fault, get_virtualization_alerts_history, search_virtualization_alerts_history
-    
+
     ======================================================================
     ACTION REFERENCE
     ======================================================================
-    
+
     ACTION: search_storage_savings_report
     ----------------------------------------
     Summary: Search the saving storage summary report for virtualization engines.
@@ -151,7 +179,7 @@ def reporting_tool(
     Endpoint: /reporting/storage-savings-report/search
     Required Parameters: limit, cursor, sort
     Key Parameters (provide as applicable): filter_expression
-    
+
     Filterable Fields:
         - dsource_id: Id of the dSource.
         - dependant_vdbs: The number of VDBs that are dependant on this dSource. Th...
@@ -165,15 +193,15 @@ def reporting_tool(
         - estimated_current_timeflows_savings: The disk space that has been saved by using Delphix virtu...
         - estimated_current_timeflows_savings_perc: The disk space that has been saved by using Delphix virtu...
         - is_replica: Indicates if the dSource is a replica
-    
+
     Filter Syntax:
         Operators: EQ, NE, GT, GE, LT, LE, CONTAINS, IN, NOT_IN
         Combine: AND, OR
         Example: "name CONTAINS 'prod' AND status EQ 'RUNNING'"
-    
+
     Example:
         >>> reporting_tool(action='search_storage_savings_report', limit=..., cursor=..., sort=..., filter_expression="name CONTAINS 'test'")
-    
+
     ACTION: search_vdb_inventory_report
     ----------------------------------------
     Summary: Search the inventory report for virtualization engine VDBs.
@@ -181,7 +209,7 @@ def reporting_tool(
     Endpoint: /reporting/vdb-inventory-report/search
     Required Parameters: limit, cursor, sort
     Key Parameters (provide as applicable): filter_expression
-    
+
     Filterable Fields:
         - vdb_id: The VDB id.
         - engine_name: The name of the engine the VDB belongs to.
@@ -198,25 +226,25 @@ def reporting_tool(
         - enabled: Whether the VDB is enabled
         - status: The runtime status of the VDB. 'Unknown' if all attempts ...
         - storage_size: The actual space used by the VDB, in bytes.
-    
+
     Filter Syntax:
         Operators: EQ, NE, GT, GE, LT, LE, CONTAINS, IN, NOT_IN
         Combine: AND, OR
         Example: "name CONTAINS 'prod' AND status EQ 'RUNNING'"
-    
+
     Example:
         >>> reporting_tool(action='search_vdb_inventory_report', limit=..., cursor=..., sort=..., filter_expression="name CONTAINS 'test'")
-    
+
     ACTION: get_dataset_performance_analytics
     ----------------------------------------
     Summary: Get Dataset Performance analytics
     Method: POST
     Endpoint: /reporting/dataset-performance-analytics
     Required Parameters: dataset_ids, start, end, interval
-    
+
     Example:
         >>> reporting_tool(action='get_dataset_performance_analytics', dataset_ids=..., start=..., end=..., interval=...)
-    
+
     ACTION: search_scheduled_reports
     ----------------------------------------
     Summary: Search for report schedules.
@@ -224,38 +252,38 @@ def reporting_tool(
     Endpoint: /reporting/schedule/search
     Required Parameters: limit, cursor, sort
     Key Parameters (provide as applicable): filter_expression
-    
+
     Filterable Fields:
-        - report_id: 
-        - report_type: 
+        - report_id:
+        - report_type:
         - cron_expression: Standard cron expressions are supported e.g. 0 15 10 L * ...
         - time_zone: Timezones are specified according to the Olson tzinfo dat...
-        - message: 
-        - file_format: 
-        - enabled: 
-        - recipients: 
-        - tags: 
-        - sort_column: 
-        - row_count: 
-    
+        - message:
+        - file_format:
+        - enabled:
+        - recipients:
+        - tags:
+        - sort_column:
+        - row_count:
+
     Filter Syntax:
         Operators: EQ, NE, GT, GE, LT, LE, CONTAINS, IN, NOT_IN
         Combine: AND, OR
         Example: "name CONTAINS 'prod' AND status EQ 'RUNNING'"
-    
+
     Example:
         >>> reporting_tool(action='search_scheduled_reports', limit=..., cursor=..., sort=..., filter_expression="name CONTAINS 'test'")
-    
+
     ACTION: get_scheduled_report
     ----------------------------------------
     Summary: Returns a report schedule by ID.
     Method: GET
     Endpoint: /reporting/schedule/{reportId}
     Required Parameters: report_id
-    
+
     Example:
         >>> reporting_tool(action='get_scheduled_report', report_id='example-report-123')
-    
+
     ACTION: create_scheduled_report
     ----------------------------------------
     Summary: Create a new report schedule.
@@ -263,39 +291,39 @@ def reporting_tool(
     Endpoint: /reporting/schedule
     Required Parameters: report_type, cron_expression, message, file_format, enabled, recipients
     Key Parameters (provide as applicable): time_zone, sort_column, row_count, make_current_account_owner
-    
+
     Example:
         >>> reporting_tool(action='create_scheduled_report', report_type=..., cron_expression=..., time_zone=..., message=..., file_format=..., enabled=..., recipients=..., sort_column=..., row_count=..., make_current_account_owner=...)
-    
+
     ACTION: delete_scheduled_report
     ----------------------------------------
     Summary: Delete report schedule by ID.
     Method: DELETE
     Endpoint: /reporting/schedule/{reportId}
     Required Parameters: report_id
-    
+
     Example:
         >>> reporting_tool(action='delete_scheduled_report', report_id='example-report-123')
-    
+
     ACTION: get_license
     ----------------------------------------
     Summary: Returns the DCT license information.
     Method: GET
     Endpoint: /management/license
-    
+
     Example:
         >>> reporting_tool(action='get_license')
-    
+
     ACTION: get_virtualization_jobs_history
     ----------------------------------------
     Summary: Fetch a list of all virtualization jobs
     Method: GET
     Endpoint: /virtualization-jobs/history
     Required Parameters: limit, cursor, sort, object_id
-    
+
     Example:
         >>> reporting_tool(action='get_virtualization_jobs_history', limit=..., cursor=..., sort=..., object_id='example-object-123')
-    
+
     ACTION: search_virtualization_jobs_history
     ----------------------------------------
     Summary: Search virtualization jobs
@@ -303,16 +331,16 @@ def reporting_tool(
     Endpoint: /virtualization-jobs/history/search
     Required Parameters: limit, cursor, sort
     Key Parameters (provide as applicable): filter_expression
-    
+
     Filterable Fields:
         - engine_job_id: ID of the virtualization engine job.
         - engine_id: ID of the RegisteredEngine.
         - legacy_job_type: Legacy type of the job.
-        - job_type: 
+        - job_type:
         - target_object_id: ID of the target object.
         - legacy_target_object_type: Legacy type of the target object.
-        - target_object_type: 
-        - job_state: 
+        - target_object_type:
+        - job_state:
         - start_time: The time the job started.
         - update_time: The time the job was last updated.
         - suspendable: Indicates whether the job can be suspended.
@@ -323,25 +351,25 @@ def reporting_tool(
         - percent_complete: The percentage of the job that is complete.
         - run_duration: The time this job took to complete in milliseconds.
         - events: The events associated with this job.
-    
+
     Filter Syntax:
         Operators: EQ, NE, GT, GE, LT, LE, CONTAINS, IN, NOT_IN
         Combine: AND, OR
         Example: "name CONTAINS 'prod' AND status EQ 'RUNNING'"
-    
+
     Example:
         >>> reporting_tool(action='search_virtualization_jobs_history', limit=..., cursor=..., sort=..., filter_expression="name CONTAINS 'test'")
-    
+
     ACTION: get_virtualization_actions_history
     ----------------------------------------
     Summary: Fetch a list of all virtualization actions
     Method: GET
     Endpoint: /virtualization-actions/history
     Required Parameters: limit, cursor, sort
-    
+
     Example:
         >>> reporting_tool(action='get_virtualization_actions_history', limit=..., cursor=..., sort=...)
-    
+
     ACTION: search_virtualization_actions_history
     ----------------------------------------
     Summary: Search virtualization actions
@@ -349,7 +377,7 @@ def reporting_tool(
     Endpoint: /virtualization-actions/history/search
     Required Parameters: limit, cursor, sort
     Key Parameters (provide as applicable): filter_expression
-    
+
     Filterable Fields:
         - id: ID of the virtualization engine action.
         - engine_id: ID of the RegisteredEngine.
@@ -369,25 +397,25 @@ def reporting_tool(
         - failure_description: Details of the action failure.
         - failure_action: Action to be taken to resolve the failure.
         - failure_message_code: Message ID associated with the event.
-    
+
     Filter Syntax:
         Operators: EQ, NE, GT, GE, LT, LE, CONTAINS, IN, NOT_IN
         Combine: AND, OR
         Example: "name CONTAINS 'prod' AND status EQ 'RUNNING'"
-    
+
     Example:
         >>> reporting_tool(action='search_virtualization_actions_history', limit=..., cursor=..., sort=..., filter_expression="name CONTAINS 'test'")
-    
+
     ACTION: get_virtualization_faults_history
     ----------------------------------------
     Summary: Fetch a list of all virtualization faults
     Method: GET
     Endpoint: /virtualization-faults/history
     Required Parameters: limit, cursor, sort
-    
+
     Example:
         >>> reporting_tool(action='get_virtualization_faults_history', limit=..., cursor=..., sort=...)
-    
+
     ACTION: search_virtualization_faults_history
     ----------------------------------------
     Summary: Search virtualization faults
@@ -395,7 +423,7 @@ def reporting_tool(
     Endpoint: /virtualization-faults/history/search
     Required Parameters: limit, cursor, sort
     Key Parameters (provide as applicable): filter_expression
-    
+
     Filterable Fields:
         - id: ID of the virtualization engine fault.
         - engine_id: ID of the RegisteredEngine.
@@ -412,35 +440,35 @@ def reporting_tool(
         - date_diagnosed: The date when the fault was diagnosed.
         - date_resolved: The date when the fault was resolved.
         - resolution_comments: A comment that describes the fault resolution.
-    
+
     Filter Syntax:
         Operators: EQ, NE, GT, GE, LT, LE, CONTAINS, IN, NOT_IN
         Combine: AND, OR
         Example: "name CONTAINS 'prod' AND status EQ 'RUNNING'"
-    
+
     Example:
         >>> reporting_tool(action='search_virtualization_faults_history', limit=..., cursor=..., sort=..., filter_expression="name CONTAINS 'test'")
-    
+
     ACTION: resolve_or_ignore_faults
     ----------------------------------------
     Summary: Marks selected faults as resolved or ignored.
     Method: POST
     Endpoint: /virtualization-faults/resolveOrIgnore
     Key Parameters (provide as applicable): engine_id, ignore, fault_ids
-    
+
     Example:
         >>> reporting_tool(action='resolve_or_ignore_faults', engine_id='example-engine-123', ignore=..., fault_ids=...)
-    
+
     ACTION: resolve_all_engine_faults
     ----------------------------------------
     Summary: Marks all active faults of an engine that the user has permissions over as resolved.
     Method: POST
     Endpoint: /virtualization-faults/{engineId}/resolveAll
     Required Parameters: engine_id
-    
+
     Example:
         >>> reporting_tool(action='resolve_all_engine_faults', engine_id='example-engine-123')
-    
+
     ACTION: resolve_fault
     ----------------------------------------
     Summary: Marks the fault as resolved. The Delphix engine will attempt to automatically detect cases where the fault has been resolved; but this is not always possible and may only occur on periodic intervals. In these cases, the user can proactively mark the fault resolved. This does not change the underlying disposition of the fault - if the problem is still present the system may immediately diagnose the same problem again. This should only be used to notify the system of resolution after the underlying problem has been resolved.
@@ -448,20 +476,20 @@ def reporting_tool(
     Endpoint: /virtualization-fault/{faultId}/resolve
     Required Parameters: fault_id
     Key Parameters (provide as applicable): ignore, resolution_comments
-    
+
     Example:
         >>> reporting_tool(action='resolve_fault', ignore=..., fault_id='example-fault-123', resolution_comments=...)
-    
+
     ACTION: get_virtualization_alerts_history
     ----------------------------------------
     Summary: Fetch a list of all virtualization alerts
     Method: GET
     Endpoint: /virtualization-alerts/history
     Required Parameters: limit, cursor, sort
-    
+
     Example:
         >>> reporting_tool(action='get_virtualization_alerts_history', limit=..., cursor=..., sort=...)
-    
+
     ACTION: search_virtualization_alerts_history
     ----------------------------------------
     Summary: Search virtualization alerts
@@ -469,7 +497,7 @@ def reporting_tool(
     Endpoint: /virtualization-alerts/history/search
     Required Parameters: limit, cursor, sort
     Key Parameters (provide as applicable): filter_expression
-    
+
     Filterable Fields:
         - id: ID of the virtualization engine alert.
         - engine_id: ID of the RegisteredEngine.
@@ -484,22 +512,22 @@ def reporting_tool(
         - target_object_type: The type of the target object for the event.
         - target_object_id: The ID of the target object.
         - target_name: The name of the target object.
-    
+
     Filter Syntax:
         Operators: EQ, NE, GT, GE, LT, LE, CONTAINS, IN, NOT_IN
         Combine: AND, OR
         Example: "name CONTAINS 'prod' AND status EQ 'RUNNING'"
-    
+
     Example:
         >>> reporting_tool(action='search_virtualization_alerts_history', limit=..., cursor=..., sort=..., filter_expression="name CONTAINS 'test'")
-    
+
     ======================================================================
     PARAMETERS
     ======================================================================
-    
+
     Args:
         action (str): The operation to perform. One of: search_storage_savings_report, search_vdb_inventory_report, get_dataset_performance_analytics, search_scheduled_reports, get_scheduled_report, create_scheduled_report, delete_scheduled_report, get_license, get_virtualization_jobs_history, search_virtualization_jobs_history, get_virtualization_actions_history, search_virtualization_actions_history, get_virtualization_faults_history, search_virtualization_faults_history, resolve_or_ignore_faults, resolve_all_engine_faults, resolve_fault, get_virtualization_alerts_history, search_virtualization_alerts_history
-    
+
       -- General parameters (all database types) --
         cron_expression (str): Standard cron expressions are supported e.g. 0 15 10 L * ?  - Schedule at 10:...
             [Required for: create_scheduled_report]
@@ -551,162 +579,418 @@ def reporting_tool(
             [Required for: get_dataset_performance_analytics]
         time_zone (str): Timezones are specified according to the Olson tzinfo database - "https://en....
             [Optional for all actions]
-    
+
     Returns:
         Dict[str, Any]: The API response containing operation results
-    
+
     Raises:
         Returns error dict if required parameters are missing for the action
     """
     # Route to appropriate API based on action
-    if action == 'search_storage_savings_report':
+    if action == "search_storage_savings_report":
         params = build_params(limit=limit, cursor=cursor, sort=sort)
-        body = {'filter_expression': filter_expression} if filter_expression else {}
-        conf = check_confirmation('POST', '/reporting/storage-savings-report/search', action, 'reporting_tool', confirmed or False, request_params=params, request_body=body)
+        body = {"filter_expression": filter_expression} if filter_expression else {}
+        conf = check_confirmation(
+            "POST",
+            "/reporting/storage-savings-report/search",
+            action,
+            "reporting_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', '/reporting/storage-savings-report/search', params=params, json_body=body)
-    elif action == 'search_vdb_inventory_report':
+        return make_api_request(
+            "POST",
+            "/reporting/storage-savings-report/search",
+            params=params,
+            json_body=body,
+        )
+    elif action == "search_vdb_inventory_report":
         params = build_params(limit=limit, cursor=cursor, sort=sort)
-        body = {'filter_expression': filter_expression} if filter_expression else {}
-        conf = check_confirmation('POST', '/reporting/vdb-inventory-report/search', action, 'reporting_tool', confirmed or False, request_params=params, request_body=body)
+        body = {"filter_expression": filter_expression} if filter_expression else {}
+        conf = check_confirmation(
+            "POST",
+            "/reporting/vdb-inventory-report/search",
+            action,
+            "reporting_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', '/reporting/vdb-inventory-report/search', params=params, json_body=body)
-    elif action == 'get_dataset_performance_analytics':
-        params = build_params(dataset_ids=dataset_ids, start=start, end=end, interval=interval)
-        body = {k: v for k, v in {'dataset_ids': dataset_ids, 'start': start, 'end': end, 'interval': interval}.items() if v is not None}
-        conf = check_confirmation('POST', '/reporting/dataset-performance-analytics', action, 'reporting_tool', confirmed or False, request_params=params, request_body=body)
+        return make_api_request(
+            "POST",
+            "/reporting/vdb-inventory-report/search",
+            params=params,
+            json_body=body,
+        )
+    elif action == "get_dataset_performance_analytics":
+        params = build_params(
+            dataset_ids=dataset_ids, start=start, end=end, interval=interval
+        )
+        body = {
+            k: v
+            for k, v in {
+                "dataset_ids": dataset_ids,
+                "start": start,
+                "end": end,
+                "interval": interval,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            "/reporting/dataset-performance-analytics",
+            action,
+            "reporting_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', '/reporting/dataset-performance-analytics', params=params, json_body=body if body else None)
-    elif action == 'search_scheduled_reports':
+        return make_api_request(
+            "POST",
+            "/reporting/dataset-performance-analytics",
+            params=params,
+            json_body=body if body else None,
+        )
+    elif action == "search_scheduled_reports":
         params = build_params(limit=limit, cursor=cursor, sort=sort)
-        body = {'filter_expression': filter_expression} if filter_expression else {}
-        conf = check_confirmation('POST', '/reporting/schedule/search', action, 'reporting_tool', confirmed or False, request_params=params, request_body=body)
+        body = {"filter_expression": filter_expression} if filter_expression else {}
+        conf = check_confirmation(
+            "POST",
+            "/reporting/schedule/search",
+            action,
+            "reporting_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', '/reporting/schedule/search', params=params, json_body=body)
-    elif action == 'get_scheduled_report':
+        return make_api_request(
+            "POST", "/reporting/schedule/search", params=params, json_body=body
+        )
+    elif action == "get_scheduled_report":
         if report_id is None:
-            return {'error': 'Missing required parameter: report_id for action get_scheduled_report'}
-        endpoint = f'/reporting/schedule/{report_id}'
+            return {
+                "error": "Missing required parameter: report_id for action get_scheduled_report"
+            }
+        endpoint = f"/reporting/schedule/{report_id}"
         params = build_params()
-        conf = check_confirmation('GET', endpoint, action, 'reporting_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            endpoint,
+            action,
+            "reporting_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', endpoint, params=params)
-    elif action == 'create_scheduled_report':
-        params = build_params(report_type=report_type, cron_expression=cron_expression, message=message, file_format=file_format, enabled=enabled, recipients=recipients)
-        body = {k: v for k, v in {'report_type': report_type, 'cron_expression': cron_expression, 'time_zone': time_zone, 'message': message, 'file_format': file_format, 'enabled': enabled, 'recipients': recipients, 'sort_column': sort_column, 'row_count': row_count, 'make_current_account_owner': make_current_account_owner}.items() if v is not None}
-        conf = check_confirmation('POST', '/reporting/schedule', action, 'reporting_tool', confirmed or False, request_params=params, request_body=body)
+        return make_api_request("GET", endpoint, params=params)
+    elif action == "create_scheduled_report":
+        params = build_params(
+            report_type=report_type,
+            cron_expression=cron_expression,
+            message=message,
+            file_format=file_format,
+            enabled=enabled,
+            recipients=recipients,
+        )
+        body = {
+            k: v
+            for k, v in {
+                "report_type": report_type,
+                "cron_expression": cron_expression,
+                "time_zone": time_zone,
+                "message": message,
+                "file_format": file_format,
+                "enabled": enabled,
+                "recipients": recipients,
+                "sort_column": sort_column,
+                "row_count": row_count,
+                "make_current_account_owner": make_current_account_owner,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            "/reporting/schedule",
+            action,
+            "reporting_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', '/reporting/schedule', params=params, json_body=body if body else None)
-    elif action == 'delete_scheduled_report':
+        return make_api_request(
+            "POST",
+            "/reporting/schedule",
+            params=params,
+            json_body=body if body else None,
+        )
+    elif action == "delete_scheduled_report":
         if report_id is None:
-            return {'error': 'Missing required parameter: report_id for action delete_scheduled_report'}
-        endpoint = f'/reporting/schedule/{report_id}'
+            return {
+                "error": "Missing required parameter: report_id for action delete_scheduled_report"
+            }
+        endpoint = f"/reporting/schedule/{report_id}"
         params = build_params()
-        conf = check_confirmation('DELETE', endpoint, action, 'reporting_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "DELETE",
+            endpoint,
+            action,
+            "reporting_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('DELETE', endpoint, params=params)
-    elif action == 'get_license':
+        return make_api_request("DELETE", endpoint, params=params)
+    elif action == "get_license":
         params = build_params()
-        conf = check_confirmation('GET', '/management/license', action, 'reporting_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            "/management/license",
+            action,
+            "reporting_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', '/management/license', params=params)
-    elif action == 'get_virtualization_jobs_history':
+        return make_api_request("GET", "/management/license", params=params)
+    elif action == "get_virtualization_jobs_history":
         params = build_params(limit=limit, cursor=cursor, sort=sort)
-        conf = check_confirmation('GET', '/virtualization-jobs/history', action, 'reporting_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            "/virtualization-jobs/history",
+            action,
+            "reporting_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', '/virtualization-jobs/history', params=params)
-    elif action == 'search_virtualization_jobs_history':
+        return make_api_request("GET", "/virtualization-jobs/history", params=params)
+    elif action == "search_virtualization_jobs_history":
         params = build_params(limit=limit, cursor=cursor, sort=sort)
-        body = {'filter_expression': filter_expression} if filter_expression else {}
-        conf = check_confirmation('POST', '/virtualization-jobs/history/search', action, 'reporting_tool', confirmed or False, request_params=params, request_body=body)
+        body = {"filter_expression": filter_expression} if filter_expression else {}
+        conf = check_confirmation(
+            "POST",
+            "/virtualization-jobs/history/search",
+            action,
+            "reporting_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', '/virtualization-jobs/history/search', params=params, json_body=body)
-    elif action == 'get_virtualization_actions_history':
+        return make_api_request(
+            "POST", "/virtualization-jobs/history/search", params=params, json_body=body
+        )
+    elif action == "get_virtualization_actions_history":
         params = build_params(limit=limit, cursor=cursor, sort=sort)
-        conf = check_confirmation('GET', '/virtualization-actions/history', action, 'reporting_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            "/virtualization-actions/history",
+            action,
+            "reporting_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', '/virtualization-actions/history', params=params)
-    elif action == 'search_virtualization_actions_history':
+        return make_api_request("GET", "/virtualization-actions/history", params=params)
+    elif action == "search_virtualization_actions_history":
         params = build_params(limit=limit, cursor=cursor, sort=sort)
-        body = {'filter_expression': filter_expression} if filter_expression else {}
-        conf = check_confirmation('POST', '/virtualization-actions/history/search', action, 'reporting_tool', confirmed or False, request_params=params, request_body=body)
+        body = {"filter_expression": filter_expression} if filter_expression else {}
+        conf = check_confirmation(
+            "POST",
+            "/virtualization-actions/history/search",
+            action,
+            "reporting_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', '/virtualization-actions/history/search', params=params, json_body=body)
-    elif action == 'get_virtualization_faults_history':
+        return make_api_request(
+            "POST",
+            "/virtualization-actions/history/search",
+            params=params,
+            json_body=body,
+        )
+    elif action == "get_virtualization_faults_history":
         params = build_params(limit=limit, cursor=cursor, sort=sort)
-        conf = check_confirmation('GET', '/virtualization-faults/history', action, 'reporting_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            "/virtualization-faults/history",
+            action,
+            "reporting_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', '/virtualization-faults/history', params=params)
-    elif action == 'search_virtualization_faults_history':
+        return make_api_request("GET", "/virtualization-faults/history", params=params)
+    elif action == "search_virtualization_faults_history":
         params = build_params(limit=limit, cursor=cursor, sort=sort)
-        body = {'filter_expression': filter_expression} if filter_expression else {}
-        conf = check_confirmation('POST', '/virtualization-faults/history/search', action, 'reporting_tool', confirmed or False, request_params=params, request_body=body)
+        body = {"filter_expression": filter_expression} if filter_expression else {}
+        conf = check_confirmation(
+            "POST",
+            "/virtualization-faults/history/search",
+            action,
+            "reporting_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', '/virtualization-faults/history/search', params=params, json_body=body)
-    elif action == 'resolve_or_ignore_faults':
+        return make_api_request(
+            "POST",
+            "/virtualization-faults/history/search",
+            params=params,
+            json_body=body,
+        )
+    elif action == "resolve_or_ignore_faults":
         params = build_params()
-        body = {k: v for k, v in {'engine_id': engine_id, 'ignore': ignore, 'fault_ids': fault_ids}.items() if v is not None}
-        conf = check_confirmation('POST', '/virtualization-faults/resolveOrIgnore', action, 'reporting_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "engine_id": engine_id,
+                "ignore": ignore,
+                "fault_ids": fault_ids,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            "/virtualization-faults/resolveOrIgnore",
+            action,
+            "reporting_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', '/virtualization-faults/resolveOrIgnore', params=params, json_body=body if body else None)
-    elif action == 'resolve_all_engine_faults':
+        return make_api_request(
+            "POST",
+            "/virtualization-faults/resolveOrIgnore",
+            params=params,
+            json_body=body if body else None,
+        )
+    elif action == "resolve_all_engine_faults":
         if engine_id is None:
-            return {'error': 'Missing required parameter: engine_id for action resolve_all_engine_faults'}
-        endpoint = f'/virtualization-faults/{engine_id}/resolveAll'
+            return {
+                "error": "Missing required parameter: engine_id for action resolve_all_engine_faults"
+            }
+        endpoint = f"/virtualization-faults/{engine_id}/resolveAll"
         params = build_params()
-        conf = check_confirmation('POST', endpoint, action, 'reporting_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "reporting_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params)
-    elif action == 'resolve_fault':
+        return make_api_request("POST", endpoint, params=params)
+    elif action == "resolve_fault":
         if fault_id is None:
-            return {'error': 'Missing required parameter: fault_id for action resolve_fault'}
-        endpoint = f'/virtualization-fault/{fault_id}/resolve'
+            return {
+                "error": "Missing required parameter: fault_id for action resolve_fault"
+            }
+        endpoint = f"/virtualization-fault/{fault_id}/resolve"
         params = build_params()
-        body = {k: v for k, v in {'ignore': ignore, 'resolution_comments': resolution_comments}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'reporting_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "ignore": ignore,
+                "resolution_comments": resolution_comments,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "reporting_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'get_virtualization_alerts_history':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "get_virtualization_alerts_history":
         params = build_params(limit=limit, cursor=cursor, sort=sort)
-        conf = check_confirmation('GET', '/virtualization-alerts/history', action, 'reporting_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            "/virtualization-alerts/history",
+            action,
+            "reporting_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', '/virtualization-alerts/history', params=params)
-    elif action == 'search_virtualization_alerts_history':
+        return make_api_request("GET", "/virtualization-alerts/history", params=params)
+    elif action == "search_virtualization_alerts_history":
         params = build_params(limit=limit, cursor=cursor, sort=sort)
-        body = {'filter_expression': filter_expression} if filter_expression else {}
-        conf = check_confirmation('POST', '/virtualization-alerts/history/search', action, 'reporting_tool', confirmed or False, request_params=params, request_body=body)
+        body = {"filter_expression": filter_expression} if filter_expression else {}
+        conf = check_confirmation(
+            "POST",
+            "/virtualization-alerts/history/search",
+            action,
+            "reporting_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', '/virtualization-alerts/history/search', params=params, json_body=body)
+        return make_api_request(
+            "POST",
+            "/virtualization-alerts/history/search",
+            params=params,
+            json_body=body,
+        )
     else:
-        return {'error': f'Unknown action: {action}. Valid actions: search_storage_savings_report, search_vdb_inventory_report, get_dataset_performance_analytics, search_scheduled_reports, get_scheduled_report, create_scheduled_report, delete_scheduled_report, get_license, get_virtualization_jobs_history, search_virtualization_jobs_history, get_virtualization_actions_history, search_virtualization_actions_history, get_virtualization_faults_history, search_virtualization_faults_history, resolve_or_ignore_faults, resolve_all_engine_faults, resolve_fault, get_virtualization_alerts_history, search_virtualization_alerts_history'}
+        return {
+            "error": f"Unknown action: {action}. Valid actions: search_storage_savings_report, search_vdb_inventory_report, get_dataset_performance_analytics, search_scheduled_reports, get_scheduled_report, create_scheduled_report, delete_scheduled_report, get_license, get_virtualization_jobs_history, search_virtualization_jobs_history, get_virtualization_actions_history, search_virtualization_actions_history, get_virtualization_faults_history, search_virtualization_faults_history, resolve_or_ignore_faults, resolve_all_engine_faults, resolve_fault, get_virtualization_alerts_history, search_virtualization_alerts_history"
+        }
 
 
 def register_tools(app, dct_client):
     global client
     client = dct_client
-    logger.info(f'Registering tools for reports_endpoints...')
+    logger.info("Registering tools for reports_endpoints...")
     try:
-        logger.info(f'  Registering tool function: reporting_tool')
+        logger.info("  Registering tool function: reporting_tool")
         app.add_tool(reporting_tool, name="reporting_tool")
     except Exception as e:
-        logger.error(f'Error registering tools for reports_endpoints: {e}')
-    logger.info(f'Tools registration finished for reports_endpoints.')
+        logger.error(f"Error registering tools for reports_endpoints: {e}")
+    logger.info("Tools registration finished for reports_endpoints.")

--- a/src/dct_mcp_server/tools/template_endpoints_tool.py
+++ b/src/dct_mcp_server/tools/template_endpoints_tool.py
@@ -1,7 +1,6 @@
-from mcp.server.fastmcp import FastMCP
-from typing import Dict,Any,Optional
+from typing import Dict, Any, Optional
 from dct_mcp_server.core.decorators import log_tool_execution
-from dct_mcp_server.config import get_confirmation_for_operation, requires_confirmation
+from dct_mcp_server.config import get_confirmation_for_operation
 import asyncio
 import logging
 import threading
@@ -29,7 +28,16 @@ logger = logging.getLogger(__name__)
 #       }
 # =============================================================================
 
-def check_confirmation(method: str, api_path: str, action: str, tool_name: str, confirmed: bool = False, request_params: Optional[Dict[str, Any]] = None, request_body: Optional[Dict[str, Any]] = None) -> Optional[Dict[str, Any]]:
+
+def check_confirmation(
+    method: str,
+    api_path: str,
+    action: str,
+    tool_name: str,
+    confirmed: bool = False,
+    request_params: Optional[Dict[str, Any]] = None,
+    request_body: Optional[Dict[str, Any]] = None,
+) -> Optional[Dict[str, Any]]:
     """Check if operation requires confirmation. Returns confirmation response or None if confirmed/not needed."""
     confirmation = get_confirmation_for_operation(method, api_path)
     if confirmation["level"] != "none" and not confirmed:
@@ -41,7 +49,11 @@ def check_confirmation(method: str, api_path: str, action: str, tool_name: str, 
             review.update(request_params)
         if request_body:
             review.update(request_body)
-        is_review_critical = action.startswith("provision_") or action.startswith("dsource_link_") or action == "dsource_create_snapshot"
+        is_review_critical = (
+            action.startswith("provision_")
+            or action.startswith("dsource_link_")
+            or action == "dsource_create_snapshot"
+        )
         instructions = (
             "STOP: You MUST display the confirmation_message to the user and wait for their EXPLICIT "
             "approval before re-calling with confirmed=True. Do NOT proceed without user consent."
@@ -56,7 +68,9 @@ def check_confirmation(method: str, api_path: str, action: str, tool_name: str, 
         return {
             "status": "confirmation_required",
             "confirmation_level": confirmation["level"],
-            "confirmation_message": confirmation.get("message", "Please confirm this operation."),
+            "confirmation_message": confirmation.get(
+                "message", "Please confirm this operation."
+            ),
             "action": action,
             "tool": tool_name,
             "api_path": api_path,
@@ -66,8 +80,10 @@ def check_confirmation(method: str, api_path: str, action: str, tool_name: str, 
         }
     return None
 
+
 def async_to_sync(async_func):
     """Utility decorator to convert async functions to sync with proper event loop handling."""
+
     @wraps(async_func)
     def wrapper(*args, **kwargs):
         try:
@@ -76,12 +92,14 @@ def async_to_sync(async_func):
                 # Create a task and run it synchronously
                 result = None
                 exception = None
+
                 def run_in_thread():
                     nonlocal result, exception
                     try:
                         result = asyncio.run(async_func(*args, **kwargs))
                     except Exception as e:
                         exception = e
+
                 thread = threading.Thread(target=run_in_thread)
                 thread.start()
                 thread.join()
@@ -92,18 +110,28 @@ def async_to_sync(async_func):
                 return loop.run_until_complete(async_func(*args, **kwargs))
         except RuntimeError:
             return asyncio.run(async_func(*args, **kwargs))
+
     return wrapper
 
-def make_api_request(method: str, endpoint: str, params: dict = None, json_body: dict = None):
+
+def make_api_request(
+    method: str, endpoint: str, params: dict = None, json_body: dict = None
+):
     """Utility function to make API requests with consistent parameter handling."""
+
     @async_to_sync
     async def _make_request():
-        return await client.make_request(method, endpoint, params=params or {}, json=json_body)
+        return await client.make_request(
+            method, endpoint, params=params or {}, json=json_body
+        )
+
     return _make_request()
+
 
 def build_params(**kwargs):
     """Build parameters dictionary excluding None and empty string values."""
-    return {k: v for k, v in kwargs.items() if v is not None and v != ''}
+    return {k: v for k, v in kwargs.items() if v is not None and v != ""}
+
 
 @log_tool_execution
 def database_template_tool(
@@ -125,13 +153,13 @@ def database_template_tool(
 ) -> Dict[str, Any]:
     """
     Unified tool for DATABASE TEMPLATE operations.
-    
+
     This tool supports 8 actions: search, get, create, update, delete, get_tags, add_tags, delete_tags
-    
+
     ======================================================================
     ACTION REFERENCE
     ======================================================================
-    
+
     ACTION: search
     ----------------------------------------
     Summary: Search DatabaseTemplates.
@@ -139,33 +167,33 @@ def database_template_tool(
     Endpoint: /database-templates/search
     Required Parameters: limit, cursor, sort
     Key Parameters (provide as applicable): filter_expression
-    
+
     Filterable Fields:
         - id: The DatabaseTemplate entity ID.
         - name: The DatabaseTemplate name.
         - description: User provided description for this template.
         - source_type: The type of the source associated with the template.
         - parameters: A name/value map of string configuration parameters.
-        - tags: 
-    
+        - tags:
+
     Filter Syntax:
         Operators: EQ, NE, GT, GE, LT, LE, CONTAINS, IN, NOT_IN
         Combine: AND, OR
         Example: "name CONTAINS 'prod' AND status EQ 'RUNNING'"
-    
+
     Example:
         >>> database_template_tool(action='search', limit=..., cursor=..., sort=..., filter_expression="name CONTAINS 'test'")
-    
+
     ACTION: get
     ----------------------------------------
     Summary: Retrieve a DatabaseTemplate by ID.
     Method: GET
     Endpoint: /database-templates/{databaseTemplateId}
     Required Parameters: database_template_id
-    
+
     Example:
         >>> database_template_tool(action='get', database_template_id='example-database_template-123')
-    
+
     ACTION: create
     ----------------------------------------
     Summary: Create a database template.
@@ -173,10 +201,10 @@ def database_template_tool(
     Endpoint: /database-templates
     Required Parameters: name, source_type
     Key Parameters (provide as applicable): description, parameters, make_current_account_owner, tags
-    
+
     Example:
         >>> database_template_tool(action='create', name=..., description=..., source_type=..., parameters=..., make_current_account_owner=..., tags=...)
-    
+
     ACTION: update
     ----------------------------------------
     Summary: Updates a DatabaseTemplate by ID
@@ -184,40 +212,40 @@ def database_template_tool(
     Endpoint: /database-templates/{databaseTemplateId}
     Required Parameters: database_template_id
     Key Parameters (provide as applicable): name, description, source_type, parameters
-    
+
     Example:
         >>> database_template_tool(action='update', database_template_id='example-database_template-123', name=..., description=..., source_type=..., parameters=...)
-    
+
     ACTION: delete
     ----------------------------------------
     Summary: Delete a DatabaseTemplate by ID.
     Method: DELETE
     Endpoint: /database-templates/{databaseTemplateId}
     Required Parameters: database_template_id
-    
+
     Example:
         >>> database_template_tool(action='delete', database_template_id='example-database_template-123')
-    
+
     ACTION: get_tags
     ----------------------------------------
     Summary: Get tags for a DatabaseTemplate.
     Method: GET
     Endpoint: /database-templates/{databaseTemplateId}/tags
     Required Parameters: database_template_id
-    
+
     Example:
         >>> database_template_tool(action='get_tags', database_template_id='example-database_template-123')
-    
+
     ACTION: add_tags
     ----------------------------------------
     Summary: Create tags for a DatabaseTemplate.
     Method: POST
     Endpoint: /database-templates/{databaseTemplateId}/tags
     Required Parameters: database_template_id, tags
-    
+
     Example:
         >>> database_template_tool(action='add_tags', database_template_id='example-database_template-123', tags=...)
-    
+
     ACTION: delete_tags
     ----------------------------------------
     Summary: Delete tags for a DatabaseTemplate.
@@ -225,17 +253,17 @@ def database_template_tool(
     Endpoint: /database-templates/{databaseTemplateId}/tags/delete
     Required Parameters: database_template_id
     Key Parameters (provide as applicable): tags, key, value
-    
+
     Example:
         >>> database_template_tool(action='delete_tags', database_template_id='example-database_template-123', tags=..., key=..., value=...)
-    
+
     ======================================================================
     PARAMETERS
     ======================================================================
-    
+
     Args:
         action (str): The operation to perform. One of: search, get, create, update, delete, get_tags, add_tags, delete_tags
-    
+
       -- General parameters (all database types) --
         cursor (str): Cursor to fetch the next or previous page of results. The value of this prope...
             [Required for: search]
@@ -263,87 +291,203 @@ def database_template_tool(
             [Required for: add_tags]
         value (str): Value of the tag
             [Optional for all actions]
-    
+
     Returns:
         Dict[str, Any]: The API response containing operation results
-    
+
     Raises:
         Returns error dict if required parameters are missing for the action
     """
     # Route to appropriate API based on action
-    if action == 'search':
+    if action == "search":
         params = build_params(limit=limit, cursor=cursor, sort=sort)
-        body = {'filter_expression': filter_expression} if filter_expression else {}
-        conf = check_confirmation('POST', '/database-templates/search', action, 'database_template_tool', confirmed or False, request_params=params, request_body=body)
+        body = {"filter_expression": filter_expression} if filter_expression else {}
+        conf = check_confirmation(
+            "POST",
+            "/database-templates/search",
+            action,
+            "database_template_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', '/database-templates/search', params=params, json_body=body)
-    elif action == 'get':
+        return make_api_request(
+            "POST", "/database-templates/search", params=params, json_body=body
+        )
+    elif action == "get":
         if database_template_id is None:
-            return {'error': 'Missing required parameter: database_template_id for action get'}
-        endpoint = f'/database-templates/{database_template_id}'
+            return {
+                "error": "Missing required parameter: database_template_id for action get"
+            }
+        endpoint = f"/database-templates/{database_template_id}"
         params = build_params()
-        conf = check_confirmation('GET', endpoint, action, 'database_template_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            endpoint,
+            action,
+            "database_template_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', endpoint, params=params)
-    elif action == 'create':
+        return make_api_request("GET", endpoint, params=params)
+    elif action == "create":
         params = build_params(name=name, source_type=source_type)
-        body = {k: v for k, v in {'name': name, 'description': description, 'source_type': source_type, 'parameters': parameters, 'make_current_account_owner': make_current_account_owner, 'tags': tags}.items() if v is not None}
-        conf = check_confirmation('POST', '/database-templates', action, 'database_template_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "name": name,
+                "description": description,
+                "source_type": source_type,
+                "parameters": parameters,
+                "make_current_account_owner": make_current_account_owner,
+                "tags": tags,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            "/database-templates",
+            action,
+            "database_template_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', '/database-templates', params=params, json_body=body if body else None)
-    elif action == 'update':
+        return make_api_request(
+            "POST",
+            "/database-templates",
+            params=params,
+            json_body=body if body else None,
+        )
+    elif action == "update":
         if database_template_id is None:
-            return {'error': 'Missing required parameter: database_template_id for action update'}
-        endpoint = f'/database-templates/{database_template_id}'
+            return {
+                "error": "Missing required parameter: database_template_id for action update"
+            }
+        endpoint = f"/database-templates/{database_template_id}"
         params = build_params()
-        body = {k: v for k, v in {'name': name, 'description': description, 'source_type': source_type, 'parameters': parameters}.items() if v is not None}
-        conf = check_confirmation('PATCH', endpoint, action, 'database_template_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "name": name,
+                "description": description,
+                "source_type": source_type,
+                "parameters": parameters,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "PATCH",
+            endpoint,
+            action,
+            "database_template_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('PATCH', endpoint, params=params, json_body=body if body else None)
-    elif action == 'delete':
+        return make_api_request(
+            "PATCH", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "delete":
         if database_template_id is None:
-            return {'error': 'Missing required parameter: database_template_id for action delete'}
-        endpoint = f'/database-templates/{database_template_id}'
+            return {
+                "error": "Missing required parameter: database_template_id for action delete"
+            }
+        endpoint = f"/database-templates/{database_template_id}"
         params = build_params()
-        conf = check_confirmation('DELETE', endpoint, action, 'database_template_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "DELETE",
+            endpoint,
+            action,
+            "database_template_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('DELETE', endpoint, params=params)
-    elif action == 'get_tags':
+        return make_api_request("DELETE", endpoint, params=params)
+    elif action == "get_tags":
         if database_template_id is None:
-            return {'error': 'Missing required parameter: database_template_id for action get_tags'}
-        endpoint = f'/database-templates/{database_template_id}/tags'
+            return {
+                "error": "Missing required parameter: database_template_id for action get_tags"
+            }
+        endpoint = f"/database-templates/{database_template_id}/tags"
         params = build_params()
-        conf = check_confirmation('GET', endpoint, action, 'database_template_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            endpoint,
+            action,
+            "database_template_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', endpoint, params=params)
-    elif action == 'add_tags':
+        return make_api_request("GET", endpoint, params=params)
+    elif action == "add_tags":
         if database_template_id is None:
-            return {'error': 'Missing required parameter: database_template_id for action add_tags'}
-        endpoint = f'/database-templates/{database_template_id}/tags'
+            return {
+                "error": "Missing required parameter: database_template_id for action add_tags"
+            }
+        endpoint = f"/database-templates/{database_template_id}/tags"
         params = build_params(tags=tags)
-        body = {k: v for k, v in {'tags': tags}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'database_template_tool', confirmed or False, request_params=params, request_body=body)
+        body = {k: v for k, v in {"tags": tags}.items() if v is not None}
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "database_template_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'delete_tags':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "delete_tags":
         if database_template_id is None:
-            return {'error': 'Missing required parameter: database_template_id for action delete_tags'}
-        endpoint = f'/database-templates/{database_template_id}/tags/delete'
+            return {
+                "error": "Missing required parameter: database_template_id for action delete_tags"
+            }
+        endpoint = f"/database-templates/{database_template_id}/tags/delete"
         params = build_params()
-        body = {k: v for k, v in {'key': key, 'value': value, 'tags': tags}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'database_template_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {"key": key, "value": value, "tags": tags}.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "database_template_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
     else:
-        return {'error': f'Unknown action: {action}. Valid actions: search, get, create, update, delete, get_tags, add_tags, delete_tags'}
+        return {
+            "error": f"Unknown action: {action}. Valid actions: search, get, create, update, delete, get_tags, add_tags, delete_tags"
+        }
+
 
 @log_tool_execution
 def hook_template_tool(
@@ -365,13 +509,13 @@ def hook_template_tool(
 ) -> Dict[str, Any]:
     """
     Unified tool for HOOK TEMPLATE operations.
-    
+
     This tool supports 8 actions: search, get, create, update, delete, get_tags, add_tags, delete_tags
-    
+
     ======================================================================
     ACTION REFERENCE
     ======================================================================
-    
+
     ACTION: search
     ----------------------------------------
     Summary: Search Hook Templates.
@@ -379,37 +523,37 @@ def hook_template_tool(
     Endpoint: /hook-templates/search
     Required Parameters: limit, cursor, sort
     Key Parameters (provide as applicable): filter_expression
-    
+
     Filterable Fields:
-        - id: 
-        - name: 
+        - id:
+        - name:
         - dct_managed: Whether this hook template is managed by DCT or by an ind...
-        - description: 
-        - shell: 
-        - command: 
+        - description:
+        - shell:
+        - command:
         - credentials_env_vars: List of environment variables that will contain credentia...
-        - engine_id: 
-        - compatible_engine_id: 
+        - engine_id:
+        - compatible_engine_id:
         - tags: The tags that are applied to this hook template.
-    
+
     Filter Syntax:
         Operators: EQ, NE, GT, GE, LT, LE, CONTAINS, IN, NOT_IN
         Combine: AND, OR
         Example: "name CONTAINS 'prod' AND status EQ 'RUNNING'"
-    
+
     Example:
         >>> hook_template_tool(action='search', limit=..., cursor=..., sort=..., filter_expression="name CONTAINS 'test'")
-    
+
     ACTION: get
     ----------------------------------------
     Summary: Fetch Hook Template by ID
     Method: GET
     Endpoint: /hook-templates/{hookTemplateId}
     Required Parameters: hook_template_id
-    
+
     Example:
         >>> hook_template_tool(action='get', hook_template_id='example-hook_template-123')
-    
+
     ACTION: create
     ----------------------------------------
     Summary: Create a Hook Template.
@@ -417,10 +561,10 @@ def hook_template_tool(
     Endpoint: /hook-templates
     Required Parameters: name, command
     Key Parameters (provide as applicable): description, shell, credentials_env_vars, tags
-    
+
     Example:
         >>> hook_template_tool(action='create', name=..., description=..., shell=..., command=..., credentials_env_vars=..., tags=...)
-    
+
     ACTION: update
     ----------------------------------------
     Summary: Update a Hook Template.
@@ -428,40 +572,40 @@ def hook_template_tool(
     Endpoint: /hook-templates/{hookTemplateId}
     Required Parameters: hook_template_id
     Key Parameters (provide as applicable): name, description, shell, command, credentials_env_vars
-    
+
     Example:
         >>> hook_template_tool(action='update', hook_template_id='example-hook_template-123', name=..., description=..., shell=..., command=..., credentials_env_vars=...)
-    
+
     ACTION: delete
     ----------------------------------------
     Summary: Delete a Hook Template.
     Method: DELETE
     Endpoint: /hook-templates/{hookTemplateId}
     Required Parameters: hook_template_id
-    
+
     Example:
         >>> hook_template_tool(action='delete', hook_template_id='example-hook_template-123')
-    
+
     ACTION: get_tags
     ----------------------------------------
     Summary: Get tags for a Hook Template.
     Method: GET
     Endpoint: /hook-templates/{hookTemplateId}/tags
     Required Parameters: hook_template_id
-    
+
     Example:
         >>> hook_template_tool(action='get_tags', hook_template_id='example-hook_template-123')
-    
+
     ACTION: add_tags
     ----------------------------------------
     Summary: Create tags for a Hook Template.
     Method: POST
     Endpoint: /hook-templates/{hookTemplateId}/tags
     Required Parameters: hook_template_id, tags
-    
+
     Example:
         >>> hook_template_tool(action='add_tags', hook_template_id='example-hook_template-123', tags=...)
-    
+
     ACTION: delete_tags
     ----------------------------------------
     Summary: Delete tags for a Hook Template.
@@ -469,17 +613,17 @@ def hook_template_tool(
     Endpoint: /hook-templates/{hookTemplateId}/tags/delete
     Required Parameters: hook_template_id
     Key Parameters (provide as applicable): tags, key, value
-    
+
     Example:
         >>> hook_template_tool(action='delete_tags', hook_template_id='example-hook_template-123', tags=..., key=..., value=...)
-    
+
     ======================================================================
     PARAMETERS
     ======================================================================
-    
+
     Args:
         action (str): The operation to perform. One of: search, get, create, update, delete, get_tags, add_tags, delete_tags
-    
+
       -- General parameters (all database types) --
         command (str): Request body parameter
             [Required for: create]
@@ -507,98 +651,211 @@ def hook_template_tool(
             [Required for: add_tags]
         value (str): Value of the tag
             [Optional for all actions]
-    
+
     Returns:
         Dict[str, Any]: The API response containing operation results
-    
+
     Raises:
         Returns error dict if required parameters are missing for the action
     """
     # Route to appropriate API based on action
-    if action == 'search':
+    if action == "search":
         params = build_params(limit=limit, cursor=cursor, sort=sort)
-        body = {'filter_expression': filter_expression} if filter_expression else {}
-        conf = check_confirmation('POST', '/hook-templates/search', action, 'hook_template_tool', confirmed or False, request_params=params, request_body=body)
+        body = {"filter_expression": filter_expression} if filter_expression else {}
+        conf = check_confirmation(
+            "POST",
+            "/hook-templates/search",
+            action,
+            "hook_template_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', '/hook-templates/search', params=params, json_body=body)
-    elif action == 'get':
+        return make_api_request(
+            "POST", "/hook-templates/search", params=params, json_body=body
+        )
+    elif action == "get":
         if hook_template_id is None:
-            return {'error': 'Missing required parameter: hook_template_id for action get'}
-        endpoint = f'/hook-templates/{hook_template_id}'
+            return {
+                "error": "Missing required parameter: hook_template_id for action get"
+            }
+        endpoint = f"/hook-templates/{hook_template_id}"
         params = build_params()
-        conf = check_confirmation('GET', endpoint, action, 'hook_template_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            endpoint,
+            action,
+            "hook_template_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', endpoint, params=params)
-    elif action == 'create':
+        return make_api_request("GET", endpoint, params=params)
+    elif action == "create":
         params = build_params(name=name, command=command)
-        body = {k: v for k, v in {'name': name, 'description': description, 'shell': shell, 'command': command, 'credentials_env_vars': credentials_env_vars, 'tags': tags}.items() if v is not None}
-        conf = check_confirmation('POST', '/hook-templates', action, 'hook_template_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "name": name,
+                "description": description,
+                "shell": shell,
+                "command": command,
+                "credentials_env_vars": credentials_env_vars,
+                "tags": tags,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            "/hook-templates",
+            action,
+            "hook_template_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', '/hook-templates', params=params, json_body=body if body else None)
-    elif action == 'update':
+        return make_api_request(
+            "POST", "/hook-templates", params=params, json_body=body if body else None
+        )
+    elif action == "update":
         if hook_template_id is None:
-            return {'error': 'Missing required parameter: hook_template_id for action update'}
-        endpoint = f'/hook-templates/{hook_template_id}'
+            return {
+                "error": "Missing required parameter: hook_template_id for action update"
+            }
+        endpoint = f"/hook-templates/{hook_template_id}"
         params = build_params()
-        body = {k: v for k, v in {'name': name, 'description': description, 'shell': shell, 'command': command, 'credentials_env_vars': credentials_env_vars}.items() if v is not None}
-        conf = check_confirmation('PATCH', endpoint, action, 'hook_template_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {
+                "name": name,
+                "description": description,
+                "shell": shell,
+                "command": command,
+                "credentials_env_vars": credentials_env_vars,
+            }.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "PATCH",
+            endpoint,
+            action,
+            "hook_template_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('PATCH', endpoint, params=params, json_body=body if body else None)
-    elif action == 'delete':
+        return make_api_request(
+            "PATCH", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "delete":
         if hook_template_id is None:
-            return {'error': 'Missing required parameter: hook_template_id for action delete'}
-        endpoint = f'/hook-templates/{hook_template_id}'
+            return {
+                "error": "Missing required parameter: hook_template_id for action delete"
+            }
+        endpoint = f"/hook-templates/{hook_template_id}"
         params = build_params()
-        conf = check_confirmation('DELETE', endpoint, action, 'hook_template_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "DELETE",
+            endpoint,
+            action,
+            "hook_template_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('DELETE', endpoint, params=params)
-    elif action == 'get_tags':
+        return make_api_request("DELETE", endpoint, params=params)
+    elif action == "get_tags":
         if hook_template_id is None:
-            return {'error': 'Missing required parameter: hook_template_id for action get_tags'}
-        endpoint = f'/hook-templates/{hook_template_id}/tags'
+            return {
+                "error": "Missing required parameter: hook_template_id for action get_tags"
+            }
+        endpoint = f"/hook-templates/{hook_template_id}/tags"
         params = build_params()
-        conf = check_confirmation('GET', endpoint, action, 'hook_template_tool', confirmed or False, request_params=params, request_body=None)
+        conf = check_confirmation(
+            "GET",
+            endpoint,
+            action,
+            "hook_template_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=None,
+        )
         if conf:
             return conf
-        return make_api_request('GET', endpoint, params=params)
-    elif action == 'add_tags':
+        return make_api_request("GET", endpoint, params=params)
+    elif action == "add_tags":
         if hook_template_id is None:
-            return {'error': 'Missing required parameter: hook_template_id for action add_tags'}
-        endpoint = f'/hook-templates/{hook_template_id}/tags'
+            return {
+                "error": "Missing required parameter: hook_template_id for action add_tags"
+            }
+        endpoint = f"/hook-templates/{hook_template_id}/tags"
         params = build_params(tags=tags)
-        body = {k: v for k, v in {'tags': tags}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'hook_template_tool', confirmed or False, request_params=params, request_body=body)
+        body = {k: v for k, v in {"tags": tags}.items() if v is not None}
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "hook_template_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
-    elif action == 'delete_tags':
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
+    elif action == "delete_tags":
         if hook_template_id is None:
-            return {'error': 'Missing required parameter: hook_template_id for action delete_tags'}
-        endpoint = f'/hook-templates/{hook_template_id}/tags/delete'
+            return {
+                "error": "Missing required parameter: hook_template_id for action delete_tags"
+            }
+        endpoint = f"/hook-templates/{hook_template_id}/tags/delete"
         params = build_params()
-        body = {k: v for k, v in {'key': key, 'value': value, 'tags': tags}.items() if v is not None}
-        conf = check_confirmation('POST', endpoint, action, 'hook_template_tool', confirmed or False, request_params=params, request_body=body)
+        body = {
+            k: v
+            for k, v in {"key": key, "value": value, "tags": tags}.items()
+            if v is not None
+        }
+        conf = check_confirmation(
+            "POST",
+            endpoint,
+            action,
+            "hook_template_tool",
+            confirmed or False,
+            request_params=params,
+            request_body=body,
+        )
         if conf:
             return conf
-        return make_api_request('POST', endpoint, params=params, json_body=body if body else None)
+        return make_api_request(
+            "POST", endpoint, params=params, json_body=body if body else None
+        )
     else:
-        return {'error': f'Unknown action: {action}. Valid actions: search, get, create, update, delete, get_tags, add_tags, delete_tags'}
+        return {
+            "error": f"Unknown action: {action}. Valid actions: search, get, create, update, delete, get_tags, add_tags, delete_tags"
+        }
 
 
 def register_tools(app, dct_client):
     global client
     client = dct_client
-    logger.info(f'Registering tools for template_endpoints...')
+    logger.info("Registering tools for template_endpoints...")
     try:
-        logger.info(f'  Registering tool function: database_template_tool')
+        logger.info("  Registering tool function: database_template_tool")
         app.add_tool(database_template_tool, name="database_template_tool")
-        logger.info(f'  Registering tool function: hook_template_tool')
+        logger.info("  Registering tool function: hook_template_tool")
         app.add_tool(hook_template_tool, name="hook_template_tool")
     except Exception as e:
-        logger.error(f'Error registering tools for template_endpoints: {e}')
-    logger.info(f'Tools registration finished for template_endpoints.')
+        logger.error(f"Error registering tools for template_endpoints: {e}")
+    logger.info("Tools registration finished for template_endpoints.")

--- a/src/dct_mcp_server/toolsgenerator/driver.py
+++ b/src/dct_mcp_server/toolsgenerator/driver.py
@@ -17,23 +17,23 @@ Configuration Files Used:
 - config/toolsets/*.txt: Toolset definitions with METHOD|path|action format and # TOOL headers
 """
 
-
 import yaml
 import os
 import glob
 import re
 import requests
-import urllib3
 import logging
 import tempfile
 from dct_mcp_server.config.config import get_dct_config
 from dct_mcp_server.config.loader import TOOLSETS_DIR
 
 # Get the absolute path of the project root
-project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+project_root = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "..")
+)
 
 # For uvx/package installations, use the package directory structure
-if 'site-packages' in __file__:
+if "site-packages" in __file__:
     # Use temp directory for generated tools to avoid permission issues
     TOOLS_DIR = os.path.join(tempfile.gettempdir(), "dct_mcp_tools")
 else:
@@ -60,16 +60,16 @@ SKIPPED_ENTRIES: list[dict] = []
 TOOL_DOMAIN_HINTS = {
     "data_tool": (
         "IMPORTANT — Delphix domain terminology:\n"
-        "  • \"dSource\" is often used as a VERB meaning \"create/link a dSource\" "
+        '  • "dSource" is often used as a VERB meaning "create/link a dSource" '
         "(i.e. ingest a source database). When a user says "
-        "\"dSource database X\", they want to LINK a new dSource for database X, "
+        '"dSource database X", they want to LINK a new dSource for database X, '
         "NOT look up an existing dSource named X. Use the appropriate "
         "dsource_link_* action (dsource_link_oracle, dsource_link_mssql, "
         "dsource_link_ase, dsource_link_appdata) depending on the database type.\n"
-        "  • \"provision\" or \"spin up\" a VDB or \"create a golden image of a "
-        "VDB\" means creating a virtual database from a dSource or bookmark  —"
+        '  • "provision" or "spin up" a VDB or "create a golden image of a '
+        'VDB" means creating a virtual database from a dSource or bookmark  —'
         " use provision_by_timestamp, provision_by_snapshot, etc.\n"
-        "  • \"refresh\" a VDB means updating it with newer data from its parent — "
+        '  • "refresh" a VDB means updating it with newer data from its parent — '
         "use refresh_vdb_by_timestamp, refresh_vdb_by_snapshot, etc."
     ),
 }
@@ -146,41 +146,43 @@ ACTION_DOMAIN_HINTS: dict[str, str] = {
 def load_api_endpoints_from_toolsets():
     """
     Load API endpoints from the SELECTED toolset file and group by TOOL NAME.
-    
+
     Only reads the toolset specified by DCT_TOOLSET config (default: self_service).
     Parses tool comments like "# TOOL 1: vdb_tool" to group APIs into unified tools.
     Each tool will support multiple actions (search, get, create, etc.).
     """
     global TOOLS_BY_NAME
     TOOLS_BY_NAME = {}
-    
+
     if not TOOLSETS_DIR.exists():
         logger.error(f"Toolsets directory not found: {TOOLSETS_DIR}")
         return
-    
+
     # Get the selected toolset from config
     dct_config = get_dct_config()
     selected_toolset = dct_config.get("toolset", "self_service")
-    
+
     # "auto" and "dynamic" modes do not use the persona-grouped generator output
     # (dynamic mode loads the spec directly); fall back to self_service for grouping.
     if selected_toolset in ("auto", "dynamic"):
         selected_toolset = "self_service"
-    
+
     toolset_file = TOOLSETS_DIR / f"{selected_toolset}.txt"
-    
+
     if not toolset_file.exists():
         logger.error(f"Toolset file not found: {toolset_file}")
         return
-    
+
     logger.info(f"Loading toolset: {selected_toolset} from {toolset_file}")
-    
+
     # Parse the selected toolset file
     _parse_toolset_file(toolset_file)
-    
+
     # Log summary
     total_apis = sum(len(apis) for apis in TOOLS_BY_NAME.values())
-    logger.info(f"Loaded {total_apis} APIs grouped into {len(TOOLS_BY_NAME)} unified tools")
+    logger.info(
+        f"Loaded {total_apis} APIs grouped into {len(TOOLS_BY_NAME)} unified tools"
+    )
     for tool_name, apis in TOOLS_BY_NAME.items():
         logger.info(f"  {tool_name}: {len(apis)} actions")
 
@@ -188,23 +190,23 @@ def load_api_endpoints_from_toolsets():
 def _parse_toolset_file(toolset_file):
     """
     Parse a single toolset file and populate TOOLS_BY_NAME.
-    
+
     Handles inheritance directives (@inherit:parent_toolset).
     """
     global TOOLS_BY_NAME
     current_tool = None
-    
-    with open(toolset_file, 'r') as f:
+
+    with open(toolset_file, "r") as f:
         for line in f:
             line = line.strip()
-            
+
             # Skip empty lines
             if not line:
                 continue
-            
+
             # Handle inheritance directive
-            if line.startswith('@inherit:'):
-                parent_name = line.split(':')[1].strip()
+            if line.startswith("@inherit:"):
+                parent_name = line.split(":")[1].strip()
                 parent_file = TOOLSETS_DIR / f"{parent_name}.txt"
                 if parent_file.exists():
                     logger.info(f"  Inheriting from: {parent_name}")
@@ -212,34 +214,36 @@ def _parse_toolset_file(toolset_file):
                 else:
                     logger.warning(f"Parent toolset not found: {parent_name}")
                 continue
-            
+
             # Check for tool header comments like "# TOOL 1: vdb_tool"
             # Must start with "# TOOL" followed by number and colon (not "# Inherited: TOOL")
-            tool_header_match = re.match(r'^#\s*TOOL\s+\d+\s*:\s*(\w+)', line, re.IGNORECASE)
+            tool_header_match = re.match(
+                r"^#\s*TOOL\s+\d+\s*:\s*(\w+)", line, re.IGNORECASE
+            )
             if tool_header_match:
                 # Extract tool name from regex group
                 current_tool = tool_header_match.group(1).strip()
                 if current_tool and current_tool not in TOOLS_BY_NAME:
                     TOOLS_BY_NAME[current_tool] = []
                 continue
-            
+
             # Skip other comments
-            if line.startswith('#'):
+            if line.startswith("#"):
                 continue
-            
+
             # Parse METHOD|path|action format
-            parts = line.split('|')
+            parts = line.split("|")
             if len(parts) >= 3 and current_tool:
                 http_method = parts[0].strip().upper()
                 api_path = parts[1].strip()
                 action_name = parts[2].strip()
-                
+
                 api_entry = {
                     "method": http_method,
                     "path": api_path,
-                    "action": action_name
+                    "action": action_name,
                 }
-                
+
                 # Avoid duplicates
                 if api_entry not in TOOLS_BY_NAME[current_tool]:
                     TOOLS_BY_NAME[current_tool].append(api_entry)
@@ -255,16 +259,16 @@ def download_open_api_yaml(api_url: str, save_path: str):
     """Downloads the OpenAPI YAML from the given URL."""
     try:
         logger.info(f"Downloading OpenAPI spec from {api_url}...")
-        
+
         # Get DCT configuration for proper authentication and SSL settings
         dct_config = get_dct_config()
         verify_ssl = dct_config.get("verify_ssl", False)
         api_key = dct_config.get("api_key")
-        
+
         # Prepare headers with authentication if API key is available
         headers = {
             "Accept": "application/x-yaml, text/yaml, application/json",
-            "User-Agent": "dct-mcp-server-toolgen/1.0"
+            "User-Agent": "dct-mcp-server-toolgen/1.0",
         }
         if api_key:
             headers["Authorization"] = f"apk {api_key}"
@@ -278,6 +282,7 @@ def download_open_api_yaml(api_url: str, save_path: str):
     except requests.exceptions.RequestException as e:
         logger.warning(f"Error downloading OpenAPI spec: {e}")
         raise
+
 
 translated_dict_for_types = {
     "integer": "int",
@@ -377,20 +382,35 @@ def build_params(**kwargs):
 
 """
 
+
 def create_register_tool_function(tool_name, apis):
     func_str = "\n"
     func_str += "def register_tools(app, dct_client):\n"
-    func_str += " "* INDENT_SIZE + "global client\n"
-    func_str += " "* INDENT_SIZE + "client = dct_client\n"
-    func_str += " "* INDENT_SIZE + f"logger.info(f'Registering tools for {tool_name}...')\n"
-    func_str += " "* INDENT_SIZE + "try:\n"
+    func_str += " " * INDENT_SIZE + "global client\n"
+    func_str += " " * INDENT_SIZE + "client = dct_client\n"
+    func_str += (
+        " " * INDENT_SIZE + f"logger.info(f'Registering tools for {tool_name}...')\n"
+    )
+    func_str += " " * INDENT_SIZE + "try:\n"
     for function in apis:
-        func_str += " "* INDENT_SIZE*2 + f"logger.info(f'  Registering tool function: {function}')\n"
-        func_str += " "* INDENT_SIZE*2 + f"app.add_tool({function}, name=\"{function}\")\n"
-    func_str += " "* INDENT_SIZE + "except Exception as e:\n"
-    func_str += " "* INDENT_SIZE*2 + f"logger.error(f'Error registering tools for {tool_name}: {{e}}')\n"
-    func_str += " "* INDENT_SIZE + f"logger.info(f'Tools registration finished for {tool_name}.')\n"
+        func_str += (
+            " " * INDENT_SIZE * 2
+            + f"logger.info(f'  Registering tool function: {function}')\n"
+        )
+        func_str += (
+            " " * INDENT_SIZE * 2 + f'app.add_tool({function}, name="{function}")\n'
+        )
+    func_str += " " * INDENT_SIZE + "except Exception as e:\n"
+    func_str += (
+        " " * INDENT_SIZE * 2
+        + f"logger.error(f'Error registering tools for {tool_name}: {{e}}')\n"
+    )
+    func_str += (
+        " " * INDENT_SIZE
+        + f"logger.info(f'Tools registration finished for {tool_name}.')\n"
+    )
     return func_str
+
 
 def read_open_api_yaml(api_file):
     yaml_body = ""
@@ -404,11 +424,11 @@ def resolve_ref(ref: str, root: dict):
     Resolve a JSON pointer $ref like '#/components/schemas/DSource'
     inside a loaded OpenAPI YAML dict.
     """
-    if not ref.startswith('#/'):
+    if not ref.startswith("#/"):
         raise ValueError(f"Unsupported ref format: {ref}")
 
     # Remove starting '#/' and split by "/"
-    path = ref.lstrip('#/').split('/')
+    path = ref.lstrip("#/").split("/")
 
     node = root
     for part in path:
@@ -438,7 +458,6 @@ def resolve_schema_properties(schema: dict, api_spec: dict) -> tuple:
 
         for sub_schema in schema["allOf"]:
             is_ref = "$ref" in sub_schema
-            ref_name = sub_schema.get("$ref", "").split("/")[-1] if is_ref else ""
 
             # Resolve $ref in sub-schema
             if is_ref:
@@ -446,7 +465,9 @@ def resolve_schema_properties(schema: dict, api_spec: dict) -> tuple:
 
             # Recursively handle nested allOf
             if "allOf" in sub_schema:
-                nested_props, nested_required, nested_key = resolve_schema_properties(sub_schema, api_spec)
+                nested_props, nested_required, nested_key = resolve_schema_properties(
+                    sub_schema, api_spec
+                )
                 combined_properties.update(nested_props)
                 combined_required.extend(nested_required)
                 # Don't propagate key_properties from base schemas
@@ -473,7 +494,7 @@ def resolve_schema_properties(schema: dict, api_spec: dict) -> tuple:
 def generate_tools_from_openapi():
     """
     Generates UNIFIED tool files from OpenAPI spec based on TOOLS_BY_NAME.
-    
+
     Each tool supports multiple actions through an 'action' parameter.
     Example: vdb_tool(action="search", ...) or vdb_tool(action="start", vdb_id="...")
     """
@@ -483,19 +504,21 @@ def generate_tools_from_openapi():
     dct_config = get_dct_config()
     base_url = dct_config.get("base_url")
     if not base_url:
-        logger.error("DCT_BASE_URL not configured. Cannot download OpenAPI specification.")
+        logger.error(
+            "DCT_BASE_URL not configured. Cannot download OpenAPI specification."
+        )
         raise ValueError("DCT_BASE_URL is required for tool generation")
-    
+
     # Construct the OpenAPI spec URL
     client_address = f"{base_url.rstrip('/')}/dct/static/api-external.yaml"
     logger.info(f"OpenAPI spec URL: {client_address}")
-    
+
     # Use temp directory for package installations, project directory for local development
-    if 'site-packages' in __file__:
+    if "site-packages" in __file__:
         API_FILE = os.path.join(tempfile.gettempdir(), "api.yaml")
     else:
         API_FILE = os.path.join(project_root, "src", "api.yaml")
-    
+
     download_open_api_yaml(client_address, API_FILE)
 
     api_spec = read_open_api_yaml(API_FILE)
@@ -503,7 +526,7 @@ def generate_tools_from_openapi():
 
     # Reset per-run skip tracker so the summary only reflects this generation.
     SKIPPED_ENTRIES.clear()
-    
+
     os.makedirs(TOOLS_DIR, exist_ok=True)
 
     # Clean up existing generated tool files before creating new ones
@@ -514,7 +537,7 @@ def generate_tools_from_openapi():
             logger.info(f"Deleted existing tool file: {tool_file}")
         except OSError as e:
             logger.warning(f"Could not delete {tool_file}: {e}")
-    
+
     logger.info(f"Cleaned up {len(existing_tools)} existing tool files")
 
     # Group tools by module for file organization
@@ -526,7 +549,7 @@ def generate_tools_from_openapi():
             module_name = _get_module_for_path(first_path)
         else:
             module_name = "misc_endpoints"
-        
+
         if module_name not in module_tools:
             module_tools[module_name] = {}
         module_tools[module_name][tool_name] = apis
@@ -534,7 +557,7 @@ def generate_tools_from_openapi():
     # Generate one file per module containing unified tools
     for module_name, tools in module_tools.items():
         TOOL_FILE = os.path.join(TOOLS_DIR, f"{module_name}_tool.py")
-        
+
         tool_file_content = prefix
 
         function_lists = []
@@ -554,7 +577,7 @@ def generate_tools_from_openapi():
 
         with open(TOOL_FILE, "w") as f:
             f.write(tool_file_content)
-        
+
         logger.info(f"Generated {TOOL_FILE} with {len(function_lists)} unified tools")
 
     # Delete the api.yaml file after generating all tools
@@ -590,38 +613,30 @@ def _get_module_for_path(api_path: str) -> str:
         "/sources": "dataset_endpoints",
         "/data-connections": "dataset_endpoints",
         "/timeflows": "dataset_endpoints",
-        
         # Job endpoints
         "/jobs": "job_endpoints",
-        
         # Environment endpoints
         "/environments": "environment_endpoints",
         "/toolkits": "environment_endpoints",
-        
         # Engine endpoints
         "/management/engines": "engine_endpoints",
         "/engines": "engine_endpoints",
-        
         # Compliance endpoints
         "/masking": "compliance_endpoints",
         "/connectors": "compliance_endpoints",
         "/executions": "compliance_endpoints",
         "/algorithms": "compliance_endpoints",
-        
         # Reports endpoints
         "/reporting": "reports_endpoints",
         "/reports": "reports_endpoints",
-        
         # IAM endpoints (accounts, roles, access-groups)
         "/management/accounts": "iam_endpoints",
         "/roles": "iam_endpoints",
         "/access-groups": "iam_endpoints",
         "/management/tags": "iam_endpoints",
-        
         # Policy endpoints (replication, virtualization policies)
         "/replication-profiles": "policy_endpoints",
         "/virtualization-policies": "policy_endpoints",
-        
         # Admin/Platform endpoints (AI, telemetry, SMTP, LDAP, SAML, proxy, license, properties)
         "/ai": "admin_endpoints",
         "/management/properties": "admin_endpoints",
@@ -631,12 +646,11 @@ def _get_module_for_path(api_path: str) -> str:
         "/management/saml-config": "admin_endpoints",
         "/management/proxy-configuration": "admin_endpoints",
         "/management/license": "admin_endpoints",
-        
         # Template endpoints
         "/database-templates": "template_endpoints",
         "/hook-templates": "template_endpoints",
     }
-    
+
     # Check from most specific to least specific (longer paths first)
     for prefix in sorted(path_to_module.keys(), key=len, reverse=True):
         if api_path.startswith(prefix):
@@ -644,31 +658,30 @@ def _get_module_for_path(api_path: str) -> str:
     return "misc_endpoints"
 
 
-
 def _generate_unified_tool(tool_name: str, apis: list, api_spec: dict) -> str:
     """
     Generate a unified tool function that supports multiple actions.
-    
+
     Args:
         tool_name: Name of the tool (e.g., "vdb_tool")
         apis: List of API entries [{"method": "POST", "path": "/vdbs/search", "action": "search"}, ...]
         api_spec: Parsed OpenAPI specification
-    
+
     Returns:
         Generated Python code for the unified tool function
     """
     # Collect all parameters across all actions
     all_params = {}  # {param_name: {"type": str, "required_for": [actions], "description": str, "param_type": str}}
     action_details = {}  # {action_name: {"method": str, "path": str, "path_params": [], "has_filter": bool, "body_params": []}}
-    
+
     # Extract resource type from tool name for descriptions
     resource_type = tool_name.replace("_tool", "").replace("_", " ").upper()
-    
+
     for api_entry in apis:
         action = api_entry["action"]
         method = api_entry["method"]
         path = api_entry["path"]
-        
+
         path_item = api_spec.get("paths", {}).get(path, {})
         operation = path_item.get(method.lower())
 
@@ -676,8 +689,10 @@ def _generate_unified_tool(tool_name: str, apis: list, api_spec: dict) -> str:
             # Distinguish "path not in spec" from "wrong method on a valid path"
             # so the startup summary can point to the likely typo directly.
             available_methods = sorted(
-                m.upper() for m in path_item.keys()
-                if m.lower() in {"get", "post", "put", "patch", "delete", "head", "options"}
+                m.upper()
+                for m in path_item.keys()
+                if m.lower()
+                in {"get", "post", "put", "patch", "delete", "head", "options"}
             )
             if available_methods:
                 hint = (
@@ -688,30 +703,34 @@ def _generate_unified_tool(tool_name: str, apis: list, api_spec: dict) -> str:
             else:
                 hint = "path not found in OpenAPI spec — likely stale or misspelled."
             logger.warning(f"Skipping {tool_name}.{action}: {method} {path} — {hint}")
-            SKIPPED_ENTRIES.append({
-                "tool": tool_name,
-                "action": action,
-                "method": method,
-                "path": path,
-                "hint": hint,
-            })
+            SKIPPED_ENTRIES.append(
+                {
+                    "tool": tool_name,
+                    "action": action,
+                    "method": method,
+                    "path": path,
+                    "hint": hint,
+                }
+            )
             continue
-        
+
         # Extract path parameters
-        path_params = re.findall(r'\{(\w+)\}', path)
-        path_params_snake = [(p, re.sub(r'(?<!^)(?=[A-Z])', '_', p).lower()) for p in path_params]
-        
-        has_filter = operation.get('x-filterable', False)
-        
+        path_params = re.findall(r"\{(\w+)\}", path)
+        path_params_snake = [
+            (p, re.sub(r"(?<!^)(?=[A-Z])", "_", p).lower()) for p in path_params
+        ]
+
+        has_filter = operation.get("x-filterable", False)
+
         action_details[action] = {
             "method": method,
             "path": path,
             "path_params": path_params_snake,
             "has_filter": has_filter,
             "summary": operation.get("summary", ""),
-            "operation_id": operation.get("operationId", action)
+            "operation_id": operation.get("operationId", action),
         }
-        
+
         # Add path parameters
         for orig_name, snake_name in path_params_snake:
             param_key = snake_name
@@ -719,59 +738,83 @@ def _generate_unified_tool(tool_name: str, apis: list, api_spec: dict) -> str:
                 # Find description from parameters
                 desc = f"The unique identifier for the {orig_name.replace('Id', '')}."
                 for param in operation.get("parameters", []):
-                    param_def = resolve_ref(param["$ref"], api_spec) if "$ref" in param else param
+                    param_def = (
+                        resolve_ref(param["$ref"], api_spec)
+                        if "$ref" in param
+                        else param
+                    )
                     if param_def.get("name") == orig_name:
                         desc = param_def.get("description", desc)
                         break
-                all_params[param_key] = {"type": "str", "required_for": [], "description": desc, "param_type": "path"}
+                all_params[param_key] = {
+                    "type": "str",
+                    "required_for": [],
+                    "description": desc,
+                    "param_type": "path",
+                }
             all_params[param_key]["required_for"].append(action)
-        
+
         # Add query parameters
         for param in operation.get("parameters", []):
-            param_def = resolve_ref(param["$ref"], api_spec) if "$ref" in param else param
+            param_def = (
+                resolve_ref(param["$ref"], api_spec) if "$ref" in param else param
+            )
             if param_def.get("in") == "path":
                 continue
 
             name = param_def.get("name", "unknown")
             try:
-                param_type = translated_dict_for_types.get(param_def['schema']['type'], "str")
+                param_type = translated_dict_for_types.get(
+                    param_def["schema"]["type"], "str"
+                )
                 desc = param_def.get("description", "Query parameter")
 
                 # Include enum values in description if they exist
-                enum_values = param_def.get('schema', {}).get('enum')
+                enum_values = param_def.get("schema", {}).get("enum")
                 if enum_values:
                     desc = f"{desc} Valid values: {', '.join(str(v) for v in enum_values)}."
 
                 # Capture default value from the spec if present
-                default_value = param_def.get('schema', {}).get('default')
+                default_value = param_def.get("schema", {}).get("default")
                 if default_value is not None:
                     desc = f"{desc} (Default: {default_value})"
 
                 if name not in all_params:
-                    all_params[name] = {"type": param_type, "required_for": [], "description": desc, "param_type": "query", "default": default_value}
-                elif default_value is not None and all_params[name].get("default") is None:
+                    all_params[name] = {
+                        "type": param_type,
+                        "required_for": [],
+                        "description": desc,
+                        "param_type": "query",
+                        "default": default_value,
+                    }
+                elif (
+                    default_value is not None
+                    and all_params[name].get("default") is None
+                ):
                     all_params[name]["default"] = default_value
                     all_params[name]["description"] = desc
                 all_params[name]["required_for"].append(action)
             except KeyError:
                 continue
-        
+
         # Add request body parameters for POST/PUT/PATCH
         body_params_for_action = []  # Initialize for all methods
         request_body = operation.get("requestBody", {})
-        
+
         # Resolve $ref in requestBody if present
         if "$ref" in request_body:
             request_body = resolve_ref(request_body["$ref"], api_spec)
-        
+
         if request_body and method.upper() in ["POST", "PUT", "PATCH"]:
             content = request_body.get("content", {})
             json_content = content.get("application/json", {})
             schema = json_content.get("schema", {})
-            
+
             # Use helper to resolve schema properties (handles $ref and allOf)
-            properties, required_props, key_props = resolve_schema_properties(schema, api_spec)
-            
+            properties, required_props, key_props = resolve_schema_properties(
+                schema, api_spec
+            )
+
             for prop_name, prop_def in properties.items():
                 # Handle nested $ref in property definition
                 if "$ref" in prop_def:
@@ -788,13 +831,15 @@ def _generate_unified_tool(tool_name: str, apis: list, api_spec: dict) -> str:
                     desc = prop_def.get("description", "Request body parameter")
 
                     # Include enum values in description if they exist
-                    enum_values = prop_def.get('enum')
+                    enum_values = prop_def.get("enum")
                     if enum_values:
                         desc = f"{desc} Valid values: {', '.join(str(v) for v in enum_values)}."
 
                     # Add JSON hint for object/array params
                     if is_json_param:
-                        json_kind = "JSON object" if prop_type == "object" else "JSON array"
+                        json_kind = (
+                            "JSON object" if prop_type == "object" else "JSON array"
+                        )
                         desc = f"{desc} (Pass as {json_kind})"
 
                     # Read x-dct-toolkit-subcommand to tag database-type-specific params
@@ -807,12 +852,16 @@ def _generate_unified_tool(tool_name: str, apis: list, api_spec: dict) -> str:
                             "appdata": "AppData only",
                             "postgres": "Postgres only",
                         }
-                        label = subcommand_labels.get(toolkit_subcommand, f"{toolkit_subcommand} only")
+                        label = subcommand_labels.get(
+                            toolkit_subcommand, f"{toolkit_subcommand} only"
+                        )
                         desc = f"[{label}] {desc}"
 
                     # Convert camelCase to snake_case for consistency
-                    snake_name = re.sub(r'(?<!^)(?=[A-Z])', '_', prop_name).lower()
-                    body_params_for_action.append((prop_name, snake_name, is_json_param))
+                    snake_name = re.sub(r"(?<!^)(?=[A-Z])", "_", prop_name).lower()
+                    body_params_for_action.append(
+                        (prop_name, snake_name, is_json_param)
+                    )
 
                     # Capture default value from the spec if present
                     default_value = prop_def.get("default")
@@ -820,8 +869,20 @@ def _generate_unified_tool(tool_name: str, apis: list, api_spec: dict) -> str:
                         desc = f"{desc} (Default: {default_value})"
 
                     if snake_name not in all_params:
-                        all_params[snake_name] = {"type": python_type, "required_for": [], "key_for": [], "description": desc, "param_type": "body", "is_json": is_json_param, "default": default_value, "toolkit_subcommand": toolkit_subcommand}
-                    elif default_value is not None and all_params[snake_name].get("default") is None:
+                        all_params[snake_name] = {
+                            "type": python_type,
+                            "required_for": [],
+                            "key_for": [],
+                            "description": desc,
+                            "param_type": "body",
+                            "is_json": is_json_param,
+                            "default": default_value,
+                            "toolkit_subcommand": toolkit_subcommand,
+                        }
+                    elif (
+                        default_value is not None
+                        and all_params[snake_name].get("default") is None
+                    ):
                         # Update default if this action provides one and we didn't have one yet
                         all_params[snake_name]["default"] = default_value
                         all_params[snake_name]["description"] = desc
@@ -831,10 +892,10 @@ def _generate_unified_tool(tool_name: str, apis: list, api_spec: dict) -> str:
                         # Key parameter: action-specific but not in the required list.
                         # Surface these so the LLM knows they are the primary inputs.
                         all_params[snake_name].setdefault("key_for", []).append(action)
-        
+
         # Store body params for this action
         action_details[action]["body_params"] = body_params_for_action
-        
+
         # Add filter_expression for search actions
         if has_filter:
             if "filter_expression" not in all_params:
@@ -842,18 +903,17 @@ def _generate_unified_tool(tool_name: str, apis: list, api_spec: dict) -> str:
                     "type": "str",
                     "required_for": [],
                     "description": "Filter expression to narrow results (e.g., \"name CONTAINS 'prod'\")",
-                    "param_type": "body"
+                    "param_type": "body",
                 }
-    
+
     # Skip generating tool if no valid actions were found
     if not action_details:
         logger.warning(f"Skipping tool '{tool_name}' - no valid API operations found")
         return ""
-    
+
     # Build function signature
     actions_list = list(action_details.keys())
-    actions_literal = "|".join([f"'{a}'" for a in actions_list])
-    
+
     func_code = f"@log_tool_execution\nasync def {tool_name}(\n"
     func_code += f"    action: str,  # One of: {', '.join(actions_list)}\n"
 
@@ -879,20 +939,24 @@ def _generate_unified_tool(tool_name: str, apis: list, api_spec: dict) -> str:
                 default_repr = repr(default_value)
             else:
                 default_repr = repr(default_value)
-            func_code += f"    {param_name}: Optional[{param_info['type']}] = {default_repr},\n"
+            func_code += (
+                f"    {param_name}: Optional[{param_info['type']}] = {default_repr},\n"
+            )
         else:
             func_code += f"    {param_name}: Optional[{param_info['type']}] = None,\n"
 
     # Add confirmed parameter for destructive operation confirmation
-    func_code += f"    confirmed: Optional[bool] = None,\n"
+    func_code += "    confirmed: Optional[bool] = None,\n"
 
     func_code += ") -> Dict[str, Any]:\n"
-    
+
     # Build comprehensive docstring with detailed action documentation
     docstring_lines = []
     docstring_lines.append(f"Unified tool for {resource_type} operations.")
     docstring_lines.append("")
-    docstring_lines.append(f"This tool supports {len(actions_list)} actions: {', '.join(actions_list)}")
+    docstring_lines.append(
+        f"This tool supports {len(actions_list)} actions: {', '.join(actions_list)}"
+    )
     docstring_lines.append("")
 
     # Inject domain terminology hints for tools that need them
@@ -906,7 +970,7 @@ def _generate_unified_tool(tool_name: str, apis: list, api_spec: dict) -> str:
     docstring_lines.append("=" * 70)
     docstring_lines.append("ACTION REFERENCE")
     docstring_lines.append("=" * 70)
-    
+
     for action_name, details in action_details.items():
         docstring_lines.append("")
         docstring_lines.append(f"ACTION: {action_name}")
@@ -914,22 +978,29 @@ def _generate_unified_tool(tool_name: str, apis: list, api_spec: dict) -> str:
         docstring_lines.append(f"Summary: {details['summary']}")
         docstring_lines.append(f"Method: {details['method']}")
         docstring_lines.append(f"Endpoint: {details['path']}")
-        
+
         # Required parameters for this action
-        required_params = [p for p, info in all_params.items() if action_name in info["required_for"]]
+        required_params = [
+            p for p, info in all_params.items() if action_name in info["required_for"]
+        ]
         if required_params:
             docstring_lines.append(f"Required Parameters: {', '.join(required_params)}")
 
         # Key parameters: action-specific but not strictly required (e.g. provide at least one of these)
-        key_params = [p for p, info in all_params.items()
-                      if action_name in info.get("key_for", []) and p not in required_params]
+        key_params = [
+            p
+            for p, info in all_params.items()
+            if action_name in info.get("key_for", []) and p not in required_params
+        ]
         if key_params:
-            docstring_lines.append(f"Key Parameters (provide as applicable): {', '.join(key_params)}")
-        
+            docstring_lines.append(
+                f"Key Parameters (provide as applicable): {', '.join(key_params)}"
+            )
+
         # Get full operation details from api_spec for filterable fields
         path_item = api_spec.get("paths", {}).get(details["path"], {})
         operation = path_item.get(details["method"].lower(), {})
-        
+
         # Document filterable fields for search actions
         if details["has_filter"]:
             docstring_lines.append("")
@@ -937,38 +1008,60 @@ def _generate_unified_tool(tool_name: str, apis: list, api_spec: dict) -> str:
             try:
                 responses = operation.get("responses", {})
                 for status_code, resp_details in responses.items():
-                    if 'content' in resp_details and 'application/json' in resp_details['content']:
-                        schema = resp_details['content']['application/json'].get('schema', {})
-                        if 'properties' in schema and 'items' in schema['properties']:
-                            items_schema = schema['properties']['items']
-                            if 'items' in items_schema and '$ref' in items_schema['items']:
-                                response_schema = resolve_ref(items_schema['items']['$ref'], api_spec)
+                    if (
+                        "content" in resp_details
+                        and "application/json" in resp_details["content"]
+                    ):
+                        schema = resp_details["content"]["application/json"].get(
+                            "schema", {}
+                        )
+                        if "properties" in schema and "items" in schema["properties"]:
+                            items_schema = schema["properties"]["items"]
+                            if (
+                                "items" in items_schema
+                                and "$ref" in items_schema["items"]
+                            ):
+                                response_schema = resolve_ref(
+                                    items_schema["items"]["$ref"], api_spec
+                                )
                                 props = response_schema.get("properties", {})
                                 for prop_name, prop_def in props.items():
                                     prop_desc = prop_def.get("description", "")
                                     if len(prop_desc) > 60:
                                         prop_desc = prop_desc[:57] + "..."
-                                    docstring_lines.append(f"    - {prop_name}: {prop_desc}")
+                                    docstring_lines.append(
+                                        f"    - {prop_name}: {prop_desc}"
+                                    )
                                 break
             except Exception:
-                docstring_lines.append("    (See API documentation for filterable fields)")
-            
+                docstring_lines.append(
+                    "    (See API documentation for filterable fields)"
+                )
+
             docstring_lines.append("")
             docstring_lines.append("Filter Syntax:")
-            docstring_lines.append("    Operators: EQ, NE, GT, GE, LT, LE, CONTAINS, IN, NOT_IN")
+            docstring_lines.append(
+                "    Operators: EQ, NE, GT, GE, LT, LE, CONTAINS, IN, NOT_IN"
+            )
             docstring_lines.append("    Combine: AND, OR")
-            docstring_lines.append("    Example: \"name CONTAINS 'prod' AND status EQ 'RUNNING'\"")
-        
+            docstring_lines.append(
+                "    Example: \"name CONTAINS 'prod' AND status EQ 'RUNNING'\""
+            )
+
         # Example for this action (include both required and key params)
         docstring_lines.append("")
         docstring_lines.append("Example:")
         example_params = [f"action='{action_name}'"]
         for param, info in all_params.items():
-            if action_name in info["required_for"] or action_name in info.get("key_for", []):
+            if action_name in info["required_for"] or action_name in info.get(
+                "key_for", []
+            ):
                 if param.endswith("_id"):
-                    example_params.append(f"{param}='example-{param.replace('_id', '')}-123'")
+                    example_params.append(
+                        f"{param}='example-{param.replace('_id', '')}-123'"
+                    )
                 elif param == "filter_expression":
-                    example_params.append(f"filter_expression=\"name CONTAINS 'test'\"")
+                    example_params.append("filter_expression=\"name CONTAINS 'test'\"")
                 else:
                     example_params.append(f"{param}=...")
         docstring_lines.append(f"    >>> {tool_name}({', '.join(example_params)})")
@@ -998,7 +1091,9 @@ def _generate_unified_tool(tool_name: str, apis: list, api_spec: dict) -> str:
     docstring_lines.append("=" * 70)
     docstring_lines.append("")
     docstring_lines.append("Args:")
-    docstring_lines.append(f"    action (str): The operation to perform. One of: {', '.join(actions_list)}")
+    docstring_lines.append(
+        f"    action (str): The operation to perform. One of: {', '.join(actions_list)}"
+    )
 
     # Separate params into general vs database-type-specific groups
     general_params = {}
@@ -1016,7 +1111,7 @@ def _generate_unified_tool(tool_name: str, apis: list, api_spec: dict) -> str:
             req_note = f"Required for: {', '.join(required_actions)}"
         else:
             req_note = "Optional for all actions"
-        desc = param_info['description']
+        desc = param_info["description"]
         if len(desc) > 80:
             desc = desc[:77] + "..."
         return [
@@ -1039,29 +1134,37 @@ def _generate_unified_tool(tool_name: str, apis: list, api_spec: dict) -> str:
         "postgres": "Postgres-specific parameters",
     }
     for subcommand, params in sorted(typed_params.items()):
-        group_label = subcommand_group_labels.get(subcommand, f"{subcommand}-specific parameters")
+        group_label = subcommand_group_labels.get(
+            subcommand, f"{subcommand}-specific parameters"
+        )
         docstring_lines.append("")
-        docstring_lines.append(f"  -- {group_label} (SKIP if not provisioning {subcommand}) --")
+        docstring_lines.append(
+            f"  -- {group_label} (SKIP if not provisioning {subcommand}) --"
+        )
         for param_name, param_info in params.items():
             docstring_lines.extend(_format_param_line(param_name, param_info))
-    
+
     docstring_lines.append("")
     docstring_lines.append("Returns:")
-    docstring_lines.append("    Dict[str, Any]: The API response containing operation results")
+    docstring_lines.append(
+        "    Dict[str, Any]: The API response containing operation results"
+    )
     docstring_lines.append("")
     docstring_lines.append("Raises:")
-    docstring_lines.append("    Returns error dict if required parameters are missing for the action")
-    
+    docstring_lines.append(
+        "    Returns error dict if required parameters are missing for the action"
+    )
+
     docstring = '    """\n'
     for line in docstring_lines:
         docstring += f"    {line}\n"
     docstring += '    """\n'
-    
+
     func_code += docstring
-    
+
     # Build function body with action routing
     func_code += "    # Route to appropriate API based on action\n"
-    
+
     first = True
     for action_name, details in action_details.items():
         if first:
@@ -1069,32 +1172,37 @@ def _generate_unified_tool(tool_name: str, apis: list, api_spec: dict) -> str:
             first = False
         else:
             func_code += f"    elif action == '{action_name}':\n"
-        
+
         # Build endpoint with path parameters
         path = details["path"]
         path_params = details["path_params"]
-        
+
         if path_params:
             # Check required parameters
             for orig, snake in path_params:
                 func_code += f"        if {snake} is None:\n"
                 func_code += f"            return {{'error': 'Missing required parameter: {snake} for action {action_name}'}}\n"
-            
+
             endpoint_expr = f"f'{path}'"
             for orig, snake in path_params:
-                endpoint_expr = endpoint_expr.replace("{" + orig + "}", "{" + snake + "}")
+                endpoint_expr = endpoint_expr.replace(
+                    "{" + orig + "}", "{" + snake + "}"
+                )
             func_code += f"        endpoint = {endpoint_expr}\n"
             endpoint_var = "endpoint"
         else:
             endpoint_var = f"'{path}'"
-        
+
         # Build params dict
         func_code += "        params = build_params("
         # Add query params that are relevant to this action
-        query_params = [p for p, info in all_params.items()
-                       if action_name in info["required_for"]
-                       and not p.endswith("_id")
-                       and p != "filter_expression"]
+        query_params = [
+            p
+            for p, info in all_params.items()
+            if action_name in info["required_for"]
+            and not p.endswith("_id")
+            and p != "filter_expression"
+        ]
         if query_params:
             func_code += ", ".join([f"{p}={p}" for p in query_params])
         func_code += ")\n"
@@ -1102,10 +1210,10 @@ def _generate_unified_tool(tool_name: str, apis: list, api_spec: dict) -> str:
         # Build request body BEFORE confirmation check so the review payload
         # can surface the exact values that will be sent to DCT.
         method = details["method"]
-        func_code += f"        _ctx = {{k: v for k, v in locals().items() if v is not None and not k.startswith('_')}}\n"
+        func_code += "        _ctx = {k: v for k, v in locals().items() if v is not None and not k.startswith('_')}\n"
         func_code += f"        conf = check_confirmation('{method}', {endpoint_var}, action, '{tool_name}', confirmed or False, context=_ctx)\n"
-        func_code += f"        if conf:\n"
-        func_code += f"            return conf\n"
+        func_code += "        if conf:\n"
+        func_code += "            return conf\n"
 
         # Handle request body
         body_var = None
@@ -1115,10 +1223,9 @@ def _generate_unified_tool(tool_name: str, apis: list, api_spec: dict) -> str:
         elif method in ["POST", "PUT", "PATCH"]:
             body_params = details.get("body_params", [])
             if body_params:
-                body_items = ", ".join([
-                    f"'{orig}': {snake}"
-                    for orig, snake, is_json in body_params
-                ])
+                body_items = ", ".join(
+                    [f"'{orig}': {snake}" for orig, snake, is_json in body_params]
+                )
                 body_param_names = {snake for _, snake, _ in body_params}
                 if "environment_user_id" in body_param_names:
                     func_code += "        if not environment_user_id:\n"
@@ -1133,12 +1240,12 @@ def _generate_unified_tool(tool_name: str, apis: list, api_spec: dict) -> str:
             func_code += f"        return await make_api_request('{method}', {endpoint_var}, params=params, json_body=body if body else None)\n"
         else:
             func_code += f"        return await make_api_request('{method}', {endpoint_var}, params=params)\n"
-    
+
     # Add else clause for unknown action
     func_code += "    else:\n"
     func_code += f"        return {{'error': f'Unknown action: {{action}}. Valid actions: {', '.join(actions_list)}'}}\n"
     func_code += "\n"
-    
+
     return func_code
 
 

--- a/tests/test_tool_factory_hooks.py
+++ b/tests/test_tool_factory_hooks.py
@@ -1,7 +1,5 @@
 """Unit tests for hook-key normalization in tool_factory (DLPXECO-13799)."""
 
-import pytest
-
 from dct_mcp_server.tools.core.tool_factory import (
     _VALID_HOOK_TYPES,
     _camel_to_snake,
@@ -34,7 +32,11 @@ def test_normalize_hooks_mixed_keys():
     }
     err = _normalize_hooks_in_body(body)
     assert err is None
-    assert set(body["hooks"].keys()) == {"configure_clone", "pre_refresh", "post_snapshot"}
+    assert set(body["hooks"].keys()) == {
+        "configure_clone",
+        "pre_refresh",
+        "post_snapshot",
+    }
     assert body["hooks"]["configure_clone"] == [{"name": "a"}]
     assert body["hooks"]["pre_refresh"] == [{"name": "b"}]
     assert body["hooks"]["post_snapshot"] == [{"name": "c"}]


### PR DESCRIPTION
## Summary

Implements **HG1** of the S2 AI-Maturity epic (DLPXECO-14003): a GitHub Actions CI gate with enforced coverage, lint, and format checks for this public repo. This PR is the complete HG1 *code* deliverable (folded together rather than split across multiple PRs).

Ticket: **DLPXECO-14016**

## What's in this PR

### CI workflow — `.github/workflows/ci.yml`
Triggers on `push` + `pull_request` to `main`. Three jobs, **first-party actions only, zero secrets** (unit tests are httpx-mocked — no live DCT):

| Job | What | Blocking? |
|-----|------|-----------|
| `lint (ruff check + format)` | `ruff check` (flake8-equivalent) + `ruff format --check` (black-equivalent), ruff pinned `0.15.17` | **Yes** |
| `test + coverage` | `pytest --cov --cov-fail-under=4`, **Python 3.11 + 3.12 matrix**, per-leg coverage artifacts | **Yes** |
| `build (sdist + wheel)` | `python -m build` | **Yes** |

### Lint/format standardized on ruff
- `ruff` replaces **flake8 + black** with one tool — run identically in CI and in `.pre-commit-config.yaml` (local pre-commit hooks).
- `[tool.ruff]` config in `pyproject.toml` (line-length, `target-version=py311`, `per-file-ignores` for `__init__.py` re-export hubs).
- One-time `ruff format .` pass across the codebase (38 files) so the format gate is green.

### Coverage visibility & docs
- README coverage badge (static shields.io; ~5% until DLPXECO-14014 / PR #92 lands more tests).
- `CONTRIBUTING.md` documents the current floor (`--cov-fail-under=4`), the **ratchet plan to 80%**, and the rule that ratchet authors bump both `ci.yml` and `CONTRIBUTING.md`.

### Bug fix surfaced by the new lint gate
The F821 (undefined-name) check caught a **latent `NameError`** in `misc_endpoints_tool.py`: 7 handlers referenced undefined `environment_user_ref` / `environment_user`. Removed the dead fallback blocks (crash path → graceful no-op). Tracked as **DLPXECO-14211** for the open question of whether those were meant to be real parameters.

## Testing
- `ruff check .` → All checks passed; `ruff format --check .` → clean (local, ruff 0.15.17).
- `pytest` → 12/12 pass on Python 3.11; CI runs the full 3.11 + 3.12 matrix.
- All four CI jobs green on this branch (lint now blocking).

## Maps to acceptance criteria (DLPXECO-14016)
- **AC-1** lint/test/build run & report — ✅
- **AC-2 / AC-3** failing test / coverage drop blocks merge — ⚠️ **requires repo admin** to add `test + coverage` as a required status check in `main` branch protection (cannot be set from the workflow file)
- **AC-4** coverage badge — ✅
- **AC-5** CONTRIBUTING threshold + ratchet doc — ✅

## ⚠️ Reviewer notes
- **Large diff:** the 38-file `ruff format` pass dominates the diff; the substantive changes are `ci.yml`, `pyproject.toml`, `CONTRIBUTING.md`, `README.md`, `.pre-commit-config.yaml`, and the `misc_endpoints_tool.py` bug fix.
- **One admin step remains** to fully close HG1: wire the required status check (branch protection). That is intentionally out of code scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
