### PR TITLE
DLPXECO-14017 Align CONTRIBUTING AC threshold to story points >=3

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -27,7 +27,7 @@ We appreciate your contribution and patience during this process!
 
 ## Acceptance Criteria Format
 
-All non-trivial stories and tasks (story points ≥ 2) must include at least one acceptance criterion written as a testable Given/When/Then assertion. Acceptance criteria belong both in the Jira ticket description and in the `## Acceptance Criteria (test assertions)` section of the GitHub PR template.
+All non-trivial stories and tasks (story points ≥ 3) must include at least one acceptance criterion written as a testable Given/When/Then assertion — this matches the Jira automation rule that blocks such tickets from leaving "To Do" without an acceptance-criteria section. Acceptance criteria belong both in the Jira ticket description and in the `## Acceptance Criteria (test assertions)` section of the GitHub PR template.
 
 **Format**:
 


### PR DESCRIPTION
## Summary

Small follow-up to #99 (DLPXECO-14017, HG2). The merged CONTRIBUTING.md documents acceptance criteria as required at **story points ≥ 2**, but HG2's Jira automation rule (the enforcement half) blocks at **≥ 3**. This aligns the doc to the enforced threshold so there's no "doc says must / rule doesn't block" gap, and adds a clause noting the doc mirrors the automation rule.

One-line doc change, no code.

## Testing
- ruff/test/build CI runs via `ci.yml` (docs-only, no Python changed).
