### PR TITLE
DLPXECO-14248 Ecosystem-MCP: Standardized object model for OpenAPI spec (request bodies, responses, domain objects)

### DIFF
--- a/src/dct_mcp_server/tools/core/dynamic.py
+++ b/src/dct_mcp_server/tools/core/dynamic.py
@@ -24,11 +24,9 @@ from dct_mcp_server.core.exceptions import DCTClientError
 from dct_mcp_server.core.logging import get_logger
 from dct_mcp_server.tools.core.confirmation_resolver import check_confirmation
 from dct_mcp_server.tools.core.spec_cache import get_cached_spec
+from dct_mcp_server.tools.core.spec_model import OpenAPISpec, RequestBody
 
 logger = get_logger(__name__)
-
-# Maximum $ref resolution depth to prevent infinite recursion on circular schemas
-_MAX_REF_DEPTH = 10
 
 # Pagination hard cap
 _MAX_PAGE_SIZE = 50
@@ -76,6 +74,16 @@ def _get_spec(app: FastMCP) -> dict[str, Any] | None:
     spec_cache.load_and_cache_spec(); discovery/execute read it here.
     """
     return get_cached_spec()
+
+
+def _get_spec_model(app: FastMCP) -> OpenAPISpec | None:
+    """Return the cached spec wrapped in the shared :class:`OpenAPISpec` model.
+
+    All structural traversal ($ref/allOf resolution, path-template matching,
+    request-body flattening) flows through this object rather than ad-hoc dict
+    walking; see tools/core/spec_model.py.
+    """
+    return OpenAPISpec.wrap(get_cached_spec())
 
 
 def _make_discovery_fn(app: FastMCP):
@@ -154,10 +162,9 @@ def _make_discovery_fn(app: FastMCP):
                     "message": "'operation_method' is required for get_operation_schema",
                 }
             return _action_get_operation_schema(
-                paths_map=paths_map,
+                model=OpenAPISpec.wrap(spec),
                 path=path,
                 operation_method=operation_method.upper(),
-                spec=spec,
             )
 
         return {
@@ -219,7 +226,7 @@ def _make_execute_fn(app: FastMCP, dct_client: Any):
             }
 
         method_upper = method.upper()
-        paths_map: dict[str, Any] = spec.get("paths", {}) or {}
+        model = OpenAPISpec.wrap(spec)
 
         # ---------------------------------------------------------------- #
         # Step 1 — Resolve path parameters
@@ -241,14 +248,12 @@ def _make_execute_fn(app: FastMCP, dct_client: Any):
         # ---------------------------------------------------------------- #
         # Step 2 — Look up operation in spec
         # ---------------------------------------------------------------- #
-        # Try to find by the resolved path first, then by the template path
-        path_item = _find_path_item(paths_map, resolved_path) or _find_path_item(
-            paths_map, path
-        )
+        # Try the resolved path first, then the template path, then without a
+        # leading /dct/v3 prefix in case the caller included it.
+        path_item = model.find_path_item(resolved_path) or model.find_path_item(path)
         if path_item is None:
-            # Also try without leading /dct/v3 prefix in case caller included it
             stripped = re.sub(r"^/dct/v3", "", resolved_path)
-            path_item = _find_path_item(paths_map, stripped)
+            path_item = model.find_path_item(stripped)
 
         if path_item is None:
             return {
@@ -285,7 +290,7 @@ def _make_execute_fn(app: FastMCP, dct_client: Any):
             query_params or {},
             body,
             resolved_path=resolved_path,
-            spec=spec,
+            model=model,
         )
         if validation_error:
             return validation_error
@@ -463,19 +468,29 @@ def _action_list_operations(
 
 
 def _action_get_operation_schema(
-    paths_map: dict[str, Any],
+    model: OpenAPISpec | None,
     path: str,
     operation_method: str,
-    spec: dict[str, Any],
 ) -> dict[str, Any]:
-    """Return the fully-resolved schema for a specific operation."""
+    """Return the fully-resolved schema for a specific operation.
+
+    All $ref resolution and request-body flattening is delegated to the shared
+    :class:`OpenAPISpec` model (tools/core/spec_model.py).
+    """
+    if model is None:
+        return {
+            "status": "error",
+            "code": "SPEC_NOT_LOADED",
+            "message": "OpenAPI spec is not loaded. Server may still be starting up.",
+        }
+
     # Support "POST /vdbs/{vdbId}/delete" format in path argument
     if " " in path:
         parts = path.split(" ", 1)
         operation_method = parts[0].upper()
         path = parts[1].strip()
 
-    path_item = _find_path_item(paths_map, path)
+    path_item = model.find_path_item(path)
     if path_item is None:
         return {
             "status": "error",
@@ -486,8 +501,7 @@ def _action_get_operation_schema(
             ),
         }
 
-    op = path_item.get(operation_method.lower())
-    if op is None:
+    if path_item.get(operation_method.lower()) is None:
         available = [
             m.upper()
             for m in path_item
@@ -502,42 +516,36 @@ def _action_get_operation_schema(
             ),
         }
 
-    if not isinstance(op, dict):
+    op = model.operation_at(path, operation_method)
+    if op is None:
         return {
             "status": "error",
             "code": "SCHEMA_PARSE_ERROR",
             "message": f"Unexpected operation format for {operation_method} {path}",
         }
 
+    schema_truncated = False
+
     # Resolve $ref in parameters
     parameters: list[dict] = []
-    schema_truncated = False
-    for param in op.get("parameters", []) or []:
-        resolved, truncated = _resolve_refs(param, spec, depth=0, visited=frozenset())
-        if truncated:
-            schema_truncated = True
+    for param in op.parameters:
+        resolved, truncated = model.resolve_refs(param.raw)
+        schema_truncated = schema_truncated or truncated
         parameters.append(resolved)
 
     # Resolve $ref in requestBody → flatten to field list
     request_body_fields: list[dict] = []
-    request_body = op.get("requestBody", {}) or {}
-    if request_body:
-        resolved_rb, truncated = _resolve_refs(
-            request_body, spec, depth=0, visited=frozenset()
-        )
-        if truncated:
-            schema_truncated = True
-        request_body_fields = _flatten_request_body(resolved_rb)
+    if op.request_body is not None:
+        _, truncated = model.resolve_refs(op.request_body.raw)
+        schema_truncated = schema_truncated or truncated
+        request_body_fields = op.request_body.fields()
 
     # Resolve $ref in responses
     responses: dict = {}
-    for status_code, resp_obj in (op.get("responses", {}) or {}).items():
-        resolved_resp, truncated = _resolve_refs(
-            resp_obj, spec, depth=0, visited=frozenset()
-        )
-        if truncated:
-            schema_truncated = True
-        responses[str(status_code)] = resolved_resp
+    for status_code, response in op.responses.items():
+        resolved_resp, truncated = model.resolve_refs(response.raw)
+        schema_truncated = schema_truncated or truncated
+        responses[status_code] = resolved_resp
 
     # Confirmation annotation
     conf = check_confirmation(operation_method.upper(), path)
@@ -545,9 +553,9 @@ def _action_get_operation_schema(
     result = {
         "path": path,
         "method": operation_method.upper(),
-        "operationId": op.get("operationId", ""),
-        "summary": op.get("summary", ""),
-        "description": op.get("description", ""),
+        "operationId": op.operation_id,
+        "summary": op.summary,
+        "description": op.description,
         "parameters": parameters,
         "request_body_fields": request_body_fields,
         "responses": responses,
@@ -586,39 +594,13 @@ def _substitute_path_params(
     return resolved, missing
 
 
-def _find_path_item(paths_map: dict[str, Any], path: str) -> dict[str, Any] | None:
-    """
-    Find the path item in the spec for the given resolved path.
-
-    Tries exact match first, then pattern match (treating {paramName} segments
-    in spec paths as wildcards).
-    """
-    # Exact match
-    if path in paths_map:
-        return paths_map[path]
-
-    # Pattern match: compare resolved path against spec path templates
-    path_segments = path.split("/")
-    for spec_path, item in paths_map.items():
-        spec_segments = spec_path.split("/")
-        if len(spec_segments) != len(path_segments):
-            continue
-        if all(
-            sp == rp or (sp.startswith("{") and sp.endswith("}"))
-            for sp, rp in zip(spec_segments, path_segments)
-        ):
-            return item
-
-    return None
-
-
 def _validate_required_params(
     operation: dict[str, Any],
     path_params: dict[str, Any],
     query_params: dict[str, Any],
     body: dict[str, Any] | None,
     resolved_path: str = "",
-    spec: dict[str, Any] | None = None,
+    model: OpenAPISpec | None = None,
 ) -> dict[str, Any] | None:
     """
     Check that all required parameters are present.
@@ -652,9 +634,13 @@ def _validate_required_params(
     request_body = operation.get("requestBody", {}) or {}
     if request_body.get("required", False) and body is None:
         missing.append("requestBody")
-    elif body is not None and request_body:
-        # Check individual required properties in the body schema
-        _check_required_body_fields(request_body, body, missing, spec)
+    elif body is not None and request_body and model is not None:
+        # Real DCT requestBody schemas are $ref pointers carrying no inline
+        # required key, so RequestBody resolves the pointer (via the shared
+        # OpenAPISpec model) before reading required field names.
+        for field in RequestBody(model, request_body).required_field_names():
+            if field not in body:
+                missing.append(f"body:{field}")
 
     if missing:
         return {
@@ -664,39 +650,6 @@ def _validate_required_params(
             "message": f"Required fields missing: {missing}",
         }
     return None
-
-
-def _check_required_body_fields(
-    request_body: dict[str, Any],
-    body: dict[str, Any],
-    missing: list[str],
-    spec: dict[str, Any] | None = None,
-) -> None:
-    """Extract required property names from requestBody.content schema and check against body.
-
-    Real DCT requestBody schemas are ``$ref`` pointers (e.g.
-    ``#/components/schemas/ProvisionVDBByTimestampParameters``) which carry no
-    inline ``required`` key, so the schema is resolved against the spec before
-    its required fields are read. Without this the check is a silent no-op for
-    every mutating endpoint.
-    """
-    try:
-        content = request_body.get("content", {}) or {}
-        for media_type, media_obj in content.items():
-            if not isinstance(media_obj, dict):
-                continue
-            schema = media_obj.get("schema", {}) or {}
-            if spec is not None:
-                schema, _ = _resolve_refs(schema, spec, depth=0, visited=frozenset())
-                if not isinstance(schema, dict):
-                    break
-            required_fields = schema.get("required", []) or []
-            for field in required_fields:
-                if field not in body:
-                    missing.append(f"body:{field}")
-            break  # Only check the first media type
-    except Exception:
-        pass  # Non-fatal — best-effort validation only
 
 
 def _classify_operation_type(method: str) -> str:
@@ -716,117 +669,5 @@ def _extract_http_status(error_message: str) -> int | None:
     return None
 
 
-# =========================================================================== #
-# $ref resolution helpers
-# =========================================================================== #
-
-
-def _resolve_refs(
-    obj: Any,
-    spec: dict[str, Any],
-    depth: int,
-    visited: frozenset[str],
-) -> tuple[Any, bool]:
-    """
-    Recursively resolve $ref pointers in obj up to _MAX_REF_DEPTH levels.
-
-    Returns:
-        (resolved_obj, schema_truncated)
-        schema_truncated is True if a cycle or depth limit was hit.
-    """
-    truncated = False
-
-    if depth > _MAX_REF_DEPTH:
-        return {"$ref_truncated": True, "reason": "max_depth_exceeded"}, True
-
-    if not isinstance(obj, dict):
-        return obj, False
-
-    if "$ref" in obj:
-        ref = obj["$ref"]
-        if ref in visited:
-            return {
-                "$ref_truncated": True,
-                "reason": "cycle_detected",
-                "ref": ref,
-            }, True
-        try:
-            resolved_target = _lookup_ref(ref, spec)
-            resolved, truncated = _resolve_refs(
-                resolved_target, spec, depth + 1, visited | {ref}
-            )
-            return resolved, truncated
-        except (KeyError, TypeError, ValueError) as exc:
-            return {
-                "status": "error",
-                "code": "SCHEMA_REF_NOT_FOUND",
-                "ref": ref,
-                "message": str(exc),
-            }, False
-
-    result: dict[str, Any] = {}
-    for k, v in obj.items():
-        if isinstance(v, dict):
-            resolved_v, child_truncated = _resolve_refs(v, spec, depth + 1, visited)
-            if child_truncated:
-                truncated = True
-            result[k] = resolved_v
-        elif isinstance(v, list):
-            resolved_list: list[Any] = []
-            for item in v:
-                resolved_item, child_truncated = _resolve_refs(
-                    item, spec, depth + 1, visited
-                )
-                if child_truncated:
-                    truncated = True
-                resolved_list.append(resolved_item)
-            result[k] = resolved_list
-        else:
-            result[k] = v
-
-    return result, truncated
-
-
-def _lookup_ref(ref: str, spec: dict[str, Any]) -> Any:
-    """Resolve a JSON $ref pointer string against the spec dict."""
-    if not ref.startswith("#/"):
-        raise ValueError(f"Unsupported $ref format: {ref}")
-    parts = ref.lstrip("#/").split("/")
-    node: Any = spec
-    for part in parts:
-        node = node[part]
-    return node
-
-
-def _flatten_request_body(
-    resolved_request_body: dict[str, Any],
-) -> list[dict[str, Any]]:
-    """
-    Flatten a resolved requestBody into a list of field descriptors.
-
-    Each entry: {name, required, type, description}
-    """
-    fields: list[dict[str, Any]] = []
-    try:
-        content = resolved_request_body.get("content", {}) or {}
-        for _media_type, media_obj in content.items():
-            if not isinstance(media_obj, dict):
-                continue
-            schema = media_obj.get("schema", {}) or {}
-            properties = schema.get("properties", {}) or {}
-            required_fields = set(schema.get("required", []) or [])
-            for name, prop in properties.items():
-                if not isinstance(prop, dict):
-                    continue
-                fields.append(
-                    {
-                        "name": name,
-                        "required": name in required_fields,
-                        "type": prop.get("type", "object"),
-                        "description": prop.get("description", ""),
-                    }
-                )
-            break  # Only process first media type
-    except Exception as exc:
-        logger.debug("Could not flatten requestBody fields: %s", exc)
-    return fields
+# $ref resolution, path-template matching, and request-body flattening now live
+# in the shared OpenAPISpec model (tools/core/spec_model.py).

--- a/src/dct_mcp_server/tools/core/endpoint_discovery.py
+++ b/src/dct_mcp_server/tools/core/endpoint_discovery.py
@@ -6,6 +6,7 @@ from difflib import SequenceMatcher
 from typing import Any
 
 from dct_mcp_server.core.logging import get_logger
+from dct_mcp_server.tools.core.spec_model import OpenAPISpec
 
 logger = get_logger(__name__)
 
@@ -33,46 +34,34 @@ def extract_hot_keywords_from_spec(spec: dict[str, Any]) -> frozenset[str]:
     Returns tokens that appear in at least 3 operations (genuinely domain-relevant).
     """
     freq: dict[str, int] = {}
-    paths = spec.get("paths", {}) or {}
-    for _path, item in paths.items():
-        if not isinstance(item, dict):
-            continue
-        for method, op in item.items():
-            if method.lower() not in {"get", "post", "put", "patch", "delete"}:
-                continue
-            if not isinstance(op, dict):
-                continue
-            for tag in op.get("tags", []):
-                for t in _TOKEN_RE.findall(tag.lower()):
-                    freq[t] = freq.get(t, 0) + 3
-            op_id = op.get("operationId", "") or ""
-            for t in re.findall(r"[a-z]+|[A-Z][a-z]*", op_id):
-                freq[t.lower()] = freq.get(t.lower(), 0) + 1
+    model = OpenAPISpec.wrap(spec)
+    if model is None:
+        return frozenset()
+    for op in model.operations():
+        for tag in op.tags:
+            for t in _TOKEN_RE.findall(tag.lower()):
+                freq[t] = freq.get(t, 0) + 3
+        for t in re.findall(r"[a-z]+|[A-Z][a-z]*", op.operation_id):
+            freq[t.lower()] = freq.get(t.lower(), 0) + 1
     return frozenset(k for k, v in freq.items() if v >= 3 and len(k) > 2)
 
 
 def build_corpus_from_spec(spec: dict[str, Any]) -> list[dict[str, Any]]:
-    """Flatten spec.paths into a list of candidate dicts."""
-    out: list[dict[str, Any]] = []
-    paths = spec.get("paths", {}) or {}
-    for path, item in paths.items():
-        if not isinstance(item, dict):
-            continue
-        for method, op in item.items():
-            if method.lower() not in {"get", "post", "put", "patch", "delete"}:
-                continue
-            if not isinstance(op, dict):
-                continue
-            out.append(
-                {
-                    "method": method.upper(),
-                    "path": path,
-                    "operation_id": op.get("operationId", "") or "",
-                    "summary": op.get("summary", "") or "",
-                    "description": op.get("description", "") or "",
-                    "tags": op.get("tags", []) or [],
-                }
-            )
+    """Flatten the spec's operations into a list of candidate dicts."""
+    model = OpenAPISpec.wrap(spec)
+    if model is None:
+        return []
+    return [
+        {
+            "method": op.method,
+            "path": op.path,
+            "operation_id": op.operation_id,
+            "summary": op.summary,
+            "description": op.description,
+            "tags": op.tags,
+        }
+        for op in model.operations()
+    ]
     return out
 
 

--- a/src/dct_mcp_server/tools/core/spec_model.py
+++ b/src/dct_mcp_server/tools/core/spec_model.py
@@ -1,0 +1,569 @@
+"""
+Standardized object model over the DCT OpenAPI spec.
+
+Historically every consumer of the spec (discovery/execute in ``dynamic.py``,
+the fuzzy ranker in ``endpoint_discovery.py``, and the two code generators in
+``toolsgenerator/driver.py`` and ``tools/core/tool_factory.py``) walked the raw
+nested ``dict`` by hand and re-implemented ``$ref`` resolution, ``allOf`` merging,
+request-body flattening, and path-template matching.  Those re-implementations
+drifted: cycle detection, depth limits, and truncation handling all differed.
+
+This module is the single source of truth for that structure.  It wraps the raw
+spec ``dict`` in lightweight, lazily-evaluated objects so consumers can ask for
+*operations*, *request bodies*, *responses*, and *domain objects* directly:
+
+    spec = OpenAPISpec.wrap(get_cached_spec())
+    op = spec.operation_at("/vdbs/{vdbId}", "GET")
+    for field in op.request_body.fields():
+        ...
+    dsource = spec.domain_object("DSource")   # -> DSource(SchemaObject)
+
+Design constraints (see DLPXECO-14248):
+
+* **Spec/metadata model, not data models.**  These classes describe the *shape*
+  of requests/responses/objects; they are never instantiated with live payloads.
+* **Generic wrapper + curated key objects.**  One generic :class:`SchemaObject`
+  covers all ~691 ``components/schemas``; :class:`DSource` and :class:`VDB` are
+  named subclasses for the two highest-value domain objects.
+* **Runtime wrappers over the cached spec.**  No build step; instances wrap the
+  already-cached dict and are memoized by object identity, so they stay in sync
+  with the live-downloaded spec.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Iterator
+
+from dct_mcp_server.core.logging import get_logger
+
+logger = get_logger(__name__)
+
+# HTTP methods that denote an operation on a path item (everything else in a
+# path item — "parameters", "summary", vendor extensions — is metadata).
+HTTP_METHODS: frozenset[str] = frozenset({"get", "post", "put", "patch", "delete"})
+
+# Default maximum $ref resolution depth, guarding against circular schemas.
+# Matches the historical _MAX_REF_DEPTH used by dynamic.py.
+DEFAULT_MAX_REF_DEPTH = 10
+
+
+# =========================================================================== #
+# Spec root
+# =========================================================================== #
+
+class OpenAPISpec:
+    """Wrapper around a parsed OpenAPI spec dict.
+
+    Owns the raw document and is the single home for ``$ref`` resolution.  Two
+    resolution styles are offered because consumers need different things:
+
+    * :meth:`resolve_pointer` — resolve one ``$ref`` string to its target node
+      (the single-level lookup the code generators use).
+    * :meth:`resolve_refs` — recursively inline every ``$ref`` in a subtree,
+      with cycle detection and a depth limit (what discovery's
+      ``get_operation_schema`` needs before handing a schema to the LLM).
+    """
+
+    __slots__ = ("raw", "_schema_object_cache")
+
+    # Identity-keyed cache of wrappers, so repeatedly wrapping the same cached
+    # spec dict (e.g. on every discovery/execute call) is free and downstream
+    # caches (schema objects, the discovery index) stay warm across calls.
+    _WRAPPER_CACHE: dict[int, "OpenAPISpec"] = {}
+
+    def __init__(self, raw: dict[str, Any]):
+        if not isinstance(raw, dict):
+            raise TypeError(f"OpenAPISpec expects a dict, got {type(raw).__name__}")
+        self.raw = raw
+        self._schema_object_cache: dict[str, SchemaObject] = {}
+
+    @classmethod
+    def wrap(cls, raw: dict[str, Any] | None) -> "OpenAPISpec | None":
+        """Return an ``OpenAPISpec`` for *raw*, memoized by object identity.
+
+        Returns ``None`` when *raw* is falsy so callers can treat "spec not
+        loaded yet" uniformly.  The cached spec dict is replaced (not mutated)
+        on reload, so keying by ``id(raw)`` is a safe invalidation signal.
+        """
+        if not raw:
+            return None
+        key = id(raw)
+        cached = cls._WRAPPER_CACHE.get(key)
+        if cached is not None and cached.raw is raw:
+            return cached
+        wrapper = cls(raw)
+        cls._WRAPPER_CACHE = {key: wrapper}  # only the current spec is useful
+        return wrapper
+
+    # ------------------------------------------------------------------ #
+    # Top-level accessors
+    # ------------------------------------------------------------------ #
+
+    @property
+    def paths(self) -> dict[str, Any]:
+        return self.raw.get("paths", {}) or {}
+
+    @property
+    def components(self) -> dict[str, Any]:
+        return self.raw.get("components", {}) or {}
+
+    @property
+    def schemas(self) -> dict[str, Any]:
+        return self.components.get("schemas", {}) or {}
+
+    # ------------------------------------------------------------------ #
+    # $ref resolution
+    # ------------------------------------------------------------------ #
+
+    def resolve_pointer(self, ref: str) -> Any:
+        """Resolve a single JSON ``$ref`` pointer like ``#/components/schemas/DSource``.
+
+        This is the single-level lookup historically duplicated as
+        ``resolve_ref`` (driver.py) and ``_resolve_ref`` (tool_factory.py).
+        Raises ``ValueError`` for unsupported (non-fragment) refs and
+        ``KeyError`` when the target is absent.
+        """
+        if not ref.startswith("#/"):
+            raise ValueError(f"Unsupported ref format: {ref}")
+        node: Any = self.raw
+        for part in ref.lstrip("#/").split("/"):
+            node = node[part]
+        return node
+
+    def resolve_refs(
+        self,
+        obj: Any,
+        *,
+        max_depth: int = DEFAULT_MAX_REF_DEPTH,
+        depth: int = 0,
+        visited: frozenset[str] = frozenset(),
+    ) -> tuple[Any, bool]:
+        """Recursively inline every ``$ref`` in *obj*.
+
+        Returns ``(resolved_obj, truncated)`` where *truncated* is ``True`` if a
+        cycle or the depth limit was hit.  Behaviour matches the former
+        ``dynamic.py._resolve_refs`` exactly, including the marker dicts emitted
+        for truncation / missing refs, so it is a drop-in replacement.
+        """
+        if depth > max_depth:
+            return {"$ref_truncated": True, "reason": "max_depth_exceeded"}, True
+
+        if not isinstance(obj, dict):
+            return obj, False
+
+        if "$ref" in obj:
+            ref = obj["$ref"]
+            if ref in visited:
+                return {"$ref_truncated": True, "reason": "cycle_detected", "ref": ref}, True
+            try:
+                target = self.resolve_pointer(ref)
+            except (KeyError, TypeError, ValueError) as exc:
+                return {
+                    "status": "error",
+                    "code": "SCHEMA_REF_NOT_FOUND",
+                    "ref": ref,
+                    "message": str(exc),
+                }, False
+            return self.resolve_refs(
+                target, max_depth=max_depth, depth=depth + 1, visited=visited | {ref}
+            )
+
+        truncated = False
+        result: dict[str, Any] = {}
+        for key, value in obj.items():
+            if isinstance(value, dict):
+                resolved_v, child_truncated = self.resolve_refs(
+                    value, max_depth=max_depth, depth=depth + 1, visited=visited
+                )
+                truncated = truncated or child_truncated
+                result[key] = resolved_v
+            elif isinstance(value, list):
+                resolved_list: list[Any] = []
+                for item in value:
+                    resolved_item, child_truncated = self.resolve_refs(
+                        item, max_depth=max_depth, depth=depth + 1, visited=visited
+                    )
+                    truncated = truncated or child_truncated
+                    resolved_list.append(resolved_item)
+                result[key] = resolved_list
+            else:
+                result[key] = value
+        return result, truncated
+
+    # ------------------------------------------------------------------ #
+    # Operations
+    # ------------------------------------------------------------------ #
+
+    def operations(self) -> Iterator["Operation"]:
+        """Yield an :class:`Operation` for every (path, HTTP method) in the spec."""
+        for path, item in self.paths.items():
+            if not isinstance(item, dict):
+                continue
+            for method, op in item.items():
+                if method.lower() not in HTTP_METHODS or not isinstance(op, dict):
+                    continue
+                yield Operation(self, path, method.upper(), op)
+
+    def find_path_item(self, path: str) -> dict[str, Any] | None:
+        """Return the path-item dict for *path*.
+
+        Tries an exact match first, then treats ``{paramName}`` segments in spec
+        paths as wildcards so a fully-resolved path (``/vdbs/vdb-123``) matches
+        its template (``/vdbs/{vdbId}``).  Centralizes the former
+        ``dynamic.py._find_path_item``.
+        """
+        paths = self.paths
+        if path in paths:
+            return paths[path]
+
+        target_segments = path.split("/")
+        for spec_path, item in paths.items():
+            spec_segments = spec_path.split("/")
+            if len(spec_segments) != len(target_segments):
+                continue
+            if all(
+                sp == tp or (sp.startswith("{") and sp.endswith("}"))
+                for sp, tp in zip(spec_segments, target_segments)
+            ):
+                return item
+        return None
+
+    def operation_at(self, path: str, method: str) -> "Operation | None":
+        """Return the :class:`Operation` for *path* + *method*, or ``None``."""
+        item = self.find_path_item(path)
+        if item is None:
+            return None
+        op = item.get(method.lower())
+        if not isinstance(op, dict):
+            return None
+        return Operation(self, path, method.upper(), op)
+
+    # ------------------------------------------------------------------ #
+    # Domain objects (components/schemas)
+    # ------------------------------------------------------------------ #
+
+    def schema_object(self, schema: dict[str, Any]) -> "SchemaObject":
+        """Wrap an inline schema dict in a :class:`SchemaObject`."""
+        return SchemaObject(self, schema)
+
+    def domain_object(self, name: str) -> "SchemaObject | None":
+        """Return the named ``components/schemas`` entry as a :class:`SchemaObject`.
+
+        Returns a curated subclass (:class:`DSource`, :class:`VDB`) when one is
+        registered for *name*, otherwise the generic :class:`SchemaObject`.
+        Returns ``None`` if the schema is absent.  Results are cached per spec.
+        """
+        if name in self._schema_object_cache:
+            return self._schema_object_cache[name]
+        raw_schema = self.schemas.get(name)
+        if raw_schema is None:
+            return None
+        cls = _CURATED_DOMAIN_OBJECTS.get(name, SchemaObject)
+        obj = cls(self, raw_schema, name=name)
+        self._schema_object_cache[name] = obj
+        return obj
+
+
+# =========================================================================== #
+# Operation
+# =========================================================================== #
+
+class Operation:
+    """A single API operation — one (path, HTTP method) pair."""
+
+    __slots__ = ("spec", "path", "method", "raw")
+
+    def __init__(self, spec: OpenAPISpec, path: str, method: str, raw: dict[str, Any]):
+        self.spec = spec
+        self.path = path
+        self.method = method.upper()
+        self.raw = raw
+
+    @property
+    def operation_id(self) -> str:
+        return self.raw.get("operationId", "") or ""
+
+    @property
+    def summary(self) -> str:
+        return self.raw.get("summary", "") or ""
+
+    @property
+    def description(self) -> str:
+        return self.raw.get("description", "") or ""
+
+    @property
+    def tags(self) -> list[str]:
+        return self.raw.get("tags", []) or []
+
+    @property
+    def parameters(self) -> list["Parameter"]:
+        return [
+            Parameter(self.spec, p)
+            for p in self.raw.get("parameters", []) or []
+            if isinstance(p, dict)
+        ]
+
+    @property
+    def request_body(self) -> "RequestBody | None":
+        rb = self.raw.get("requestBody")
+        if not rb:
+            return None
+        return RequestBody(self.spec, rb)
+
+    @property
+    def responses(self) -> dict[str, "Response"]:
+        return {
+            str(status): Response(self.spec, str(status), resp)
+            for status, resp in (self.raw.get("responses", {}) or {}).items()
+        }
+
+    @property
+    def path_param_names(self) -> list[str]:
+        """Names of ``{placeholder}`` path parameters declared in the path."""
+        return re.findall(r"\{([^}]+)\}", self.path)
+
+
+# =========================================================================== #
+# Parameter
+# =========================================================================== #
+
+class Parameter:
+    """A path/query/header parameter on an operation."""
+
+    __slots__ = ("spec", "raw")
+
+    def __init__(self, spec: OpenAPISpec, raw: dict[str, Any]):
+        self.spec = spec
+        self.raw = raw
+
+    @property
+    def name(self) -> str:
+        return self.raw.get("name", "") or ""
+
+    @property
+    def location(self) -> str:
+        """Where the parameter lives — the OpenAPI ``in`` value (path/query/...)."""
+        return self.raw.get("in", "") or ""
+
+    @property
+    def required(self) -> bool:
+        return bool(self.raw.get("required", False))
+
+    @property
+    def description(self) -> str:
+        return self.raw.get("description", "") or ""
+
+    @property
+    def schema(self) -> dict[str, Any]:
+        return self.raw.get("schema", {}) or {}
+
+
+# =========================================================================== #
+# RequestBody
+# =========================================================================== #
+
+class RequestBody:
+    """An operation's ``requestBody``.
+
+    Real DCT request bodies are ``$ref`` pointers to ``components/schemas``
+    carrying no inline ``required`` key, so :meth:`schema_object` resolves the
+    pointer before exposing properties — without it, required-field checks were
+    silent no-ops for every mutating endpoint.
+    """
+
+    __slots__ = ("spec", "raw")
+
+    def __init__(self, spec: OpenAPISpec, raw: dict[str, Any]):
+        self.spec = spec
+        self.raw = raw
+
+    @property
+    def required(self) -> bool:
+        return bool(self.raw.get("required", False))
+
+    @property
+    def content(self) -> dict[str, Any]:
+        return self.raw.get("content", {}) or {}
+
+    def _primary_schema_dict(self) -> dict[str, Any]:
+        """Raw schema of the first media type (DCT bodies are application/json)."""
+        for media_obj in self.content.values():
+            if isinstance(media_obj, dict):
+                return media_obj.get("schema", {}) or {}
+        return {}
+
+    def schema_object(self) -> "SchemaObject | None":
+        """The request body schema as a :class:`SchemaObject` (``$ref`` resolved)."""
+        schema = self._primary_schema_dict()
+        if not schema:
+            return None
+        return SchemaObject(self.spec, schema)
+
+    def required_field_names(self) -> list[str]:
+        """Top-level required field names of the (ref-resolved) body schema.
+
+        Used by execute's best-effort body validation.  Deliberately reads only
+        the resolved schema's top-level ``required`` list (not ``allOf``-merged
+        requireds) to preserve the historically lenient validation behaviour.
+        """
+        schema = self._primary_schema_dict()
+        if not schema:
+            return []
+        resolved, _ = self.spec.resolve_refs(schema)
+        if not isinstance(resolved, dict):
+            return []
+        return list(resolved.get("required", []) or [])
+
+    def fields(self) -> list[dict[str, Any]]:
+        """Flatten the body schema into ``{name, required, type, description}`` rows.
+
+        Replaces the former ``dynamic.py._flatten_request_body``.
+        """
+        obj = self.schema_object()
+        if obj is None:
+            return []
+        required = obj.required
+        out: list[dict[str, Any]] = []
+        for name, prop in obj.properties.items():
+            if not isinstance(prop, dict):
+                continue
+            out.append({
+                "name": name,
+                "required": name in required,
+                "type": prop.get("type", "object"),
+                "description": prop.get("description", "") or "",
+            })
+        return out
+
+
+# =========================================================================== #
+# Response
+# =========================================================================== #
+
+class Response:
+    """A single response entry keyed by status code."""
+
+    __slots__ = ("spec", "status_code", "raw")
+
+    def __init__(self, spec: OpenAPISpec, status_code: str, raw: dict[str, Any]):
+        self.spec = spec
+        self.status_code = status_code
+        self.raw = raw
+
+    @property
+    def description(self) -> str:
+        return self.raw.get("description", "") or ""
+
+    @property
+    def content(self) -> dict[str, Any]:
+        return self.raw.get("content", {}) or {}
+
+    def schema_object(self) -> "SchemaObject | None":
+        """The response payload schema as a :class:`SchemaObject` (``$ref`` resolved)."""
+        for media_obj in self.content.values():
+            if isinstance(media_obj, dict):
+                schema = media_obj.get("schema", {}) or {}
+                if schema:
+                    return SchemaObject(self.spec, schema)
+        return None
+
+
+# =========================================================================== #
+# SchemaObject (domain objects: dSource, VDB, request/response bodies, …)
+# =========================================================================== #
+
+class SchemaObject:
+    """A ``components/schemas`` entry or any inline schema.
+
+    Resolves a top-level ``$ref``, merges ``allOf`` composition, and distinguishes
+    *key properties* (action-specific) from large inherited base schemas — the
+    logic formerly living only in ``driver.py.resolve_schema_properties``.
+    """
+
+    __slots__ = ("spec", "raw", "name", "_resolved")
+
+    def __init__(self, spec: OpenAPISpec, raw: dict[str, Any], name: str | None = None):
+        self.spec = spec
+        self.raw = raw
+        self.name = name
+        self._resolved: tuple[dict[str, Any], list[str], set[str]] | None = None
+
+    def _resolve(self) -> tuple[dict[str, Any], list[str], set[str]]:
+        """Compute ``(properties, required, key_properties)`` once, then cache."""
+        if self._resolved is not None:
+            return self._resolved
+
+        schema = self.raw
+        if "$ref" in schema:
+            schema = self.spec.resolve_pointer(schema["$ref"])
+
+        if "allOf" in schema:
+            properties: dict[str, Any] = {}
+            required: list[str] = []
+            key_properties: set[str] = set()
+
+            for sub in schema["allOf"]:
+                is_ref = isinstance(sub, dict) and "$ref" in sub
+                if is_ref:
+                    sub = self.spec.resolve_pointer(sub["$ref"])
+                if not isinstance(sub, dict):
+                    continue
+
+                if "allOf" in sub:
+                    nested = SchemaObject(self.spec, sub)
+                    properties.update(nested.properties)
+                    required.extend(nested.required)
+                    # Base-schema key properties are intentionally not propagated.
+                else:
+                    props = sub.get("properties", {}) or {}
+                    properties.update(props)
+                    required.extend(sub.get("required", []) or [])
+                    # Inline objects and small $ref'd schemas (<=5 props) are
+                    # action-specific; large $ref'd schemas are inherited bases.
+                    if not is_ref or len(props) <= 5:
+                        key_properties.update(props.keys())
+
+            self._resolved = (properties, required, key_properties)
+        else:
+            props = schema.get("properties", {}) or {}
+            self._resolved = (props, schema.get("required", []) or [], set(props.keys()))
+
+        return self._resolved
+
+    @property
+    def properties(self) -> dict[str, Any]:
+        return self._resolve()[0]
+
+    @property
+    def required(self) -> list[str]:
+        return self._resolve()[1]
+
+    @property
+    def key_properties(self) -> set[str]:
+        """Property names from action-specific sub-schemas (not inherited bases)."""
+        return self._resolve()[2]
+
+
+# --------------------------------------------------------------------------- #
+# Curated domain objects
+# --------------------------------------------------------------------------- #
+
+class DSource(SchemaObject):
+    """The DCT ``DSource`` domain object (a linked/ingested source dataset)."""
+
+    SCHEMA_NAME = "DSource"
+
+
+class VDB(SchemaObject):
+    """The DCT ``VDB`` domain object (a provisioned virtual database)."""
+
+    SCHEMA_NAME = "VDB"
+
+
+# Registry consulted by OpenAPISpec.domain_object() to upgrade a generic
+# SchemaObject to a curated subclass.  Add high-value objects here only.
+_CURATED_DOMAIN_OBJECTS: dict[str, type[SchemaObject]] = {
+    DSource.SCHEMA_NAME: DSource,
+    VDB.SCHEMA_NAME: VDB,
+}

--- a/src/dct_mcp_server/tools/core/tool_factory.py
+++ b/src/dct_mcp_server/tools/core/tool_factory.py
@@ -25,6 +25,7 @@ from dct_mcp_server.config import (
 )
 from dct_mcp_server.config.config import get_dct_config
 from dct_mcp_server.core.decorators import log_tool_execution
+from dct_mcp_server.tools.core.spec_model import OpenAPISpec
 from .dynamic_confirmation import resolve_confirmation
 
 logger = logging.getLogger(__name__)
@@ -196,15 +197,12 @@ def clear_spec_cache():
 
 
 def _resolve_ref(ref: str, spec: Dict[str, Any]) -> Dict[str, Any]:
-    """Resolve a JSON $ref pointer in the OpenAPI spec."""
-    if not ref.startswith("#/"):
-        raise ValueError(f"Unsupported ref format: {ref}")
+    """Resolve a JSON $ref pointer in the OpenAPI spec.
 
-    path = ref.lstrip("#/").split("/")
-    node = spec
-    for part in path:
-        node = node[part]
-    return node
+    Thin wrapper over the shared OpenAPISpec model (tools/core/spec_model.py),
+    the single source of truth for $ref resolution.
+    """
+    return OpenAPISpec(spec).resolve_pointer(ref)
 
 
 def _get_python_type(schema_type: str) -> str:

--- a/src/dct_mcp_server/toolsgenerator/driver.py
+++ b/src/dct_mcp_server/toolsgenerator/driver.py
@@ -26,6 +26,7 @@ import logging
 import tempfile
 from dct_mcp_server.config.config import get_dct_config
 from dct_mcp_server.config.loader import TOOLSETS_DIR
+from dct_mcp_server.tools.core.spec_model import OpenAPISpec, SchemaObject
 
 # Get the absolute path of the project root
 project_root = os.path.abspath(
@@ -423,17 +424,11 @@ def resolve_ref(ref: str, root: dict):
     """
     Resolve a JSON pointer $ref like '#/components/schemas/DSource'
     inside a loaded OpenAPI YAML dict.
+
+    Thin wrapper over the shared OpenAPISpec model (tools/core/spec_model.py),
+    which is the single source of truth for $ref resolution.
     """
-    if not ref.startswith("#/"):
-        raise ValueError(f"Unsupported ref format: {ref}")
-
-    # Remove starting '#/' and split by "/"
-    path = ref.lstrip("#/").split("/")
-
-    node = root
-    for part in path:
-        node = node[part]
-    return node
+    return OpenAPISpec(root).resolve_pointer(ref)
 
 
 def resolve_schema_properties(schema: dict, api_spec: dict) -> tuple:
@@ -445,50 +440,12 @@ def resolve_schema_properties(schema: dict, api_spec: dict) -> tuple:
                key_properties contains property names from action-specific
                sub-schemas (inline objects and small $ref'd schemas), as
                opposed to large inherited base schemas.
+
+    Delegates to the shared SchemaObject (tools/core/spec_model.py); the allOf /
+    key-property logic lives there now so every consumer agrees.
     """
-    # Resolve top-level $ref if present
-    if "$ref" in schema:
-        schema = resolve_ref(schema["$ref"], api_spec)
-
-    # Handle allOf composition
-    if "allOf" in schema:
-        combined_properties = {}
-        combined_required = []
-        key_properties = set()
-
-        for sub_schema in schema["allOf"]:
-            is_ref = "$ref" in sub_schema
-
-            # Resolve $ref in sub-schema
-            if is_ref:
-                sub_schema = resolve_ref(sub_schema["$ref"], api_spec)
-
-            # Recursively handle nested allOf
-            if "allOf" in sub_schema:
-                nested_props, nested_required, nested_key = resolve_schema_properties(
-                    sub_schema, api_spec
-                )
-                combined_properties.update(nested_props)
-                combined_required.extend(nested_required)
-                # Don't propagate key_properties from base schemas
-            else:
-                props = sub_schema.get("properties", {})
-                combined_properties.update(props)
-                combined_required.extend(sub_schema.get("required", []))
-
-                # Determine if this sub-schema is action-specific or a large base.
-                # Inline objects (not $ref) and small $ref'd schemas (<=5 props)
-                # are considered action-specific — their properties are "key".
-                # Large $ref'd schemas (e.g. BaseProvisionVDBParameters with 60+
-                # props via nested allOf) are inherited base schemas.
-                if not is_ref or len(props) <= 5:
-                    key_properties.update(props.keys())
-
-        return combined_properties, combined_required, key_properties
-
-    # Direct properties (no allOf) — all are key
-    props = schema.get("properties", {})
-    return props, schema.get("required", []), set(props.keys())
+    obj = SchemaObject(OpenAPISpec(api_spec), schema)
+    return obj.properties, obj.required, obj.key_properties
 
 
 def generate_tools_from_openapi():

--- a/tests/test_spec_model.py
+++ b/tests/test_spec_model.py
@@ -1,0 +1,232 @@
+"""Tests for the shared OpenAPI object model (tools/core/spec_model.py).
+
+These exercise the centralized $ref/allOf resolution, path-template matching,
+request-body flattening, and curated domain objects that discovery/execute and
+the code generators now all delegate to.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from dct_mcp_server.tools.core.spec_model import (
+    DSource,
+    OpenAPISpec,
+    RequestBody,
+    SchemaObject,
+    VDB,
+)
+
+
+@pytest.fixture
+def spec_dict() -> dict:
+    """A small but representative spec: $ref, allOf, cycle, and path templates."""
+    return {
+        "openapi": "3.0.0",
+        "paths": {
+            "/vdbs/{vdbId}": {
+                "get": {
+                    "operationId": "get_vdb_by_id",
+                    "summary": "Get a VDB",
+                    "tags": ["VDBs"],
+                    "parameters": [
+                        {"name": "vdbId", "in": "path", "required": True,
+                         "schema": {"type": "string"}},
+                    ],
+                    "responses": {
+                        "200": {
+                            "description": "ok",
+                            "content": {"application/json": {
+                                "schema": {"$ref": "#/components/schemas/VDB"}}},
+                        }
+                    },
+                },
+            },
+            "/dsources/link": {
+                "post": {
+                    "operationId": "link_dsource",
+                    "summary": "Link a dSource",
+                    "tags": ["dSources"],
+                    "requestBody": {
+                        "required": True,
+                        "content": {"application/json": {
+                            "schema": {"$ref": "#/components/schemas/LinkParams"}}},
+                    },
+                    "responses": {"200": {"description": "ok"}},
+                },
+            },
+        },
+        "components": {
+            "schemas": {
+                "VDB": {
+                    "type": "object",
+                    "properties": {"id": {"type": "string"}, "name": {"type": "string"}},
+                },
+                "DSource": {
+                    "type": "object",
+                    "properties": {"id": {"type": "string"}},
+                },
+                # >5 properties so it counts as a large inherited base schema
+                # (its props are excluded from key_properties).
+                "Base": {
+                    "type": "object",
+                    "properties": {
+                        "a": {"type": "string"}, "b": {"type": "string"},
+                        "c": {"type": "string"}, "d": {"type": "string"},
+                        "e": {"type": "string"}, "f": {"type": "string"},
+                    },
+                    "required": ["a"],
+                },
+                "LinkParams": {
+                    "required": ["source_id"],
+                    "allOf": [
+                        {"$ref": "#/components/schemas/Base"},
+                        {"type": "object",
+                         "properties": {"source_id": {"type": "string",
+                                                      "description": "the source"}},
+                         "required": ["source_id"]},
+                    ],
+                },
+                # Self-referential schema to exercise cycle detection.
+                "Node": {
+                    "type": "object",
+                    "properties": {"child": {"$ref": "#/components/schemas/Node"}},
+                },
+            }
+        },
+    }
+
+
+# --------------------------------------------------------------------------- #
+# OpenAPISpec
+# --------------------------------------------------------------------------- #
+
+def test_wrap_memoizes_by_identity(spec_dict):
+    a = OpenAPISpec.wrap(spec_dict)
+    b = OpenAPISpec.wrap(spec_dict)
+    assert a is b
+    assert OpenAPISpec.wrap(None) is None
+
+
+def test_resolve_pointer(spec_dict):
+    spec = OpenAPISpec(spec_dict)
+    assert spec.resolve_pointer("#/components/schemas/VDB")["type"] == "object"
+    with pytest.raises(ValueError):
+        spec.resolve_pointer("components/schemas/VDB")  # missing leading #/
+    with pytest.raises(KeyError):
+        spec.resolve_pointer("#/components/schemas/Nope")
+
+
+def test_resolve_refs_inlines_and_flags_cycle(spec_dict):
+    spec = OpenAPISpec(spec_dict)
+    resolved, truncated = spec.resolve_refs({"$ref": "#/components/schemas/VDB"})
+    assert resolved["properties"]["id"]["type"] == "string"
+    assert truncated is False
+
+    # The self-referential Node schema must terminate and flag truncation.
+    resolved, truncated = spec.resolve_refs({"$ref": "#/components/schemas/Node"})
+    assert truncated is True
+
+
+def test_resolve_refs_depth_limit(spec_dict):
+    spec = OpenAPISpec(spec_dict)
+    nested = {"a": {"b": {"c": {"d": {"e": "deep"}}}}}
+    _, truncated = spec.resolve_refs(nested, max_depth=2)
+    assert truncated is True
+
+
+def test_resolve_refs_missing_ref_returns_error_marker(spec_dict):
+    spec = OpenAPISpec(spec_dict)
+    resolved, truncated = spec.resolve_refs({"$ref": "#/components/schemas/Ghost"})
+    assert resolved["code"] == "SCHEMA_REF_NOT_FOUND"
+    assert truncated is False
+
+
+# --------------------------------------------------------------------------- #
+# Operations & path matching
+# --------------------------------------------------------------------------- #
+
+def test_operations_iterates_all(spec_dict):
+    spec = OpenAPISpec(spec_dict)
+    ops = {(o.method, o.path) for o in spec.operations()}
+    assert ("GET", "/vdbs/{vdbId}") in ops
+    assert ("POST", "/dsources/link") in ops
+
+
+def test_find_path_item_exact_and_wildcard(spec_dict):
+    spec = OpenAPISpec(spec_dict)
+    assert spec.find_path_item("/vdbs/{vdbId}") is not None
+    # A fully-resolved path matches its template.
+    assert spec.find_path_item("/vdbs/vdb-123") is not None
+    assert spec.find_path_item("/vdbs/vdb-123/extra") is None
+
+
+def test_operation_at(spec_dict):
+    spec = OpenAPISpec(spec_dict)
+    # A resolved path matches its template; the Operation carries the queried
+    # path (matching the historical get_operation_schema behaviour).
+    op = spec.operation_at("/vdbs/vdb-9", "get")
+    assert op is not None
+    assert op.operation_id == "get_vdb_by_id"
+    assert op.tags == ["VDBs"]
+    assert [p.name for p in op.parameters] == ["vdbId"]
+    assert spec.operation_at("/vdbs/vdb-9", "delete") is None
+
+    # Querying with the template path exposes the {placeholder} names.
+    op_tmpl = spec.operation_at("/vdbs/{vdbId}", "get")
+    assert op_tmpl.path_param_names == ["vdbId"]
+
+
+# --------------------------------------------------------------------------- #
+# RequestBody
+# --------------------------------------------------------------------------- #
+
+def test_request_body_fields_merge_allof(spec_dict):
+    spec = OpenAPISpec(spec_dict)
+    op = spec.operation_at("/dsources/link", "post")
+    rb = op.request_body
+    assert isinstance(rb, RequestBody)
+    assert rb.required is True
+    names = {f["name"] for f in rb.fields()}
+    # allOf-merged: base props (a, b) plus the action-specific source_id.
+    assert {"a", "b", "source_id"} <= names
+    src = next(f for f in rb.fields() if f["name"] == "source_id")
+    assert src["required"] is True
+    assert src["description"] == "the source"
+
+
+def test_request_body_required_field_names_top_level_only(spec_dict):
+    spec = OpenAPISpec(spec_dict)
+    op = spec.operation_at("/dsources/link", "post")
+    # Execute validation reads only the resolved schema's top-level required
+    # (lenient behaviour preserved): source_id, not the allOf-nested "a".
+    assert op.request_body.required_field_names() == ["source_id"]
+
+
+# --------------------------------------------------------------------------- #
+# SchemaObject & curated domain objects
+# --------------------------------------------------------------------------- #
+
+def test_schema_object_allof_key_properties(spec_dict):
+    spec = OpenAPISpec(spec_dict)
+    obj = SchemaObject(spec, {"$ref": "#/components/schemas/LinkParams"})
+    assert set(obj.properties) == {"a", "b", "c", "d", "e", "f", "source_id"}
+    # Inline (non-$ref) sub-schema props are "key"; the large $ref'd Base
+    # (>5 props) is an inherited base and its props are excluded.
+    assert obj.key_properties == {"source_id"}
+    assert "a" in obj.required and "source_id" in obj.required
+
+
+def test_domain_object_returns_curated_subclasses(spec_dict):
+    spec = OpenAPISpec(spec_dict)
+    assert isinstance(spec.domain_object("DSource"), DSource)
+    assert isinstance(spec.domain_object("VDB"), VDB)
+    # Generic fallback for non-curated schemas, None when absent.
+    generic = spec.domain_object("Base")
+    assert isinstance(generic, SchemaObject) and not isinstance(generic, (DSource, VDB))
+    assert spec.domain_object("DoesNotExist") is None
+
+
+def test_domain_object_cached(spec_dict):
+    spec = OpenAPISpec(spec_dict)
+    assert spec.domain_object("VDB") is spec.domain_object("VDB")


### PR DESCRIPTION
## What changed

Introduces `src/dct_mcp_server/tools/core/spec_model.py` — a standardized, class-based object model over the DCT OpenAPI spec — and refactors every consumer to use it instead of walking the raw spec dict by hand.

**New model** (runtime wrappers over the cached spec dict, memoized by object identity — no build step, stays in sync with the live-downloaded spec):

- **`OpenAPISpec`** — the single home for `$ref` resolution: `resolve_pointer()` (single-level) and `resolve_refs()` (deep recursive, with cycle detection, depth limit, and truncation flag — preserving `dynamic.py`'s exact semantics). Also `operations()`, `find_path_item()` (exact + `{param}` wildcard), `operation_at()`, `domain_object()`.
- **`Operation` / `Parameter` / `RequestBody` / `Response`** — request bodies and responses as objects. `RequestBody.fields()` (allOf-merged) and `required_field_names()` (top-level only, preserving execute's lenient validation).
- **`SchemaObject`** — generic wrapper for all ~691 `components/schemas`, carrying the `allOf` merge + key-property logic. Curated **`DSource`** and **`VDB`** subclasses for the two highest-value domain objects.

**Consumers now delegate** instead of duplicating traversal:

| File | Change |
|---|---|
| `tools/core/dynamic.py` (discovery/execute) | removed `_resolve_refs`, `_lookup_ref`, `_find_path_item`, `_flatten_request_body` (−215 lines net) |
| `tools/core/endpoint_discovery.py` | iterates `model.operations()` |
| `toolsgenerator/driver.py` | `resolve_ref` / `resolve_schema_properties` are thin wrappers over the model |
| `tools/core/tool_factory.py` | `_resolve_ref` wraps `resolve_pointer` |

`meta_tools.get_spec_chunk` is intentionally left intact — it is a distinct JSON-pointer tool (handles `~0`/`~1` escapes, list indices, graceful error dicts), not the same single-level resolver.

## Why

The spec was read as a raw nested dict and traversed by hand in four independent places, each re-implementing `$ref` resolution / `allOf` merging / request-body flattening / path-template matching — and they had drifted (cycle detection, depth limits, and truncation all differed). This centralizes that structure into one source of truth so discovery, execute, and the code generators all agree on how request bodies, responses, and domain objects (dSource, VDB) are extracted. Tracked in DLPXECO-14248.

### Behavior note
One intentional improvement: discovery's `request_body_fields` now populates for `allOf`-composed bodies (previously empty). Strictly more complete; execute's body validation stays lenient/unchanged.

## Testing

- **66 tests pass** (53 existing, unchanged + 13 new in `tests/test_spec_model.py` covering pointer/recursive resolution, cycle + depth truncation, path-template matching, allOf merge, key-properties, request-body flatten, and curated domain objects).
- Behavioral smoke tests against the real `api-external.yaml` (798 paths): discovery (`list_tags`, `list_operations`, `get_operation_schema`), execute (validation, path resolution, confirmation gate `DELETE /bookmarks/{id}` → `confirmation_required` → confirmed `success`), and `driver.py`/`tool_factory.py` resolver parity all verified.
- DCT version: spec-only refactor; no live DCT calls changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
