### PR TITLE
DLPXECO-14264 Remove coverage badge from README until integration testing completes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 ![Support](https://img.shields.io/badge/Support-Community-yellow.svg)
 ![Python](https://img.shields.io/badge/Python-3.11+-blue.svg)
 ![License](https://img.shields.io/badge/License-MIT-green.svg)
-[![Coverage](https://img.shields.io/badge/coverage-5%25-yellow.svg)](https://github.com/delphix/dxi-mcp-server/actions/workflows/ci.yml)
 
 # Delphix DCT MCP Server
 


### PR DESCRIPTION
## What changed
Removes the code-coverage badge line from `README.md`:
```
[![Coverage](https://img.shields.io/badge/coverage-5%25-yellow.svg)](https://github.com/delphix/dxi-mcp-server/actions/workflows/ci.yml)
```
No other content changes.

## Why
The 5% coverage badge is misleading at this stage; it will be re-added once integration testing is complete and a representative coverage figure is available. Tracked by DLPXECO-14264 (under epic DLPXECO-14003).

## Relationship to PR #107
This is a fresh PR off current `main` carrying the same change as #107 (`elima-sugunan-patch-1`). That branch was BEHIND `main` and could not be rebased because branch protection blocks force-pushes. Once this PR is approved, #107 can be closed.

## Testing
Documentation-only change; README renders with the remaining Support / Python / License badges intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)