### PR TITLE
DLPXECO-14265 Complete residual auto-mode cleanup not landed by PR #106

### DIFF
--- a/.claude/rules/build-and-execution.md
+++ b/.claude/rules/build-and-execution.md
@@ -38,7 +38,7 @@ This allows server restarts without reconfiguring the client.
 |----------|----------|---------|-------|
 | `DCT_API_KEY` | Yes | — | Do not prefix with `apk` |
 | `DCT_BASE_URL` | Yes | — | No `/dct` suffix |
-| `DCT_TOOLSET` | No | `dynamic` | `dynamic`, `auto`, `self_service`, `self_service_provision`, `continuous_data_admin`, `platform_admin`, `reporting_insights` |
+| `DCT_TOOLSET` | No | `dynamic` | `dynamic`, `self_service`, `self_service_provision`, `continuous_data_admin`, `platform_admin`, `reporting_insights` |
 | `DCT_VERIFY_SSL` | No | `false` | Set `true` in production |
 | `DCT_LOG_LEVEL` | No | `INFO` | `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL` |
 | `DCT_TIMEOUT` | No | `30` | Seconds |

--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -46,7 +46,7 @@ Do not inline DCT API paths as raw strings in tool functions. Paths come from th
 | Entry point | `main.py` | Startup/shutdown only — no business logic |
 | Tool registration | `tools/__init__.py` | Discovery and loading only |
 | Tool implementations | `tools/*_endpoints_tool.py` | Grouped tools, one file per resource domain |
-| Auto mode | `tools/core/meta_tools.py` | Only registered when `DCT_TOOLSET=auto` |
+| Spec helpers | `tools/core/meta_tools.py` | Retained `find_endpoint` / `get_spec_chunk` utilities (not registered as MCP tools) |
 | Dynamic generation | `tools/core/tool_factory.py` | Runtime tool generation from OpenAPI spec |
 | Config loading | `config/loader.py` | All toolset and confirmation parsing |
 | HTTP client | `dct_client/client.py` | All DCT API calls go through `DCTAPIClient` |

--- a/.claude/test/test-infra.md
+++ b/.claude/test/test-infra.md
@@ -305,8 +305,8 @@ Change `DCT_TOOLSET` in `.mcp.json` and restart the MCP client:
 
 | Value | Description |
 |-------|-------------|
-| `auto` | 6 meta-tools; dynamic toolset switching at runtime |
-| `self_service` | Basic VDB operations (default) |
+| `dynamic` | 2 tools (`discovery` + `execute`) driven by the live OpenAPI spec (default) |
+| `self_service` | Basic VDB operations |
 | `self_service_provision` | Extended self-service with provisioning |
 | `continuous_data_admin` | Full DBA operations |
 | `platform_admin` | System administration |

--- a/.claude/test/testing.md
+++ b/.claude/test/testing.md
@@ -20,13 +20,13 @@ Two complementary tracks, both driven by Claude:
 | New pre-built tool module | `register_tools()` runs at startup; tool is exposed via the MCP server |
 | `TOOL_TO_MODULE` mapping change | Correct module loads for the affected toolset |
 | Dynamic tool generation change | Generated module in `$TEMP/dct_mcp_tools/` takes priority over pre-built |
-| Auto mode change | `enable_toolset` / `disable_toolset` works; subsequent tool listing reflects the change |
+| `dynamic` mode change | `discovery` + `execute` are the only tools exposed; `execute` invokes the resolved endpoint correctly |
 
 ## DCT Toolset Coverage
 
 When changing toolset configs or tool implementations, exercise at minimum:
 - The specific toolset(s) the change affects
-- `auto` mode if the change touches dynamic enable/disable behaviour
+- `dynamic` mode if the change touches `discovery` / `execute` behaviour
 
 ## Track 1 — Scenario Execution
 
@@ -90,7 +90,6 @@ Full prompt lists for each toolset are in `.claude/test/testing/`:
 
 | File | Toolset | Prompts |
 |------|---------|---------|
-| [testing/auto.md](testing/auto.md) | `auto` | 57 |
 | [testing/self_service.md](testing/self_service.md) | `self_service` | 70 |
 | [testing/self_service_provision.md](testing/self_service_provision.md) | `self_service_provision` | 70 inherited + 69 new |
 | [testing/continuous_data_admin.md](testing/continuous_data_admin.md) | `continuous_data_admin` | 431 |

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -39,7 +39,7 @@ Then [observable expected outcome].
 
 **Project-specific example** (checkbox format — use this style in your PRs):
 
-- [ ] AC-1: Given `DCT_TOOLSET=auto` and no toolset is currently enabled, when `enable_toolset("self_service")` is called, then the MCP client's tool list includes `vdb_tool` within one round-trip notification and `list_available_toolsets` still returns the full toolset catalogue.
+- [ ] AC-1: Given `DCT_TOOLSET=self_service`, when the MCP server starts, then the client's tool list includes `vdb_tool`, and a `vdb_tool(action="delete_vdb", ...)` call without `confirmed=True` returns `status=confirmation_required`.
 
 Use concrete, observable outcomes — "the response body contains `status=enabled`" is testable; "it works correctly" is not. Reference real domain concepts (`DCT_TOOLSET`, `vdb_tool`, `confirmation_required`, toolset names) rather than generic placeholders.
 

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ The Delphix DCT MCP Server provides a robust Model Context Protocol (MCP) interf
 
 ## Features
 
-- **Persona-Based Toolsets**: Choose from 5 pre-configured toolsets tailored for different roles (Self-Service, Self-Service Provisioning, Continuous Data Admin, Platform Admin, Reporting & Insights).
 - **Dynamic Mode**: Default 2-tool mode (`discovery` + `execute`) that exposes the full DCT API driven by the live OpenAPI spec.
+- **Persona-Based Toolsets**: Choose from 5 pre-configured toolsets tailored for different roles (Self-Service, Self-Service Provisioning, Continuous Data Admin, Platform Admin, Reporting & Insights).
 - **Grouped Tools**: Each tool handles multiple related actions via an `action` parameter, reducing tool count while maintaining full functionality.
 - **Confirmation System**: Built-in confirmation checks for destructive operations to prevent accidental data loss.
 - **Comprehensive DCT integration**: Access datasets, environments, engines, compliance, jobs, and reporting through specialized tools.

--- a/src/dct_mcp_server/tools/core/endpoint_discovery.py
+++ b/src/dct_mcp_server/tools/core/endpoint_discovery.py
@@ -1,4 +1,8 @@
-"""Fuzzy endpoint discovery helpers for auto-mode find_endpoint meta-tool."""
+"""Fuzzy endpoint discovery helpers backing the retained ``find_endpoint`` utility.
+
+Originally written for the auto-mode ``find_endpoint`` meta-tool; auto mode was
+removed in DLPXECO-14257 and these helpers are kept as standalone utilities.
+"""
 
 from __future__ import annotations
 import re

--- a/src/dct_mcp_server/tools/core/tool_factory.py
+++ b/src/dct_mcp_server/tools/core/tool_factory.py
@@ -6,7 +6,7 @@ Creates GROUPED tools where each logical tool has an 'action' parameter.
 
 Architecture:
 1. Fetch & cache OpenAPI spec once at startup
-2. When enable_toolset() is called, generate grouped tool functions dynamically
+2. Generate grouped tool functions dynamically from the configured toolset
 3. Each tool (e.g., vdb_tool) supports multiple actions (search, get, provision, etc.)
 4. Register generated functions with FastMCP via app.add_tool()
 """

--- a/src/dct_mcp_server/tools/dataset_endpoints_tool.py
+++ b/src/dct_mcp_server/tools/dataset_endpoints_tool.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 # For destructive operations (DELETE, POST .../delete), generated tools should:
 # 1. Call requires_confirmation(method, path) to check if confirmation needed
 # 2. If True, include confirmation_message in the response
-# 3. LLM should use check_operation_confirmation meta-tool before executing
+# 3. Re-call the action with confirmed=True to execute after confirmation
 #
 # Example usage in generated tool:
 #   confirmation = get_confirmation_for_operation("DELETE", "/vdbs/{id}")

--- a/src/dct_mcp_server/tools/engine_endpoints_tool.py
+++ b/src/dct_mcp_server/tools/engine_endpoints_tool.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 # For destructive operations (DELETE, POST .../delete), generated tools should:
 # 1. Call requires_confirmation(method, path) to check if confirmation needed
 # 2. If True, include confirmation_message in the response
-# 3. LLM should use check_operation_confirmation meta-tool before executing
+# 3. Re-call the action with confirmed=True to execute after confirmation
 #
 # Example usage in generated tool:
 #   confirmation = get_confirmation_for_operation("DELETE", "/vdbs/{id}")

--- a/src/dct_mcp_server/tools/environment_endpoints_tool.py
+++ b/src/dct_mcp_server/tools/environment_endpoints_tool.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 # For destructive operations (DELETE, POST .../delete), generated tools should:
 # 1. Call requires_confirmation(method, path) to check if confirmation needed
 # 2. If True, include confirmation_message in the response
-# 3. LLM should use check_operation_confirmation meta-tool before executing
+# 3. Re-call the action with confirmed=True to execute after confirmation
 #
 # Example usage in generated tool:
 #   confirmation = get_confirmation_for_operation("DELETE", "/vdbs/{id}")

--- a/src/dct_mcp_server/tools/iam_endpoints_tool.py
+++ b/src/dct_mcp_server/tools/iam_endpoints_tool.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 # For destructive operations (DELETE, POST .../delete), generated tools should:
 # 1. Call requires_confirmation(method, path) to check if confirmation needed
 # 2. If True, include confirmation_message in the response
-# 3. LLM should use check_operation_confirmation meta-tool before executing
+# 3. Re-call the action with confirmed=True to execute after confirmation
 #
 # Example usage in generated tool:
 #   confirmation = get_confirmation_for_operation("DELETE", "/vdbs/{id}")

--- a/src/dct_mcp_server/tools/job_endpoints_tool.py
+++ b/src/dct_mcp_server/tools/job_endpoints_tool.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 # For destructive operations (DELETE, POST .../delete), generated tools should:
 # 1. Call requires_confirmation(method, path) to check if confirmation needed
 # 2. If True, include confirmation_message in the response
-# 3. LLM should use check_operation_confirmation meta-tool before executing
+# 3. Re-call the action with confirmed=True to execute after confirmation
 #
 # Example usage in generated tool:
 #   confirmation = get_confirmation_for_operation("DELETE", "/vdbs/{id}")

--- a/src/dct_mcp_server/tools/misc_endpoints_tool.py
+++ b/src/dct_mcp_server/tools/misc_endpoints_tool.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 # For destructive operations (DELETE, POST .../delete), generated tools should:
 # 1. Call requires_confirmation(method, path) to check if confirmation needed
 # 2. If True, include confirmation_message in the response
-# 3. LLM should use check_operation_confirmation meta-tool before executing
+# 3. Re-call the action with confirmed=True to execute after confirmation
 #
 # Example usage in generated tool:
 #   confirmation = get_confirmation_for_operation("DELETE", "/vdbs/{id}")

--- a/src/dct_mcp_server/tools/policy_endpoints_tool.py
+++ b/src/dct_mcp_server/tools/policy_endpoints_tool.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 # For destructive operations (DELETE, POST .../delete), generated tools should:
 # 1. Call requires_confirmation(method, path) to check if confirmation needed
 # 2. If True, include confirmation_message in the response
-# 3. LLM should use check_operation_confirmation meta-tool before executing
+# 3. Re-call the action with confirmed=True to execute after confirmation
 #
 # Example usage in generated tool:
 #   confirmation = get_confirmation_for_operation("DELETE", "/vdbs/{id}")

--- a/src/dct_mcp_server/tools/reports_endpoints_tool.py
+++ b/src/dct_mcp_server/tools/reports_endpoints_tool.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 # For destructive operations (DELETE, POST .../delete), generated tools should:
 # 1. Call requires_confirmation(method, path) to check if confirmation needed
 # 2. If True, include confirmation_message in the response
-# 3. LLM should use check_operation_confirmation meta-tool before executing
+# 3. Re-call the action with confirmed=True to execute after confirmation
 #
 # Example usage in generated tool:
 #   confirmation = get_confirmation_for_operation("DELETE", "/vdbs/{id}")

--- a/src/dct_mcp_server/tools/template_endpoints_tool.py
+++ b/src/dct_mcp_server/tools/template_endpoints_tool.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 # For destructive operations (DELETE, POST .../delete), generated tools should:
 # 1. Call requires_confirmation(method, path) to check if confirmation needed
 # 2. If True, include confirmation_message in the response
-# 3. LLM should use check_operation_confirmation meta-tool before executing
+# 3. Re-call the action with confirmed=True to execute after confirmation
 #
 # Example usage in generated tool:
 #   confirmation = get_confirmation_for_operation("DELETE", "/vdbs/{id}")

--- a/src/dct_mcp_server/toolsgenerator/driver.py
+++ b/src/dct_mcp_server/toolsgenerator/driver.py
@@ -314,7 +314,7 @@ class _SafeDict(dict):
 # For destructive operations (DELETE, POST .../delete), generated tools should:
 # 1. Call requires_confirmation(method, path) to check if confirmation needed
 # 2. If True, include confirmation_message in the response
-# 3. LLM should use check_operation_confirmation meta-tool before executing
+# 3. Re-call the action with confirmed=True to execute after confirmation
 #
 # Example usage in generated tool:
 #   confirmation = get_confirmation_for_operation("DELETE", "/vdbs/{id}")


### PR DESCRIPTION
## What changed
Carries the 17 file edits that were **intended** for PR #106 (DLPXECO-14262) but never landed — only the `auto.md` deletion made it into that merge, so the residual auto-mode references are still on `main`.

**Contributor / instruction docs**
- `.claude/rules/build-and-execution.md` — drop `auto` from the `DCT_TOOLSET` valid-values table.
- `.claude/rules/code-style.md` — replace the "Auto mode" Code Organisation row with a "Spec helpers" row for the retained `find_endpoint`/`get_spec_chunk` utilities.
- `.github/CONTRIBUTING.md` — rewrite the AC example around the `self_service` confirmation flow.

**Test docs**
- `.claude/test/test-infra.md` — replace the `auto` toolset row with `dynamic`.
- `.claude/test/testing.md` — replace the "Auto mode change" row and `auto` coverage bullet with `dynamic` equivalents; drop the (already-deleted) `auto.md` prompt-file row.

**Source comments / docstrings**
- `tools/core/tool_factory.py`, `tools/core/endpoint_discovery.py` — docstrings no longer reference removed meta-tools.
- 9 `*_endpoints_tool.py` modules + `toolsgenerator/driver.py` — replace the `check_operation_confirmation meta-tool` comment with the `confirmed=True` re-call confirmation pattern.

Historical spec/removal docs under `docs/` are intentionally left as point-in-time records.

## Also bundled: README Features reorder
Leads the Features list with **Dynamic Mode** (the default, hero experience) ahead of **Persona-Based Toolsets**. Carried here because the original change had landed on the already-merged PR #108 branch with no open PR.

## Why
Auto mode was removed in DLPXECO-14257; these stale references present it as a live option and point at deleted meta-tools, misleading contributors and the AI assistant. Completes the cleanup PR #106 (DLPXECO-14262) was supposed to finish.

## Testing
- `pytest` — **92 passed**.
- `git grep` confirms no remaining live references to `auto` as a `DCT_TOOLSET` value, `enable_toolset`/`disable_toolset`/`list_available_toolsets`, or `check_operation_confirmation meta-tool` outside intentional historical/removal docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)